### PR TITLE
🎨 Palette: Add accessibility roles and focus management to Lightbox

### DIFF
--- a/components/Lightbox.tsx
+++ b/components/Lightbox.tsx
@@ -31,6 +31,7 @@ export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev }: Ligh
   const { exifData, exifLoading, fetchExif, clearExif } = useExif();
   const [imageLoaded, setImageLoaded] = useState(false);
   const overlayRef = useRef<HTMLDivElement>(null);
+  const closeBtnRef = useRef<HTMLButtonElement>(null);
 
   const current = assets[currentIndex];
   const [mounted, setMounted] = useState(false);
@@ -39,6 +40,13 @@ export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev }: Ligh
   useEffect(() => {
     setMounted(true);
   }, []);
+
+  // Focus the close button when the lightbox mounts/opens
+  useEffect(() => {
+    if (mounted && closeBtnRef.current) {
+      closeBtnRef.current.focus();
+    }
+  }, [mounted]);
 
   // Reset EXIF data when switching images; refetch if panel is open
   useEffect(() => {
@@ -104,9 +112,18 @@ export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev }: Ligh
       onClick={handleOverlayClick}
       onTouchStart={handleTouchStart}
       onTouchEnd={handleTouchEnd}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Image lightbox"
     >
       {/* Close button */}
-      <button className={styles.close} onClick={onClose} aria-label="Close" title="Close (Esc)">
+      <button
+        ref={closeBtnRef}
+        className={styles.close}
+        onClick={onClose}
+        aria-label="Close"
+        title="Close (Esc)"
+      >
         <svg
           viewBox="0 0 24 24"
           fill="none"


### PR DESCRIPTION
💡 **What**: Added `role="dialog"`, `aria-modal="true"`, and `aria-label="Image lightbox"` to the Lightbox overlay container, and implemented focus management to auto-focus the close button when the lightbox mounts.
🎯 **Why**: Modal overlays must identify themselves as dialogs to screen readers and trap/direct keyboard focus properly. Previously, opening the lightbox did not shift the user's focus or announce the change semantically.
📸 **Before/After**: N/A (non-visual change)
♿ **Accessibility**: Significant improvement for keyboard navigation and screen readers; users are now immediately placed inside the Lightbox context and alerted to its presence.

---
*PR created automatically by Jules for task [2874331098492051831](https://jules.google.com/task/2874331098492051831) started by @ralksta*