### PR TITLE
🎨 Palette: [UX improvement] Hide decorative SVGs from screen readers

### DIFF
--- a/components/BackLink.tsx
+++ b/components/BackLink.tsx
@@ -14,6 +14,7 @@ export function BackLink({ href, label }: BackLinkProps) {
   return (
     <Link href={href} className="album-header__back" aria-label={`Back to ${label}`}>
       <svg
+        aria-hidden="true"
         viewBox="0 0 24 24"
         fill="none"
         stroke="currentColor"

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -40,6 +40,7 @@ export function Footer() {
               aria-label="Instagram"
             >
               <svg
+                aria-hidden="true"
                 width="16"
                 height="16"
                 viewBox="0 0 24 24"
@@ -58,6 +59,7 @@ export function Footer() {
           {footer?.email && (
             <a href={`mailto:${footer.email}`} className="footer__link" aria-label="Email">
               <svg
+                aria-hidden="true"
                 width="16"
                 height="16"
                 viewBox="0 0 24 24"
@@ -81,6 +83,7 @@ export function Footer() {
               aria-label="Website"
             >
               <svg
+                aria-hidden="true"
                 width="16"
                 height="16"
                 viewBox="0 0 24 24"

--- a/components/Lightbox.tsx
+++ b/components/Lightbox.tsx
@@ -111,6 +111,7 @@ export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev }: Ligh
       {/* Close button */}
       <button className={styles.close} onClick={onClose} aria-label="Close" title="Close (Esc)">
         <svg
+          aria-hidden="true"
           viewBox="0 0 24 24"
           fill="none"
           stroke="currentColor"
@@ -131,6 +132,7 @@ export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev }: Ligh
         title="Previous photo (Left arrow)"
       >
         <svg
+          aria-hidden="true"
           viewBox="0 0 24 24"
           fill="none"
           stroke="currentColor"
@@ -171,6 +173,7 @@ export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev }: Ligh
         title="Next photo (Right arrow)"
       >
         <svg
+          aria-hidden="true"
           viewBox="0 0 24 24"
           fill="none"
           stroke="currentColor"

--- a/components/MapView.tsx
+++ b/components/MapView.tsx
@@ -151,7 +151,10 @@ export function MapView() {
 
   if (error) {
     return (
-      <div className="map-container__loading" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
+      <div
+        className="map-container__loading"
+        style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}
+      >
         <p>{error}</p>
       </div>
     );
@@ -162,27 +165,30 @@ export function MapView() {
       {loading && (
         <div
           className="map-container__loading"
-          style={{ 
-            position: 'absolute', 
-            inset: 0, 
+          role="alert"
+          aria-live="polite"
+          style={{
+            position: 'absolute',
+            inset: 0,
             zIndex: 1000,
             display: 'flex',
             flexDirection: 'column',
             alignItems: 'center',
             justifyContent: 'center',
             background: 'rgba(0, 0, 0, 0.5)',
-            color: '#fff'
+            color: '#fff',
           }}
         >
-          <svg 
-            width="24" 
-            height="24" 
-            viewBox="0 0 24 24" 
-            fill="none" 
-            stroke="currentColor" 
-            strokeWidth="2" 
-            strokeLinecap="round" 
-            strokeLinejoin="round" 
+          <svg
+            aria-hidden="true"
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
             style={{ animation: 'spin 1s linear infinite', marginBottom: '8px' }}
           >
             <circle cx="12" cy="12" r="10" strokeOpacity="0.25"></circle>

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -63,6 +63,7 @@ export function ThemeToggle() {
       {theme === 'dark' ? (
         // Sun icon
         <svg
+          aria-hidden="true"
           width="16"
           height="16"
           viewBox="0 0 24 24"
@@ -85,6 +86,7 @@ export function ThemeToggle() {
       ) : (
         // Moon icon
         <svg
+          aria-hidden="true"
           width="16"
           height="16"
           viewBox="0 0 24 24"

--- a/e2e/verify_a11y.spec.ts
+++ b/e2e/verify_a11y.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from '@playwright/test';
+
+test('Verify aria-hidden attributes', async ({ page }) => {
+  await page.goto('http://localhost:3000');
+
+  // Wait for the page to load
+  await page.waitForSelector('body');
+
+  // Check Footer svgs
+  const footerLinks = page.locator('footer a svg');
+  const count = await footerLinks.count();
+  console.log(`Found ${count} SVGs in footer`);
+  for (let i = 0; i < count; i++) {
+    const isHidden = await footerLinks.nth(i).getAttribute('aria-hidden');
+    console.log(`Footer SVG ${i} aria-hidden: ${isHidden}`);
+    expect(isHidden).toBe('true');
+  }
+
+  // Check ThemeToggle svg
+  const themeToggleSvg = page.locator('button.theme-toggle svg');
+  const toggleCount = await themeToggleSvg.count();
+  console.log(`Found ${toggleCount} SVGs in theme toggle`);
+  for (let i = 0; i < toggleCount; i++) {
+    const isHidden = await themeToggleSvg.nth(i).getAttribute('aria-hidden');
+    console.log(`Theme Toggle SVG ${i} aria-hidden: ${isHidden}`);
+    expect(isHidden).toBe('true');
+  }
+
+  // Open an album to check BackLink and Lightbox
+  const albumLink = page.locator('.album-link').first();
+  if (await albumLink.isVisible()) {
+      await albumLink.click();
+      await page.waitForSelector('.album-header__back svg');
+
+      // Check BackLink svg
+      const backLinkSvg = page.locator('.album-header__back svg');
+      const isBackLinkHidden = await backLinkSvg.getAttribute('aria-hidden');
+      console.log(`BackLink SVG aria-hidden: ${isBackLinkHidden}`);
+      expect(isBackLinkHidden).toBe('true');
+
+      // Open Lightbox
+      const photo = page.locator('.photo-grid img').first();
+      await photo.click();
+      await page.waitForSelector('[role="dialog"]');
+
+      // Check Lightbox svgs
+      const lightboxSvgs = page.locator('[role="dialog"] button svg');
+      const lightboxCount = await lightboxSvgs.count();
+      console.log(`Found ${lightboxCount} SVGs in lightbox`);
+      for (let i = 0; i < lightboxCount; i++) {
+        const isHidden = await lightboxSvgs.nth(i).getAttribute('aria-hidden');
+        console.log(`Lightbox SVG ${i} aria-hidden: ${isHidden}`);
+        expect(isHidden).toBe('true');
+      }
+  } else {
+      console.log('No albums found to check BackLink and Lightbox');
+  }
+
+  // Take screenshot for visual verification of MapView loading
+  await page.goto('http://localhost:3000/map');
+  const mapLoading = page.locator('.map-container__loading');
+  if (await mapLoading.isVisible()) {
+      const mapLoadingRole = await mapLoading.getAttribute('role');
+      const mapLoadingLive = await mapLoading.getAttribute('aria-live');
+      const mapLoadingSvgHidden = await mapLoading.locator('svg').getAttribute('aria-hidden');
+
+      console.log(`Map loading role: ${mapLoadingRole}`);
+      console.log(`Map loading aria-live: ${mapLoadingLive}`);
+      console.log(`Map loading SVG aria-hidden: ${mapLoadingSvgHidden}`);
+
+      expect(mapLoadingRole).toBe('alert');
+      expect(mapLoadingLive).toBe('polite');
+      expect(mapLoadingSvgHidden).toBe('true');
+  }
+
+  await page.screenshot({ path: '/home/jules/verification/verification.png' });
+});


### PR DESCRIPTION
💡 **What:** 
Added `aria-hidden="true"` to decorative `<svg>` icons that exist inside interactive elements (like buttons and links with `aria-label`s) across several components. Also added `role="alert"` and `aria-live="polite"` to the map loading state container, while hiding its spinning SVG spinner.

🎯 **Why:** 
Screen readers announce the raw image nodes of vector graphics without context unless explicitly hidden. When an icon acts only as a visual affordance inside a button that already provides an `aria-label`, hiding the graphic avoids redundant and confusing readouts. The map loading state also needed proper ARIA roles to ensure visually impaired users are properly informed when the map is loading.

📸 **Before/After:** 
No visual change.

♿ **Accessibility:** 
- Improved screen reader navigation by silencing redundant SVGs in `BackLink`, `Footer`, `Lightbox`, and `ThemeToggle`.
- Ensured the `MapView` loading spinner behaves as an accessible polite alert.

---
*PR created automatically by Jules for task [16295854708291897402](https://jules.google.com/task/16295854708291897402) started by @ralksta*