### PR TITLE
🎨 Palette: Improve SVG screen reader context

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Lightbox ARIA Attributes
 **Learning:** Adding `role="dialog"`, `aria-modal="true"`, and `aria-label` to custom modal/lightbox overlays ensures screen readers announce them properly instead of just falling back to reading inner content without context. Additionally, toggles that show/hide panels (like the EXIF info button) must use `aria-expanded` and link to the panel via `aria-controls` for proper screen reader communication.
 **Action:** When building or modifying custom overlays or toggle buttons in the future, always verify that ARIA attributes are set correctly to match the visual behavior.
+
+## 2024-05-25 - SVG decorative accessibility
+**Learning:** Screen readers may read the raw SVG DOM nodes in some interactive components (like `<button>`s with icon content), even if an `aria-label` is present.
+**Action:** Always add `aria-hidden="true"` to `<svg>` icons used for visual decoration inside interactive elements to force screen readers to ignore the vector nodes and rely strictly on the semantic labels.

--- a/components/BackLink.tsx
+++ b/components/BackLink.tsx
@@ -20,6 +20,7 @@ export function BackLink({ href, label }: BackLinkProps) {
         strokeWidth="2"
         strokeLinecap="round"
         strokeLinejoin="round"
+        aria-hidden="true"
       >
         <polyline points="15 18 9 12 15 6" />
       </svg>

--- a/components/Lightbox.tsx
+++ b/components/Lightbox.tsx
@@ -117,6 +117,7 @@ export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev }: Ligh
           strokeWidth="2"
           strokeLinecap="round"
           strokeLinejoin="round"
+          aria-hidden="true"
         >
           <line x1="18" y1="6" x2="6" y2="18" />
           <line x1="6" y1="6" x2="18" y2="18" />
@@ -137,6 +138,7 @@ export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev }: Ligh
           strokeWidth="2"
           strokeLinecap="round"
           strokeLinejoin="round"
+          aria-hidden="true"
         >
           <polyline points="15 18 9 12 15 6" />
         </svg>
@@ -177,6 +179,7 @@ export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev }: Ligh
           strokeWidth="2"
           strokeLinecap="round"
           strokeLinejoin="round"
+          aria-hidden="true"
         >
           <polyline points="9 6 15 12 9 18" />
         </svg>

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -71,6 +71,7 @@ export function ThemeToggle() {
           strokeWidth="1.5"
           strokeLinecap="round"
           strokeLinejoin="round"
+          aria-hidden="true"
         >
           <circle cx="12" cy="12" r="5" />
           <line x1="12" y1="1" x2="12" y2="3" />
@@ -93,6 +94,7 @@ export function ThemeToggle() {
           strokeWidth="1.5"
           strokeLinecap="round"
           strokeLinejoin="round"
+          aria-hidden="true"
         >
           <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
         </svg>


### PR DESCRIPTION
💡 **What**: Added `aria-hidden="true"` to decorative SVG icons across the app (`ThemeToggle.tsx`, `BackLink.tsx`, `Lightbox.tsx`).
🎯 **Why**: Screen readers can sometimes attempt to read the raw DOM nodes of SVGs contained within interactive elements, even if an `aria-label` is present. Hiding them forces the screen reader to rely solely on the properly defined semantic labels.
♿ **Accessibility**: Prevents redundant or confusing screen reader announcements for decorative icons inside buttons and links.
📸 **Before/After**: Visually identical; strictly an invisible accessibility improvement.

Additionally, updated `.Jules/palette.md` to record this specific learning to prevent the issue in future UI additions.

---
*PR created automatically by Jules for task [14450978502501029964](https://jules.google.com/task/14450978502501029964) started by @ralksta*