### PR TITLE
🎨 Palette: Add `aria-hidden` to decorative SVG icons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Lightbox ARIA Attributes
 **Learning:** Adding `role="dialog"`, `aria-modal="true"`, and `aria-label` to custom modal/lightbox overlays ensures screen readers announce them properly instead of just falling back to reading inner content without context. Additionally, toggles that show/hide panels (like the EXIF info button) must use `aria-expanded` and link to the panel via `aria-controls` for proper screen reader communication.
 **Action:** When building or modifying custom overlays or toggle buttons in the future, always verify that ARIA attributes are set correctly to match the visual behavior.
+
+## 2024-05-25 - Hidden SVG Icons inside Interactive Elements
+**Learning:** For accessibility, when using decorative `<svg>` icons within interactive elements like `<button>` or `<a>` that already have `aria-label`s or text, it is crucial to apply `aria-hidden="true"` to the SVG. Otherwise, screen readers may read out the raw vector node attributes or the SVG tag itself, causing noise and a confusing user experience.
+**Action:** When adding or updating SVG icons within semantic buttons or links, consistently apply `aria-hidden="true"` to the SVG element to ensure screen readers ignore it.

--- a/components/BackLink.tsx
+++ b/components/BackLink.tsx
@@ -14,6 +14,7 @@ export function BackLink({ href, label }: BackLinkProps) {
   return (
     <Link href={href} className="album-header__back" aria-label={`Back to ${label}`}>
       <svg
+        aria-hidden="true"
         viewBox="0 0 24 24"
         fill="none"
         stroke="currentColor"

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -40,6 +40,7 @@ export function Footer() {
               aria-label="Instagram"
             >
               <svg
+                aria-hidden="true"
                 width="16"
                 height="16"
                 viewBox="0 0 24 24"
@@ -58,6 +59,7 @@ export function Footer() {
           {footer?.email && (
             <a href={`mailto:${footer.email}`} className="footer__link" aria-label="Email">
               <svg
+                aria-hidden="true"
                 width="16"
                 height="16"
                 viewBox="0 0 24 24"
@@ -81,6 +83,7 @@ export function Footer() {
               aria-label="Website"
             >
               <svg
+                aria-hidden="true"
                 width="16"
                 height="16"
                 viewBox="0 0 24 24"

--- a/components/Lightbox.tsx
+++ b/components/Lightbox.tsx
@@ -111,6 +111,7 @@ export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev }: Ligh
       {/* Close button */}
       <button className={styles.close} onClick={onClose} aria-label="Close" title="Close (Esc)">
         <svg
+          aria-hidden="true"
           viewBox="0 0 24 24"
           fill="none"
           stroke="currentColor"
@@ -131,6 +132,7 @@ export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev }: Ligh
         title="Previous photo (Left arrow)"
       >
         <svg
+          aria-hidden="true"
           viewBox="0 0 24 24"
           fill="none"
           stroke="currentColor"
@@ -171,6 +173,7 @@ export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev }: Ligh
         title="Next photo (Right arrow)"
       >
         <svg
+          aria-hidden="true"
           viewBox="0 0 24 24"
           fill="none"
           stroke="currentColor"

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -63,6 +63,7 @@ export function ThemeToggle() {
       {theme === 'dark' ? (
         // Sun icon
         <svg
+          aria-hidden="true"
           width="16"
           height="16"
           viewBox="0 0 24 24"


### PR DESCRIPTION
💡 What: Added `aria-hidden="true"` to SVG elements used for decoration inside interactive elements like buttons and links.
🎯 Why: Prevents screen readers from announcing raw SVG attributes or nodes to visually impaired users, providing a cleaner navigation experience when elements already have semantic `aria-label`s.
📸 Before/After: Visuals are unchanged. 
♿ Accessibility: Improves screen reader compatibility on links and buttons in the Header, Footer, and Lightbox components. Added a log entry detailing the learning to `.Jules/palette.md`.

---
*PR created automatically by Jules for task [1325286861751886283](https://jules.google.com/task/1325286861751886283) started by @ralksta*