### PR TITLE
🛡️ Sentinel: [MEDIUM] Add rate limiting to unauthenticated endpoints

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -5,12 +5,24 @@
  * GET /api/health → { status, immich, uptime }
  */
 
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { immich } from '@/lib/immich';
+import { checkRateLimit } from '@/lib/rate-limit';
 
 const startTime = Date.now();
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  // Rate limiting
+  const ip =
+    request.headers.get('x-real-ip') ??
+    request.headers.get('x-forwarded-for')?.split(',')[0].trim() ??
+    'unknown';
+  const { success } = checkRateLimit(`health:${ip}`, 60);
+
+  if (!success) {
+    return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
+  }
+
   const immichOk = await immich.ping();
 
   const body = {

--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -7,10 +7,22 @@
  */
 
 import { ImageResponse } from 'next/og';
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { getConfig } from '@/lib/config';
+import { checkRateLimit } from '@/lib/rate-limit';
 
 export async function GET(request: NextRequest) {
+  // Rate limiting
+  const ip =
+    request.headers.get('x-real-ip') ??
+    request.headers.get('x-forwarded-for')?.split(',')[0].trim() ??
+    'unknown';
+  const { success } = checkRateLimit(`og:${ip}`, 60);
+
+  if (!success) {
+    return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
+  }
+
   const { searchParams } = request.nextUrl;
   const title = (searchParams.get('title') || 'Gallery').slice(0, 200);
   const subtitle = (searchParams.get('subtitle') || '').slice(0, 100);


### PR DESCRIPTION
The `/api/og` and `/api/health` endpoints were completely unauthenticated and missing any rate limiting. An attacker could trivially hit these endpoints, especially `/api/og` (which does image generation) and `/api/health` (which hits the backend Immich server), causing DoS.

This commit adds a reasonable rate limit of 60 RPM based on the IP address.

---
*PR created automatically by Jules for task [2598966048489783210](https://jules.google.com/task/2598966048489783210) started by @ralksta*