### PR TITLE
⚡ Bolt: Cache parsed YAML configurations to eliminate synchronous disk I/O

### DIFF
--- a/lib/config/parser.ts
+++ b/lib/config/parser.ts
@@ -2,15 +2,36 @@ import fs from 'fs';
 import path from 'path';
 import yaml from 'js-yaml';
 
+// ⚡ Bolt: Cache parsed YAML configurations in production to eliminate
+// synchronous filesystem reads and expensive js-yaml parsing on every request.
+const yamlCache = new Map<string, unknown | null>();
+
 export function loadYaml<T>(filename: string): T | null {
+  const isProd = process.env.NODE_ENV === 'production';
+
+  // ⚡ Bolt: Return a deep clone from cache to prevent caller mutations from
+  // poisoning the shared cache. structuredClone preserves Date objects correctly.
+  if (isProd && yamlCache.has(filename)) {
+    const cached = yamlCache.get(filename);
+    return cached ? (structuredClone(cached) as T) : null;
+  }
+
   const yamlPath = path.join(process.cwd(), 'content', filename);
 
   if (!fs.existsSync(yamlPath)) {
+    // ⚡ Bolt: Negative caching prevents repeated disk checks for missing files.
+    if (isProd) yamlCache.set(filename, null);
     return null;
   }
 
   const raw = fs.readFileSync(yamlPath, 'utf8');
-  return (yaml.load(raw) || {}) as T;
+  const parsed = (yaml.load(raw) || {}) as T;
+
+  if (isProd) {
+    yamlCache.set(filename, structuredClone(parsed));
+  }
+
+  return parsed;
 }
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;


### PR DESCRIPTION
**💡 What:**
Implemented an in-memory `Map` cache in `lib/config/parser.ts` to store parsed YAML configurations (`gallery.yaml`, `settings.yaml`) during production. Used `structuredClone()` to serve deep-cloned objects from the cache safely, and implemented negative caching for missing files.

**🎯 Why:**
Currently, `loadYaml` reads and parses YAML files synchronously from the disk on every single call. Because the `gallery.yaml` and `settings.yaml` files drive the entire application's routing and styling, this means every request to the Next.js server triggers `fs.readFileSync` and `yaml.load`, which is a significant performance bottleneck.

**📊 Impact:**
Significantly reduces server-side CPU utilization and blocking I/O latency on every request in production by serving deep-cloned configuration objects directly from memory instead of hitting the disk and parsing text.

**🔬 Measurement:**
To verify, run `pnpm test:unit` and ensure the configuration parser still behaves exactly the same. The performance boost is evident by tracing `loadYaml` calls under load.

---
*PR created automatically by Jules for task [18299121499430585236](https://jules.google.com/task/18299121499430585236) started by @ralksta*