### PR TITLE
🛡️ Sentinel: Add Rate Limit headers to 429 responses

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: "\U0001F41B Bug report"
 about: Something isn't working as expected
-title: "[bug] "
+title: '[bug] '
 labels: bug
 assignees: ''
 ---
@@ -26,13 +26,13 @@ What actually happened. Include screenshots if relevant.
 
 ## Environment
 
-| Field | Value |
-|---|---|
-| immich-folio version | vX.X.X / commit SHA |
-| Immich version | |
-| Deployment | Docker / manual |
-| Browser | Chrome / Firefox / Safari |
-| OS | |
+| Field                | Value                     |
+| -------------------- | ------------------------- |
+| immich-folio version | vX.X.X / commit SHA       |
+| Immich version       |                           |
+| Deployment           | Docker / manual           |
+| Browser              | Chrome / Firefox / Safari |
+| OS                   |                           |
 
 ## `content/gallery.yaml` (redacted)
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: "\U0001F4A1 Feature request"
 about: Suggest an idea or improvement
-title: "[feat] "
+title: '[feat] '
 labels: enhancement
 assignees: ''
 ---

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,7 @@
 ## Summary
 
 <!-- What does this PR do? Reference the issue it closes if applicable. -->
+
 Closes #
 
 ## Type of change

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,41 +2,41 @@ version: 2
 
 updates:
   # npm dependencies
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-      timezone: "Europe/Berlin"
+      interval: 'weekly'
+      day: 'monday'
+      time: '09:00'
+      timezone: 'Europe/Berlin'
     open-pull-requests-limit: 5
     labels:
-      - "dependencies"
+      - 'dependencies'
     groups:
       # Batch minor/patch Next.js updates together
       nextjs:
         patterns:
-          - "next"
-          - "eslint-config-next"
+          - 'next'
+          - 'eslint-config-next'
       # Batch React updates
       react:
         patterns:
-          - "react"
-          - "react-dom"
-          - "@types/react*"
+          - 'react'
+          - 'react-dom'
+          - '@types/react*'
     ignore:
       # Don't auto-update major versions (review manually)
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']
 
   # GitHub Actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-      timezone: "Europe/Berlin"
+      interval: 'weekly'
+      day: 'monday'
+      time: '09:00'
+      timezone: 'Europe/Berlin'
     labels:
-      - "dependencies"
-      - "github-actions"
+      - 'dependencies'
+      - 'github-actions'

--- a/.planning/ui-reviews/UI-REVIEW.md
+++ b/.planning/ui-reviews/UI-REVIEW.md
@@ -8,14 +8,14 @@
 
 ## Pillar Scores
 
-| Pillar | Score | Key Finding |
-|--------|-------|-------------|
-| 1. Copywriting | 3/4 | Error states use generic 'Something went wrong'. |
-| 2. Visuals | 3/4 | Standard component structures, but icon accessibility could be improved. |
-| 3. Color | 2/4 | Heavy use of hardcoded colors in `DevToolbar.tsx`. |
-| 4. Typography | 3/4 | Uses custom CSS styles rather than utility classes; mostly consistent. |
-| 5. Spacing | 3/4 | Uses custom CSS styles; no major arbitrary inline spacing found. |
-| 6. Experience Design | 3/4 | Good coverage of loading/error states in MapView and PasswordGate. |
+| Pillar               | Score | Key Finding                                                              |
+| -------------------- | ----- | ------------------------------------------------------------------------ |
+| 1. Copywriting       | 3/4   | Error states use generic 'Something went wrong'.                         |
+| 2. Visuals           | 3/4   | Standard component structures, but icon accessibility could be improved. |
+| 3. Color             | 2/4   | Heavy use of hardcoded colors in `DevToolbar.tsx`.                       |
+| 4. Typography        | 3/4   | Uses custom CSS styles rather than utility classes; mostly consistent.   |
+| 5. Spacing           | 3/4   | Uses custom CSS styles; no major arbitrary inline spacing found.         |
+| 6. Experience Design | 3/4   | Good coverage of loading/error states in MapView and PasswordGate.       |
 
 **Overall: 17/24**
 
@@ -32,30 +32,37 @@
 ## Detailed Findings
 
 ### Pillar 1: Copywriting (3/4)
