### PR TITLE
🎨 Palette: Improve map loading accessibility

### DIFF
--- a/components/MapView.tsx
+++ b/components/MapView.tsx
@@ -151,7 +151,10 @@ export function MapView() {
 
   if (error) {
     return (
-      <div className="map-container__loading" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
+      <div
+        className="map-container__loading"
+        style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}
+      >
         <p>{error}</p>
       </div>
     );
@@ -162,27 +165,30 @@ export function MapView() {
       {loading && (
         <div
           className="map-container__loading"
-          style={{ 
-            position: 'absolute', 
-            inset: 0, 
+          role="alert"
+          aria-live="polite"
+          style={{
+            position: 'absolute',
+            inset: 0,
             zIndex: 1000,
             display: 'flex',
             flexDirection: 'column',
             alignItems: 'center',
             justifyContent: 'center',
             background: 'rgba(0, 0, 0, 0.5)',
-            color: '#fff'
+            color: '#fff',
           }}
         >
-          <svg 
-            width="24" 
-            height="24" 
-            viewBox="0 0 24 24" 
-            fill="none" 
-            stroke="currentColor" 
-            strokeWidth="2" 
-            strokeLinecap="round" 
-            strokeLinejoin="round" 
+          <svg
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
             style={{ animation: 'spin 1s linear infinite', marginBottom: '8px' }}
           >
             <circle cx="12" cy="12" r="10" strokeOpacity="0.25"></circle>


### PR DESCRIPTION
💡 **What:** Added `role="alert"` and `aria-live="polite"` to the MapView loading overlay, and `aria-hidden="true"` to its SVG spinner.
🎯 **Why:** When navigating to the Map page, users on slower connections (or waiting for Leaflet initialization) see a "Loading map…" overlay. Screen readers would previously miss this state update and might attempt to announce raw `<svg>` elements if interacted with. This change ensures visually impaired users are explicitly informed of the async loading state in a non-disruptive way.
📸 **Before/After:** Functionally the visual appearance is identical (the spinner and text are still visible). The change is purely semantic/DOM-level.
♿ **Accessibility:** The loading overlay is now a polite live region, preventing screen reader silence during async map loads, and the decorative spinner is correctly hidden from the accessibility tree.

---
*PR created automatically by Jules for task [15912108584065176089](https://jules.google.com/task/15912108584065176089) started by @ralksta*