### PR TITLE
⚡ Bolt: [performance improvement] Deduplicate concurrent getAlbum requests

### DIFF
--- a/lib/immich.ts
+++ b/lib/immich.ts
@@ -73,6 +73,7 @@ export interface SubpageSummary {
 class ImmichClient {
   private hasLoggedAlbums = false;
   private pendingAlbumsPromise: Promise<ImmichAlbum[]> | null = null;
+  private pendingAlbumPromises = new Map<string, Promise<ImmichAlbum | null>>();
 
   private get config() {
     return getConfig();
@@ -281,18 +282,31 @@ class ImmichClient {
     const cached = cache.get<ImmichAlbum>(cacheKey);
     if (cached) return cached;
 
-    const album = await this.request<ImmichAlbum>(`/albums/${encodeURIComponent(albumId)}`);
-    if (!album) return null;
+    if (this.pendingAlbumPromises.has(albumId)) {
+      return this.pendingAlbumPromises.get(albumId)!;
+    }
 
-    // Filter out trashed assets
-    album.assets = (album.assets || []).filter((a) => !a.isTrashed);
+    const promise = (async () => {
+      try {
+        const album = await this.request<ImmichAlbum>(`/albums/${encodeURIComponent(albumId)}`);
+        if (!album) return null;
 
-    const name = this.config.albumOverrides[album.id] ?? album.albumName;
-    album.albumName = name;
-    album.slug = slugify(name);
+        // Filter out trashed assets
+        album.assets = (album.assets || []).filter((a) => !a.isTrashed);
 
-    cache.set(cacheKey, album, this.config.cacheTtl);
-    return album;
+        const name = this.config.albumOverrides[album.id] ?? album.albumName;
+        album.albumName = name;
+        album.slug = slugify(name);
+
+        cache.set(cacheKey, album, this.config.cacheTtl);
+        return album;
+      } finally {
+        this.pendingAlbumPromises.delete(albumId);
+      }
+    })();
+
+    this.pendingAlbumPromises.set(albumId, promise);
+    return promise;
   }
 
   /**


### PR DESCRIPTION
💡 What: Implemented request coalescing (promise caching) for the `getAlbum` method in `ImmichClient` within `lib/immich.ts`.
🎯 Why: If the application makes multiple concurrent calls to `getAlbum` for the same album ID before the first call finishes and populates the cache, it triggers redundant, identical HTTP requests to the backend Immich server. Deduplication mitigates these duplicate in-flight requests.
📊 Impact: Reduces redundant network traffic to the upstream backend during parallel SSR or concurrent component rendering when multiple parts of the application need the same album metadata simultaneously. 
🔬 Measurement: Verified that unit and E2E tests still pass, ensuring core functionality remains intact. The `pendingAlbumPromises` Map efficiently handles the async IIFE and removes the stored promise within a `finally` block to prevent stuck states on failure or completion.

---
*PR created automatically by Jules for task [679912705004690257](https://jules.google.com/task/679912705004690257) started by @ralksta*