### PR TITLE
🎨 Palette: Improve Lightbox accessibility with ARIA modal and toggle attributes

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,4 +1,3 @@
-## 2024-03-XX - Lightbox Accessibility
-
-**Learning:** Found that Lightbox overlay has good keyboard navigation (esc/left/right) but lacked tooltip hints for those controls and lacked a shortcut for EXIF data toggle.
-**Action:** Added `i` shortcut and `title` attributes on interactive elements in Lightbox.
+## 2024-05-24 - Lightbox ARIA Attributes
+**Learning:** Adding `role="dialog"`, `aria-modal="true"`, and `aria-label` to custom modal/lightbox overlays ensures screen readers announce them properly instead of just falling back to reading inner content without context. Additionally, toggles that show/hide panels (like the EXIF info button) must use `aria-expanded` and link to the panel via `aria-controls` for proper screen reader communication.
+**Action:** When building or modifying custom overlays or toggle buttons in the future, always verify that ARIA attributes are set correctly to match the visual behavior.

--- a/components/Lightbox.tsx
+++ b/components/Lightbox.tsx
@@ -104,6 +104,9 @@ export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev }: Ligh
       onClick={handleOverlayClick}
       onTouchStart={handleTouchStart}
       onTouchEnd={handleTouchEnd}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Image viewer"
     >
       {/* Close button */}
       <button className={styles.close} onClick={onClose} aria-label="Close" title="Close (Esc)">
@@ -188,6 +191,8 @@ export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev }: Ligh
       <button
         className={styles.infoToggle}
         onClick={handleExifToggle}
+        aria-expanded={showExif}
+        aria-controls="exif-panel"
         aria-label="Toggle photo info"
         title="Toggle photo info (i)"
       >
@@ -196,7 +201,7 @@ export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev }: Ligh
 
       {/* EXIF panel */}
       {showExif && (
-        <div className={styles.exifPanel}>
+        <div id="exif-panel" className={styles.exifPanel}>
           {exifLoading ? (
             <div className={styles.exifRow}>
               <span className={styles.exifLabel}>Loading...</span>


### PR DESCRIPTION
💡 **What:** 
- Added `role="dialog"`, `aria-modal="true"`, and `aria-label="Image viewer"` to the Lightbox `.overlay` wrapper.
- Added `aria-expanded={showExif}` and `aria-controls="exif-panel"` to the info toggle `<button>`.
- Added `id="exif-panel"` to the EXIF panel `<div>`.

🎯 **Why:** 
To improve keyboard and screen reader accessibility. Screen readers will now properly announce the Lightbox as a modal dialog and correctly communicate the expanded/collapsed state of the EXIF information panel.

♿ **Accessibility:** 
These enhancements specifically target screen reader usability, ensuring interactive toggle elements properly inform assistive technologies of their current state (`aria-expanded`) and what they control (`aria-controls`).

---
*PR created automatically by Jules for task [2597329167857422720](https://jules.google.com/task/2597329167857422720) started by @ralksta*