### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix timing attack in password comparison

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -5,3 +5,10 @@
 **Learning:** Next.js dynamic endpoints that do not hit external upstream APIs or databases (like image generation with `next/og`) are often overlooked for rate limiting. Rate limiting is just as critical for protecting local compute resources as it is for protecting downstream API quotas or databases. Any route performing on-the-fly heavy processing must implement throttling.
 
 **Prevention:** Apply the shared `checkRateLimit` utility (from `@/lib/rate-limit`) to all computationally expensive endpoints (such as `next/og` usage), even if they do not explicitly query external services. Ensure `getConfig().rateLimitRpm` is passed as the threshold to maintain configurable global protection.
+## 2024-05-19 - Timing Attack Vulnerability in Variable-Length Secret Comparisons
+
+**Vulnerability:** A plain string comparison (`password === sp.password`) was being used for legacy plaintext password validation in `lib/auth.ts`. This introduces a side-channel timing attack risk because string comparison algorithms typically return `false` as soon as they find the first mismatching character. An attacker can repeatedly attempt authentication, measuring the time it takes for the server to reject the guess, allowing them to incrementally deduce the password length and character by character.
+
+**Learning:** When comparing variable-length secrets (like plaintext passwords) that have not already been securely hashed, you cannot directly compare them, and you cannot simply use `crypto.timingSafeEqual` because it requires both buffers to be of exactly the same length. Passing differently sized buffers into `crypto.timingSafeEqual` will result in a length-based error, which itself acts as a side-channel leak for the length of the secret.
+
+**Prevention:** To safely prevent timing attacks when comparing variable-length secrets, hash both the user input and the stored secret using a fast, fixed-length algorithm (like SHA-256) first. The resulting hashes will be identical in length (e.g., 32 bytes for SHA-256), making them safe to compare using `crypto.timingSafeEqual()`.

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -96,7 +96,12 @@ export function authenticate(slug: string, password: string): string | null {
     isValid = verifyScrypt(password, sp.password);
   } else {
     // Plaintext fallback (deprecated)
-    isValid = password === sp.password;
+    // To prevent timing attacks when comparing variable-length secrets (like plaintext passwords in lib/auth.ts),
+    // hash both values with a fixed-length algorithm (e.g., SHA-256) before using crypto.timingSafeEqual.
+    const expectedHash = crypto.createHash('sha256').update(sp.password).digest();
+    const inputHash = crypto.createHash('sha256').update(password).digest();
+    isValid = crypto.timingSafeEqual(inputHash, expectedHash);
+
     if (isValid) {
       const recommendedHash = generateScryptHash(sp.password);
       console.warn(


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A plain string comparison (`password === sp.password`) was used for fallback plaintext password verification in `lib/auth.ts`. This comparison inherently short-circuits on the first mismatched character, creating a side-channel timing leak.
🎯 **Impact:** An attacker could exploit this timing difference to incrementally guess the length and characters of plaintext passwords, eventually compromising the authentication system.
🔧 **Fix:** Replaced the direct comparison with a constant-time execution flow. Because `crypto.timingSafeEqual` cannot be used on buffers of differing lengths, both the input and the stored secret are hashed using SHA-256 to create equal-length 32-byte buffers before passing them into the secure comparison function.
✅ **Verification:** Verified that `pnpm test` (specifically `lib/__tests__/auth.test.ts`) passes successfully and correctly validates fallback plaintexts without regression. Additionally, `eslint` and `prettier` confirmed code consistency.

---
*PR created automatically by Jules for task [16196317441919780590](https://jules.google.com/task/16196317441919780590) started by @ralksta*