### PR TITLE
⚡ Bolt: [Memory/Speed] Optimize base64 decoding for thumbhashes

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,8 @@
 
 **Learning:** When using `Promise.all` to fetch dependent data in parallel (e.g., getting multiple subpages and standalone albums that internally call a shared `getAlbums` function), the internal cache might not be populated in time. This leads to redundant concurrent network requests to the upstream server.
 **Action:** Implement Promise deduplication (request coalescing) by caching the pending Promise itself (e.g., in a `this.pendingPromise` class field) rather than just the final result. Return the pending Promise to subsequent callers until it resolves, ensuring only one network request is made.
+
+## 2024-07-02 - [Optimize memory allocation for base64 decoding]
+
+**Learning:** Node.js `Buffer` inherits directly from `Uint8Array`. When passing binary data to libraries that expect a `Uint8Array` (like `thumbhash`), wrapping a Node.js `Buffer` inside `new Uint8Array(Buffer.from(...))` creates a completely unnecessary memory copy and allocation of the underlying ArrayBuffer.
+**Action:** Return the `Buffer` instance directly when a `Uint8Array` is expected in Node.js environments. This saves memory allocation and speeds up operations, especially for functions that run frequently like `thumbHashToBlurDataUrl`.

--- a/lib/thumbhash.ts
+++ b/lib/thumbhash.ts
@@ -27,7 +27,8 @@ function setCache<K, V>(map: Map<K, V>, key: K, value: V) {
  */
 function decodeBase64(base64: string): Uint8Array {
   if (typeof Buffer !== 'undefined') {
-    return new Uint8Array(Buffer.from(base64, 'base64'));
+    // Return Buffer directly (it extends Uint8Array) to prevent unnecessary memory allocation and copy
+    return Buffer.from(base64, 'base64');
   }
   return Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
 }


### PR DESCRIPTION
🚨 **Severity**: Optimization
💡 **What**: The optimization implemented
- Changed `decodeBase64` to return `Buffer.from(base64, 'base64')` directly instead of wrapping it in `new Uint8Array(...)`.

🎯 **Why**: The performance problem it solves
- Node.js `Buffer` instances are already subclasses of `Uint8Array`.
- Calling `new Uint8Array(bufferInstance)` forces the V8 engine to allocate a completely new chunk of memory and copy the underlying ArrayBuffer data.
- Thumbhash decoding happens for *every* image displayed (hero images, album grids), meaning this was doing thousands of unnecessary memory allocations per page load.

📊 **Impact**: Expected performance improvement
- Eliminates memory allocation and copying overhead for every Thumbhash decoded server-side.
- Reduces memory pressure and garbage collection frequency.
- The `thumbhash` library APIs (`thumbHashToRGBA` and `thumbHashToDataURL`) expect a `Uint8Array`, which a `Buffer` satisfies perfectly.

🔬 **Measurement**: How to verify the improvement
- Ran `pnpm test:unit` (specifically `lib/__tests__/thumbhash.test.ts`) which passed, proving `thumbhash` handles the raw Buffer instances exactly the same as Uint8Arrays.

---
*PR created automatically by Jules for task [4203551401066855727](https://jules.google.com/task/4203551401066855727) started by @ralksta*