### PR TITLE
⚡ Bolt: [deduplicate concurrent API requests]

### DIFF
--- a/lib/immich.ts
+++ b/lib/immich.ts
@@ -73,6 +73,8 @@ export interface SubpageSummary {
 class ImmichClient {
   private hasLoggedAlbums = false;
   private pendingAlbumsPromise: Promise<ImmichAlbum[]> | null = null;
+  private pendingAlbumPromises = new Map<string, Promise<ImmichAlbum | null>>();
+  private pendingAssetPromises = new Map<string, Promise<ImmichAsset | null>>();
 
   private get config() {
     return getConfig();
@@ -281,18 +283,30 @@ class ImmichClient {
     const cached = cache.get<ImmichAlbum>(cacheKey);
     if (cached) return cached;
 
-    const album = await this.request<ImmichAlbum>(`/albums/${encodeURIComponent(albumId)}`);
-    if (!album) return null;
+    const pending = this.pendingAlbumPromises.get(albumId);
+    if (pending) return pending;
 
-    // Filter out trashed assets
-    album.assets = (album.assets || []).filter((a) => !a.isTrashed);
+    const promise = (async () => {
+      try {
+        const album = await this.request<ImmichAlbum>(`/albums/${encodeURIComponent(albumId)}`);
+        if (!album) return null;
 
-    const name = this.config.albumOverrides[album.id] ?? album.albumName;
-    album.albumName = name;
-    album.slug = slugify(name);
+        // Filter out trashed assets
+        album.assets = (album.assets || []).filter((a) => !a.isTrashed);
 
-    cache.set(cacheKey, album, this.config.cacheTtl);
-    return album;
+        const name = this.config.albumOverrides[album.id] ?? album.albumName;
+        album.albumName = name;
+        album.slug = slugify(name);
+
+        cache.set(cacheKey, album, this.config.cacheTtl);
+        return album;
+      } finally {
+        this.pendingAlbumPromises.delete(albumId);
+      }
+    })();
+
+    this.pendingAlbumPromises.set(albumId, promise);
+    return promise;
   }
 
   /**
@@ -330,11 +344,23 @@ class ImmichClient {
     const cached = cache.get<ImmichAsset>(cacheKey);
     if (cached) return cached;
 
-    const asset = await this.request<ImmichAsset>(`/assets/${encodeURIComponent(assetId)}`);
-    if (!asset) return null;
+    const pending = this.pendingAssetPromises.get(assetId);
+    if (pending) return pending;
 
-    cache.set(cacheKey, asset, this.config.cacheTtl);
-    return asset;
+    const promise = (async () => {
+      try {
+        const asset = await this.request<ImmichAsset>(`/assets/${encodeURIComponent(assetId)}`);
+        if (!asset) return null;
+
+        cache.set(cacheKey, asset, this.config.cacheTtl);
+        return asset;
+      } finally {
+        this.pendingAssetPromises.delete(assetId);
+      }
+    })();
+
+    this.pendingAssetPromises.set(assetId, promise);
+    return promise;
   }
 
   /**


### PR DESCRIPTION
**💡 What:** Implemented Promise deduplication (request coalescing) in `ImmichClient.getAlbum` and `ImmichClient.getAssetInfo`.

**🎯 Why:** When multiple parts of the application or concurrent requests hit the same endpoint before the in-memory cache is populated, the application would make redundant parallel API calls to the upstream Immich server. This optimization prevents a thundering herd scenario.

**📊 Impact:** Reduces upstream Immich server load and prevents duplicate concurrent network requests. Note: Streaming requests (`streamAsset`) are intentionally excluded from deduplication since `ReadableStream` instances can only be consumed once.

**🔬 Measurement:** Run `pnpm test:unit` to verify core logic functions correctly. The impact can be observed in high-concurrency environments by logging upstream requests before and after the change.

---
*PR created automatically by Jules for task [930685480354697926](https://jules.google.com/task/930685480354697926) started by @ralksta*