### PR TITLE
🎨 Palette: Add aria-label to BackLink component

### DIFF
--- a/components/BackLink.tsx
+++ b/components/BackLink.tsx
@@ -12,7 +12,7 @@ interface BackLinkProps {
 
 export function BackLink({ href, label }: BackLinkProps) {
   return (
-    <Link href={href} className="album-header__back">
+    <Link href={href} className="album-header__back" aria-label={`Back to ${label}`}>
       <svg
         viewBox="0 0 24 24"
         fill="none"


### PR DESCRIPTION
💡 What: Added an `aria-label` to the `BackLink` component.
🎯 Why: The component is used to navigate back to a parent subpage or the homepage, but the `Link` element inside it only contains an SVG icon and the provided `label` text. Adding an `aria-label` makes the purpose of the link clearer for screen reader users.
📸 Before/After: N/A (non-visual change)
♿ Accessibility: Improves screen reader context for the back navigation link.

---
*PR created automatically by Jules for task [6285454126913202207](https://jules.google.com/task/6285454126913202207) started by @ralksta*