### PR TITLE
🛡️ Sentinel: [MEDIUM] Add rate limiting to /api/health endpoint

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -5,12 +5,31 @@
  * GET /api/health → { status, immich, uptime }
  */
 
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { immich } from '@/lib/immich';
+import { checkRateLimit } from '@/lib/rate-limit';
 
 const startTime = Date.now();
 
-export async function GET() {
+// 60 RPM allows 1 check per second per IP, which is plenty for monitoring tools
+// while preventing abuse that could overwhelm the Immich API via ping().
+const HEALTH_RPM = 60;
+
+export async function GET(request: NextRequest) {
+  // ── Rate limiting ──────────────────────────────────
+  // Security: Prioritize x-real-ip over x-forwarded-for
+  const ip =
+    request.headers.get('x-real-ip') ??
+    request.headers.get('x-forwarded-for')?.split(',')[0].trim() ??
+    'unknown';
+  const { success, resetAt } = checkRateLimit(`health:${ip}`, HEALTH_RPM);
+
+  if (!success) {
+    const retryAfter = Math.ceil((resetAt - Date.now()) / 1000);
+    console.warn(`[Health API] ⚠️ Rate limit exceeded for IP: ${ip}. Retry after ${retryAfter}s`);
+    return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
+  }
+
   const immichOk = await immich.ping();
 
   const body = {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `/api/health` endpoint queries the backend API (`immich.ping()`) without any rate limiting. An attacker could rapidly request this endpoint, leading to a downstream DoS on the Immich server and consuming excessive application resources.
🎯 Impact: Unauthenticated attackers can exhaust server resources and Immich API limits, degrading the service.
🔧 Fix: Implemented an in-memory sliding window rate limiter at 60 RPM using `checkRateLimit` and extracting the IP from `x-real-ip` or `x-forwarded-for` headers. Returns `429 Too Many Requests` when exceeded.
✅ Verification: Ran `pnpm test` and `pnpm lint app/api/health/route.ts` successfully. Code is functionally secure and handles DoS mitigation accurately.

---
*PR created automatically by Jules for task [5884192393292437442](https://jules.google.com/task/5884192393292437442) started by @ralksta*