+
 - **PasswordGate.tsx**: Uses standard CTA ('Enter', 'Verifying...') but error state falls back to generic "Something went wrong" at line 40.
 
 ### Pillar 2: Visuals (3/4)
+
 - Components use semantic HTML for the most part. SVG icons in `ThemeToggle`, `Lightbox`, and `Footer` lack robust `aria-label` alternatives for screen readers in some instances.
 
 ### Pillar 3: Color (2/4)
+
 - **DevToolbar.tsx**: Contains over 20 distinct hardcoded hex values (clues: `#e60012`, `#e4e4e7`, `#166534`, `#ff6b35`). This violates the single-source-of-truth theme approach.
 - **Lightbox / SetupScreen**: Minimal hardcoded values used for fallback (`#000`, `#ffffff`).
 
 ### Pillar 4: Typography (3/4)
+
 - Exclusively uses CSS module classes rather than utility variables.
 - Some inline font sizes exist (e.g., `fontSize: 10` in DevToolbar).
 
 ### Pillar 5: Spacing (3/4)
+
 - Relies cleanly on CSS modules.
 - Only a few inline spacing overrides (e.g., `marginTop: 6` in DevToolbar).
 
 ### Pillar 6: Experience Design (3/4)
+
 - **PasswordGate.tsx**: Correctly disables the submit button and indicates processing state (`loading ? 'Verifying...' : 'Enter'`).
 - **MapView.tsx**: Handles API mapping errors gracefully (`error && <p>{error}</p>`).
 
 ---
 
 ## Files Audited
+
 - `app/api/auth/route.ts`
 - `app/api/health/route.ts`
 - `components/PasswordGate.tsx`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,10 +4,10 @@
 
 Only the latest release on `main` is actively maintained.
 
-| Version | Supported |
-|---|---|
-| `main` (latest) | ✅ |
-| older commits | ❌ |
+| Version         | Supported |
+| --------------- | --------- |
+| `main` (latest) | ✅        |
+| older commits   | ❌        |
 
 ## Reporting a Vulnerability
 

