### PR TITLE
⚡ Bolt: Rate limit OG image generation to prevent CPU exhaustion

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,8 @@
+## 2026-03-24 - [Rate limit CPU-intensive endpoints]
+
+**Learning:** Dynamic API endpoints that perform resource-intensive tasks on the fly, such as Next.js `next/og` ImageResponse generation, must implement rate-limiting using the shared `checkRateLimit` utility to protect server stability and prevent CPU exhaustion, even if they do not explicitly query upstream backend APIs.
+**Action:** Always identify CPU-heavy dynamic routes (like image generation or PDF rendering) during performance reviews, and wrap them with the application's rate limiter. Ensure rate limit checks happen early in the request lifecycle and return appropriate 429 status codes.
+
 ## YYYY-MM-DD - [Memoize grid item re-rendering]
 
 **Learning:** `useMemo` can significantly boost the performance of long list or grid components (like `PhotoGrid` component) that otherwise gets re-rendered on simple interactions like navigating the image lightbox. Running standard formatting `pnpm format` applies huge changes across entire directories, so it's generally best to format and clean up ONLY modified files to avoid huge diff pollution in code review.

--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -7,14 +7,34 @@
  */
 
 import { ImageResponse } from 'next/og';
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { getConfig } from '@/lib/config';
+import { checkRateLimit, getClientIp } from '@/lib/rate-limit';
 
 export async function GET(request: NextRequest) {
+  const config = getConfig();
+
+  // ── Rate limiting ──────────────────────────────────
+  // Dynamic ImageResponse generation is CPU-intensive. Limit to prevent exhaustion.
+  const ip = getClientIp(request);
+  const { success, remaining, resetAt } = checkRateLimit(ip, config.rateLimitRpm);
+
+  if (!success) {
+    const retryAfter = Math.ceil((resetAt - Date.now()) / 1000);
+    console.warn(`[OG API] ⚠️ Rate limit exceeded for IP: ${ip}. Retry after ${retryAfter}s`);
+    return NextResponse.json(
+      { error: 'Too many requests' },
+      {
+        status: 429,
+        headers: { 'Retry-After': String(retryAfter) },
+      },
+    );
+  }
+
   const { searchParams } = request.nextUrl;
   const title = (searchParams.get('title') || 'Gallery').slice(0, 200);
   const subtitle = (searchParams.get('subtitle') || '').slice(0, 100);
-  const { theme } = getConfig();
+  const { theme } = config;
 
   return new ImageResponse(
     <div
@@ -86,6 +106,7 @@ export async function GET(request: NextRequest) {
       height: 630,
       headers: {
         'Cache-Control': 'public, max-age=86400, s-maxage=86400',
+        'X-RateLimit-Remaining': String(remaining),
       },
     },
   );


### PR DESCRIPTION
💡 **What:** Added the `checkRateLimit` utility from `lib/rate-limit.ts` to the `/api/og` endpoint, returning a `429 Too Many Requests` status and a `Retry-After` header when the IP exceeds the configured request per minute limit.

🎯 **Why:** Dynamically rendering images via `next/og` (React components to image buffer) is highly CPU intensive. Without a rate limit on this public endpoint, an attacker (or aggressive scraper bot) could easily exhaust server resources and take down the entire Next.js instance by spamming requests with random query parameters. 

📊 **Impact:** Provides a critical layer of defense against CPU exhaustion (DDoS) while having negligible impact on legitimate users whose traffic falls under the normal RPM limits.

🔬 **Measurement:** Verify by repeatedly calling `/api/og` beyond the `RATE_LIMIT_RPM` environment variable threshold; the server will start correctly rejecting requests with `429 Too Many Requests` and a helpful `Retry-After` header instead of continuing to spin the CPU rendering duplicate or unneeded images.

---
*PR created automatically by Jules for task [17802628957842520258](https://jules.google.com/task/17802628957842520258) started by @ralksta*