### PR TITLE
🛡️ Sentinel: [improvement] Add standard rate limit headers

### DIFF
--- a/app/api/auth/route.ts
+++ b/app/api/auth/route.ts
@@ -13,10 +13,21 @@ const AUTH_RPM = 10;
 export async function POST(request: NextRequest) {
   // ── Rate limiting (brute-force protection) ──────────
   const ip = getClientIp(request);
-  const { success } = checkRateLimit(`auth:${ip}`, AUTH_RPM);
+  const { success, remaining, resetAt } = checkRateLimit(`auth:${ip}`, AUTH_RPM);
 
   if (!success) {
-    return NextResponse.json({ error: 'Too many attempts, try again later' }, { status: 429 });
+    const retryAfter = Math.ceil((resetAt - Date.now()) / 1000);
+    return NextResponse.json(
+      { error: 'Too many attempts, try again later' },
+      {
+        status: 429,
+        headers: {
+          'Retry-After': String(retryAfter),
+          'X-RateLimit-Limit': String(AUTH_RPM),
+          'X-RateLimit-Remaining': String(remaining),
+        },
+      },
+    );
   }
 
   try {

--- a/app/api/exif/[id]/route.ts
+++ b/app/api/exif/[id]/route.ts
@@ -21,12 +21,22 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 
   // ── Rate limiting ──────────────────────────────────
   const ip = getClientIp(request);
-  const { success, resetAt } = checkRateLimit(`exif:${ip}`, config.rateLimitRpm);
+  const { success, remaining, resetAt } = checkRateLimit(`exif:${ip}`, config.rateLimitRpm);
 
   if (!success) {
     const retryAfter = Math.ceil((resetAt - Date.now()) / 1000);
     console.warn(`[EXIF API] ⚠️ Rate limit exceeded for IP: ${ip}. Retry after ${retryAfter}s`);
-    return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
+    return NextResponse.json(
+      { error: 'Too many requests' },
+      {
+        status: 429,
+        headers: {
+          'Retry-After': String(retryAfter),
+          'X-RateLimit-Limit': String(config.rateLimitRpm),
+          'X-RateLimit-Remaining': String(remaining),
+        },
+      },
+    );
   }
 
   const { id: token } = await params;

--- a/app/api/image/[id]/route.ts
+++ b/app/api/image/[id]/route.ts
@@ -27,7 +27,8 @@ function widthToSize(w: number): ImageSize {
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   // ── Rate limiting ──────────────────────────────────
   const ip = getClientIp(request);
-  const { success, remaining, resetAt } = checkRateLimit(ip, getConfig().rateLimitRpm);
+  const rateLimitRpm = getConfig().rateLimitRpm;
+  const { success, remaining, resetAt } = checkRateLimit(ip, rateLimitRpm);
 
   if (!success) {
     const retryAfter = Math.ceil((resetAt - Date.now()) / 1000);
@@ -35,7 +36,17 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     console.warn(
       `[Image API] ⚠️ Rate limit exceeded for IP: ${ip} (UA: ${userAgent}). Retry after ${retryAfter}s`,
     );
-    return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
+    return NextResponse.json(
+      { error: 'Too many requests' },
+      {
+        status: 429,
+        headers: {
+          'Retry-After': String(retryAfter),
+          'X-RateLimit-Limit': String(rateLimitRpm),
+          'X-RateLimit-Remaining': String(remaining),
+        },
+      },
+    );
   }
 
   const { id: token } = await params;
@@ -68,7 +79,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     return new NextResponse(null, {
       status: 304,
       headers: {
-        'ETag': etag,
+        ETag: etag,
         'Cache-Control': 'public, max-age=31536000, immutable',
         'X-RateLimit-Remaining': String(remaining),
       },
@@ -87,7 +98,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       : result.contentType,
     // Images are immutable once uploaded to Immich — cache aggressively
     'Cache-Control': 'public, max-age=31536000, immutable',
-    'ETag': etag,
+    ETag: etag,
     'X-RateLimit-Remaining': String(remaining),
   };
 

--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -15,9 +15,17 @@ export async function GET(request: NextRequest) {
   const ip = getClientIp(request);
   const { theme, rateLimitRpm } = getConfig();
 
-  const { success } = checkRateLimit(`og:${ip}`, rateLimitRpm);
+  const { success, remaining, resetAt } = checkRateLimit(`og:${ip}`, rateLimitRpm);
   if (!success) {
-    return new NextResponse('Too many requests', { status: 429 });
+    const retryAfter = Math.ceil((resetAt - Date.now()) / 1000);
+    return new NextResponse('Too many requests', {
+      status: 429,
+      headers: {
+        'Retry-After': String(retryAfter),
+        'X-RateLimit-Limit': String(rateLimitRpm),
+        'X-RateLimit-Remaining': String(remaining),
+      },
+    });
   }
 
   const { searchParams } = request.nextUrl;

--- a/components/DevToolbar.tsx
+++ b/components/DevToolbar.tsx
@@ -93,7 +93,7 @@ export function DevToolbar() {
     // Update accent + fonts
     const accent = PRESET_ACCENTS[p] || 'var(--accent-studio, #e60012)';
     setVar('--accent', accent);
-    // Note: since accent might be a CSS var, appending hex opacity won't work in all browsers if it's a var, 
+    // Note: since accent might be a CSS var, appending hex opacity won't work in all browsers if it's a var,
     // but we provide it for backward compatibility where possible. Or use color-mix if supported.
     // For now we set it to same var or use a generic dim if needed.
     setVar('--accent-dim', `color-mix(in srgb, ${accent} 12%, transparent)`);


### PR DESCRIPTION
🛡️ Sentinel: [improvement] Add standard rate limit headers

🚨 Severity: LOW
💡 Vulnerability: Missing standard rate-limiting headers (`Retry-After`, `X-RateLimit-Limit`, `X-RateLimit-Remaining`) on API endpoints returning `429 Too Many Requests`. This forces clients and proxies to guess when to retry.
🎯 Impact: Enhances security defense-in-depth by explicitly communicating limits, allowing load balancers, CDNs, and legitimate clients to respect the bounds instead of continually hammering the server and wasting resources.
🔧 Fix: Updated the `429` responses in `/api/auth`, `/api/exif/[id]`, `/api/image/[id]`, and `/api/og` to include calculated `Retry-After` (in seconds) and other standard headers based on data extracted from the existing `checkRateLimit` utility.
✅ Verification: Ensure the test suite passes (`pnpm test` and `pnpm lint`), and verify that a 429 response includes the newly added headers.

---
*PR created automatically by Jules for task [16157823258422649209](https://jules.google.com/task/16157823258422649209) started by @ralksta*