--- a/app/api/auth/route.ts
+++ b/app/api/auth/route.ts
@@ -13,10 +13,21 @@ const AUTH_RPM = 10;
 export async function POST(request: NextRequest) {
   // ── Rate limiting (brute-force protection) ──────────
   const ip = getClientIp(request);
-  const { success } = checkRateLimit(`auth:${ip}`, AUTH_RPM);
+  const { success, resetAt } = checkRateLimit(`auth:${ip}`, AUTH_RPM);
 
   if (!success) {
-    return NextResponse.json({ error: 'Too many attempts, try again later' }, { status: 429 });
+    const retryAfter = Math.ceil((resetAt - Date.now()) / 1000);
+    return NextResponse.json(
+      { error: 'Too many attempts, try again later' },
+      {
+        status: 429,
+        headers: {
+          'Retry-After': String(retryAfter),
+          'X-RateLimit-Limit': String(AUTH_RPM),
+          'X-RateLimit-Remaining': '0',
+        },
+      },
+    );
   }
 
   try {

--- a/app/api/exif/[id]/route.ts
+++ b/app/api/exif/[id]/route.ts
@@ -26,7 +26,17 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
   if (!success) {
     const retryAfter = Math.ceil((resetAt - Date.now()) / 1000);
     console.warn(`[EXIF API] ⚠️ Rate limit exceeded for IP: ${ip}. Retry after ${retryAfter}s`);
-    return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
+    return NextResponse.json(
+      { error: 'Too many requests' },
+      {
+        status: 429,
+        headers: {
+          'Retry-After': String(retryAfter),
+          'X-RateLimit-Limit': String(config.rateLimitRpm),
+          'X-RateLimit-Remaining': '0',
+        },
+      },
+    );
   }
 
   const { id: token } = await params;

--- a/app/api/image/[id]/route.ts
+++ b/app/api/image/[id]/route.ts
@@ -35,7 +35,17 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     console.warn(
       `[Image API] ⚠️ Rate limit exceeded for IP: ${ip} (UA: ${userAgent}). Retry after ${retryAfter}s`,
     );
-    return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
+    return NextResponse.json(
+      { error: 'Too many requests' },
+      {
+        status: 429,
+        headers: {
+          'Retry-After': String(retryAfter),
+          'X-RateLimit-Limit': String(getConfig().rateLimitRpm),
+          'X-RateLimit-Remaining': '0',
+        },
+      },
+    );
   }
 
   const { id: token } = await params;
@@ -68,7 +78,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     return new NextResponse(null, {
       status: 304,
       headers: {
-        'ETag': etag,
+        ETag: etag,
         'Cache-Control': 'public, max-age=31536000, immutable',
         'X-RateLimit-Remaining': String(remaining),
       },
@@ -87,7 +97,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       : result.contentType,
     // Images are immutable once uploaded to Immich — cache aggressively
     'Cache-Control': 'public, max-age=31536000, immutable',
-    'ETag': etag,
+    ETag: etag,
     'X-RateLimit-Remaining': String(remaining),
   };
 

--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -15,9 +15,17 @@ export async function GET(request: NextRequest) {
   const ip = getClientIp(request);
   const { theme, rateLimitRpm } = getConfig();
 
-  const { success } = checkRateLimit(`og:${ip}`, rateLimitRpm);
+  const { success, resetAt } = checkRateLimit(`og:${ip}`, rateLimitRpm);
   if (!success) {
-    return new NextResponse('Too many requests', { status: 429 });
+    const retryAfter = Math.ceil((resetAt - Date.now()) / 1000);
+    return new NextResponse('Too many requests', {
+      status: 429,
+      headers: {
+        'Retry-After': String(retryAfter),
+        'X-RateLimit-Limit': String(rateLimitRpm),
+        'X-RateLimit-Remaining': '0',
+      },
+    });
   }
 
   const { searchParams } = request.nextUrl;

--- a/components/DevToolbar.tsx
+++ b/components/DevToolbar.tsx
@@ -93,7 +93,7 @@ export function DevToolbar() {
     // Update accent + fonts
     const accent = PRESET_ACCENTS[p] || 'var(--accent-studio, #e60012)';
     setVar('--accent', accent);
-    // Note: since accent might be a CSS var, appending hex opacity won't work in all browsers if it's a var, 
+    // Note: since accent might be a CSS var, appending hex opacity won't work in all browsers if it's a var,
     // but we provide it for backward compatibility where possible. Or use color-mix if supported.
     // For now we set it to same var or use a generic dim if needed.
     setVar('--accent-dim', `color-mix(in srgb, ${accent} 12%, transparent)`);

--- a/components/MapView.tsx
+++ b/components/MapView.tsx
@@ -151,7 +151,10 @@ export function MapView() {
 
   if (error) {
     return (
-      <div className="map-container__loading" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
+      <div
+        className="map-container__loading"
+        style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}
+      >
         <p>{error}</p>
       </div>
     );
@@ -162,27 +165,27 @@ export function MapView() {
       {loading && (
         <div
           className="map-container__loading"
-          style={{ 
-            position: 'absolute', 
-            inset: 0, 
+          style={{
+            position: 'absolute',
+            inset: 0,
             zIndex: 1000,
             display: 'flex',
             flexDirection: 'column',
             alignItems: 'center',
             justifyContent: 'center',
             background: 'rgba(0, 0, 0, 0.5)',
-            color: '#fff'
+            color: '#fff',
           }}
         >
-          <svg 
-            width="24" 
-            height="24" 
-            viewBox="0 0 24 24" 
-            fill="none" 
-            stroke="currentColor" 
-            strokeWidth="2" 
-            strokeLinecap="round" 
-            strokeLinejoin="round" 
+          <svg
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
             style={{ animation: 'spin 1s linear infinite', marginBottom: '8px' }}
           >
             <circle cx="12" cy="12" r="10" strokeOpacity="0.25"></circle>


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: API endpoints returning 429 Too Many Requests lacked standard Rate Limit headers (Retry-After, X-RateLimit-Limit, X-RateLimit-Remaining).
🎯 Impact: Clients (and intermediate load balancers/proxies) could not accurately determine how long to back off, potentially leading to persistent thundering-herd problems and making denial-of-service protections less effective.
🔧 Fix: Extracted `resetAt` from `checkRateLimit()` across `auth`, `image`, `exif`, and `og` endpoints and explicitly added `Retry-After` (in seconds), `X-RateLimit-Limit`, and `X-RateLimit-Remaining: 0` headers to 429 responses.
✅ Verification: Ran unit tests and linting to ensure functionality is preserved.

---
*PR created automatically by Jules for task [13462945338288542132](https://jules.google.com/task/13462945338288542132) started by @ralksta*