### PR TITLE
🎨 Palette: Improve ScrollToTop accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,5 @@
+# Palette Journal
+
+## 2024-05-18 - Invisible interactive elements and keyboard focus
+**Learning:** Using `opacity: 0` and `pointer-events: none` on interactive elements like buttons visually hides them but DOES NOT remove them from the keyboard tab order. This creates confusing "invisible" focus states for keyboard users.
+**Action:** When animating elements in and out of view without conditionally rendering them, always ensure to update their focusability with `tabIndex={-1}` and screen reader visibility with `aria-hidden="true"` when they are visually hidden.

--- a/components/ScrollToTop.tsx
+++ b/components/ScrollToTop.tsx
@@ -29,7 +29,10 @@ export function ScrollToTop() {
       className={`scroll-to-top ${visible ? 'scroll-to-top--visible' : ''}`}
       onClick={scrollToTop}
       aria-label="Scroll to top"
+      title="Scroll to top"
       type="button"
+      tabIndex={visible ? 0 : -1}
+      aria-hidden={!visible}
     >
       ↑
     </button>


### PR DESCRIPTION
Fix ScrollToTop invisible keyboard focus issue. Added `tabIndex` and `aria-hidden` to conditionally remove the visually hidden button from the tab order. Added a title for tooltip and updated `.Jules/palette.md` with learnings.

---
*PR created automatically by Jules for task [4531870603476591821](https://jules.google.com/task/4531870603476591821) started by @ralksta*