### PR TITLE
🎨 Palette: [UX improvement] Auto-focus Lightbox close button for accessibility

### DIFF
--- a/components/Lightbox.tsx
+++ b/components/Lightbox.tsx
@@ -71,6 +71,15 @@ export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev }: Ligh
     preload(currentIndex - 1);
   }, [currentIndex, assets]);
 
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  // Auto-focus the close button when lightbox opens
+  useEffect(() => {
+    if (mounted && closeButtonRef.current) {
+      closeButtonRef.current.focus();
+    }
+  }, [mounted]);
+
   const { handleTouchStart, handleTouchEnd } = useSwipe({
     onSwipeLeft: onNext,
     onSwipeRight: onPrev,
@@ -109,7 +118,13 @@ export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev }: Ligh
       aria-label="Image viewer"
     >
       {/* Close button */}
-      <button className={styles.close} onClick={onClose} aria-label="Close" title="Close (Esc)">
+      <button
+        ref={closeButtonRef}
+        className={styles.close}
+        onClick={onClose}
+        aria-label="Close"
+        title="Close (Esc)"
+      >
         <svg
           aria-hidden="true"
           viewBox="0 0 24 24"


### PR DESCRIPTION
💡 **What:** 
Added an auto-focus feature to the `Lightbox` component. When the Lightbox is opened, focus is automatically set to the Close button.

🎯 **Why:** 
This improves the experience for keyboard-only users, as they won't have to tab through the entire underlying page content to reach the lightbox's controls.

♿ **Accessibility:** 
This adheres to ARIA dialog patterns. By focusing on an interactive element within the modal (in this case, the close button), we trap focus visually and programmatically alert screen reader users to the newly opened context.

---
*PR created automatically by Jules for task [7167338245394659692](https://jules.google.com/task/7167338245394659692) started by @ralksta*