### PR TITLE
🎨 Palette: Improve accessibility of password gate form

### DIFF
--- a/components/PasswordGate.tsx
+++ b/components/PasswordGate.tsx
@@ -51,6 +51,7 @@ export default function PasswordGate({ slug, title }: PasswordGateProps) {
 
         <form onSubmit={handleSubmit} className={styles.form}>
           <input
+            id="password-input"
             type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
@@ -59,13 +60,20 @@ export default function PasswordGate({ slug, title }: PasswordGateProps) {
             className={styles.input}
             autoFocus
             required
+            disabled={loading}
+            aria-invalid={!!error}
+            aria-describedby={error ? 'password-error' : undefined}
           />
           <button type="submit" className={styles.button} disabled={loading}>
             {loading ? 'Verifying…' : 'Enter'}
           </button>
         </form>
 
-        {error && <p className={styles.error}>{error}</p>}
+        {error && (
+          <p id="password-error" className={styles.error} role="alert" aria-live="polite">
+            {error}
+          </p>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
💡 What: Added ARIA attributes (`role="alert"`, `aria-live="polite"`, `aria-invalid`, `aria-describedby`) to improve screen reader feedback on password errors. Added `disabled={loading}` so the input cannot be modified during verification.
🎯 Why: Ensures users with screen readers are immediately notified of validation errors (e.g. wrong password) and prevents race conditions from double-submitting during verification.
📸 Before/After: Visuals are unchanged except for disabled input state.
♿ Accessibility: Better screen reader announcement of errors and semantic linking of error text to the password input.

---
*PR created automatically by Jules for task [3254931158604621780](https://jules.google.com/task/3254931158604621780) started by @ralksta*