### PR TITLE
⚡ Bolt: Implement Promise deduplication for Immich API calls

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,6 @@
 
 **Learning:** When using `Promise.all` to fetch dependent data in parallel (e.g., getting multiple subpages and standalone albums that internally call a shared `getAlbums` function), the internal cache might not be populated in time. This leads to redundant concurrent network requests to the upstream server.
 **Action:** Implement Promise deduplication (request coalescing) by caching the pending Promise itself (e.g., in a `this.pendingPromise` class field) rather than just the final result. Return the pending Promise to subsequent callers until it resolves, ensuring only one network request is made.
+## $(date +%Y-%m-%d) - [Deduplicate concurrent API requests via Promise caching]
+**Learning:** Extending the earlier learning, it's not just the global `getAlbums` that can suffer from redundant requests. Fine-grained functions like `getAssetInfo` (called per-image) and `getAlbum` (called per-album) are also susceptible when resolving lists of IDs in parallel if the cache is cold.
+**Action:** Use a `Map<string, Promise>` to deduplicate parameterized calls (like fetching by ID) to ensure only one inflight request exists per unique resource ID, protecting the backend from spikes.

--- a/lib/immich.ts
+++ b/lib/immich.ts
@@ -73,6 +73,8 @@ export interface SubpageSummary {
 class ImmichClient {
   private hasLoggedAlbums = false;
   private pendingAlbumsPromise: Promise<ImmichAlbum[]> | null = null;
+  private pendingAlbumPromises = new Map<string, Promise<ImmichAlbum | null>>();
+  private pendingAssetPromises = new Map<string, Promise<ImmichAsset | null>>();
 
   private get config() {
     return getConfig();
@@ -281,18 +283,31 @@ class ImmichClient {
     const cached = cache.get<ImmichAlbum>(cacheKey);
     if (cached) return cached;
 
-    const album = await this.request<ImmichAlbum>(`/albums/${encodeURIComponent(albumId)}`);
-    if (!album) return null;
+    if (this.pendingAlbumPromises.has(albumId)) {
+      return this.pendingAlbumPromises.get(albumId)!;
+    }
 
-    // Filter out trashed assets
-    album.assets = (album.assets || []).filter((a) => !a.isTrashed);
+    const promise = (async () => {
+      try {
+        const album = await this.request<ImmichAlbum>(`/albums/${encodeURIComponent(albumId)}`);
+        if (!album) return null;
 
-    const name = this.config.albumOverrides[album.id] ?? album.albumName;
-    album.albumName = name;
-    album.slug = slugify(name);
+        // Filter out trashed assets
+        album.assets = (album.assets || []).filter((a) => !a.isTrashed);
 
-    cache.set(cacheKey, album, this.config.cacheTtl);
-    return album;
+        const name = this.config.albumOverrides[album.id] ?? album.albumName;
+        album.albumName = name;
+        album.slug = slugify(name);
+
+        cache.set(cacheKey, album, this.config.cacheTtl);
+        return album;
+      } finally {
+        this.pendingAlbumPromises.delete(albumId);
+      }
+    })();
+
+    this.pendingAlbumPromises.set(albumId, promise);
+    return promise;
   }
 
   /**
@@ -330,11 +345,24 @@ class ImmichClient {
     const cached = cache.get<ImmichAsset>(cacheKey);
     if (cached) return cached;
 
-    const asset = await this.request<ImmichAsset>(`/assets/${encodeURIComponent(assetId)}`);
-    if (!asset) return null;
+    if (this.pendingAssetPromises.has(assetId)) {
+      return this.pendingAssetPromises.get(assetId)!;
+    }
 
-    cache.set(cacheKey, asset, this.config.cacheTtl);
-    return asset;
+    const promise = (async () => {
+      try {
+        const asset = await this.request<ImmichAsset>(`/assets/${encodeURIComponent(assetId)}`);
+        if (!asset) return null;
+
+        cache.set(cacheKey, asset, this.config.cacheTtl);
+        return asset;
+      } finally {
+        this.pendingAssetPromises.delete(assetId);
+      }
+    })();
+
+    this.pendingAssetPromises.set(assetId, promise);
+    return promise;
   }
 
   /**


### PR DESCRIPTION
💡 **What**: Implemented Promise deduplication (request coalescing) for `getAssetInfo` and `getAlbum` within `ImmichClient`.
🎯 **Why**: When rendering grids or long lists (e.g. subpage albums or hero carousel), multiple components may request metadata for the same `assetId` or `albumId` simultaneously. If the cache is cold, this triggers redundant network requests to the upstream Immich server, wasting bandwidth and slowing down the initial render.
📊 **Impact**: Reduces redundant upstream API calls when loading pages with repeated assets (like a shared cover image across multiple subpage galleries) or reloading the app when cache is cold.
🔬 **Measurement**: Verify by inspecting network traffic to the upstream Immich server during a cold load of a subpage containing multiple albums sharing the same cover image; only one request per unique `assetId` or `albumId` should be dispatched.

---
*PR created automatically by Jules for task [18318150290124001128](https://jules.google.com/task/18318150290124001128) started by @ralksta*