### PR TITLE
🛡️ Sentinel: [HIGH] Fix cryptographic token encryption by upgrading to AES-256-GCM

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -9,3 +9,7 @@
 **Vulnerability:** Comparing variable-length plaintext passwords using strict equality (`===`) or `crypto.timingSafeEqual` with unequal lengths, which leaks length information and enables timing attacks.
 **Learning:** When comparing variable-length secrets (like plaintext fallback passwords), both values must be hashed to a fixed-length algorithm (like SHA-256) first to ensure identical input lengths for the secure comparison, preventing side-channel leaks.
 **Prevention:** Always hash variable-length secrets to a fixed length before passing them to `crypto.timingSafeEqual`.
+## 2024-05-30 - Upgrade AES-256-CBC to AES-256-GCM
+**Vulnerability:** `lib/tokens.ts` used unauthenticated `aes-256-cbc` encryption for deterministic token generation, which left the system potentially vulnerable to padding oracle attacks.
+**Learning:** Legacy CBC mode lacks authentication and allows ciphertext malleability. While used for obfuscation, using an AEAD mode like GCM provides robust cryptographic security. We also learned how to implement a graceful fallback to ensure existing cached URLs wouldn't break during migration.
+**Prevention:** Always use authenticated encryption (e.g., GCM or ChaCha20-Poly1305) over bare block cipher modes for secure tokens.

--- a/lib/__tests__/tokens.test.ts
+++ b/lib/__tests__/tokens.test.ts
@@ -40,10 +40,23 @@ describe('tokens', () => {
   });
 
   describe('decodeAssetId', () => {
-    it('round-trips a valid UUID', () => {
+    it('round-trips a valid UUID (GCM)', () => {
       const token = encodeAssetId(SAMPLE_UUID);
       const decoded = decodeAssetId(token);
       expect(decoded).toBe(SAMPLE_UUID);
+    });
+
+    it('decodes legacy AES-256-CBC tokens for backwards compatibility', async () => {
+      const crypto = await import('crypto');
+      // Manually create a legacy CBC token
+      const authSecret = 'test-auth-secret-32-chars-long-min';
+      const key = crypto.createHash('sha256').update(authSecret).digest();
+      const iv = crypto.createHash('sha256').update(SAMPLE_UUID).digest().subarray(0, 16);
+      const cipher = crypto.createCipheriv('aes-256-cbc', key, iv);
+      const encrypted = Buffer.concat([cipher.update(SAMPLE_UUID, 'utf8'), cipher.final()]);
+      const legacyToken = Buffer.concat([iv, encrypted]).toString('base64url');
+
+      expect(decodeAssetId(legacyToken)).toBe(SAMPLE_UUID);
     });
 
     it('returns null for a garbage string', () => {

--- a/lib/tokens.ts
+++ b/lib/tokens.ts
@@ -21,7 +21,7 @@ function getKey(): Buffer {
 
 /**
  * Encode an asset ID into an opaque URL-safe token.
- * Note: The AES-CBC deterministic IV causes the identical input asset ID
+ * Note: The AES-GCM deterministic IV causes the identical input asset ID
  * to encrypt to the exact same cipher token. This provides URL obfuscation
  * and caching consistency, but it does NOT provide k-anonymous cryptographic
  * security guarantees against recognizing identical items if intercepted.
@@ -29,12 +29,13 @@ function getKey(): Buffer {
 export function encodeAssetId(assetId: string): string {
   const key = getKey();
   // Deterministic IV from asset ID (same input → same token).
-  // SHA-256 slice → first 16 bytes. MD5 was deprecated for cryptographic use.
-  const iv = crypto.createHash('sha256').update(assetId).digest().subarray(0, 16);
-  const cipher = crypto.createCipheriv('aes-256-cbc', key, iv);
+  // SHA-256 slice → first 12 bytes for GCM.
+  const iv = crypto.createHash('sha256').update(assetId).digest().subarray(0, 12);
+  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
   const encrypted = Buffer.concat([cipher.update(assetId, 'utf8'), cipher.final()]);
-  // Compact: base64url(iv + ciphertext)
-  return Buffer.concat([iv, encrypted]).toString('base64url');
+  const tag = cipher.getAuthTag();
+  // Compact: base64url(iv + tag + ciphertext)
+  return Buffer.concat([iv, tag, encrypted]).toString('base64url');
 }
 
 /**
@@ -42,22 +43,46 @@ export function encodeAssetId(assetId: string): string {
  * Returns null if the token is invalid.
  */
 export function decodeAssetId(token: string): string | null {
-  try {
-    const key = getKey();
-    const data = Buffer.from(token, 'base64url');
-    if (data.length < 17) return null; // iv(16) + at least 1 byte
+  const key = getKey();
+  const data = Buffer.from(token, 'base64url');
 
-    const iv = data.subarray(0, 16);
-    const encrypted = data.subarray(16);
-    const decipher = crypto.createDecipheriv('aes-256-cbc', key, iv);
-    const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]).toString(
-      'utf8',
-    );
+  const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-    // Validate it looks like a UUID
-    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-    return uuidRegex.test(decrypted) ? decrypted : null;
-  } catch {
-    return null;
+  // Try decoding as AES-256-GCM first
+  if (data.length >= 12 + 16 + 1) {
+    // iv(12) + tag(16) + at least 1 byte
+    try {
+      const iv = data.subarray(0, 12);
+      const tag = data.subarray(12, 28);
+      const encrypted = data.subarray(28);
+      const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+      decipher.setAuthTag(tag);
+      const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]).toString(
+        'utf8',
+      );
+
+      if (uuidRegex.test(decrypted)) return decrypted;
+    } catch {
+      // Ignore and fallback to CBC
+    }
   }
+
+  // Fallback to AES-256-CBC for backwards compatibility
+  if (data.length >= 17) {
+    // iv(16) + at least 1 byte
+    try {
+      const iv = data.subarray(0, 16);
+      const encrypted = data.subarray(16);
+      const decipher = crypto.createDecipheriv('aes-256-cbc', key, iv);
+      const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]).toString(
+        'utf8',
+      );
+
+      if (uuidRegex.test(decrypted)) return decrypted;
+    } catch {
+      // Invalid CBC
+    }
+  }
+
+  return null;
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Unauthenticated AES-256-CBC encryption in `lib/tokens.ts` for asset ID tokens is susceptible to ciphertext malleability and padding oracle attacks.
🎯 **Impact:** Malicious actors could theoretically tamper with token ciphertexts to decipher asset IDs or manipulate the server state, though practically mitigated by the deterministic IV constraint.
🔧 **Fix:** Upgraded `encodeAssetId` and `decodeAssetId` to use `aes-256-gcm`, providing Authenticated Encryption with Associated Data (AEAD). Added an `aes-256-cbc` fallback in `decodeAssetId` to maintain backward compatibility with existing tokens in the wild.
✅ **Verification:** Ran `pnpm test` successfully (all 62 tests pass) including the new backward compatibility tests for legacy CBC tokens.

---
*PR created automatically by Jules for task [2936255309434917815](https://jules.google.com/task/2936255309434917815) started by @ralksta*