### PR TITLE
🛡️ Sentinel: [improvement] Add CSP Report-Only header

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -25,6 +25,11 @@ const nextConfig: NextConfig = {
             value: 'max-age=31536000; includeSubDomains',
           },
           { key: 'X-DNS-Prefetch-Control', value: 'off' },
+          {
+            key: 'Content-Security-Policy-Report-Only',
+            value:
+              "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.basemaps.cartocdn.com; font-src 'self'; connect-src 'self';",
+          },
         ],
       },
     ];


### PR DESCRIPTION
🚨 Severity: LOW / Defense-in-Depth
💡 Vulnerability: Missing Content Security Policy leaves the application more vulnerable to XSS and data injection attacks.
🎯 Impact: The addition of a CSP reduces the attack surface by explicitly defining trusted sources for scripts, styles, and external assets.
🔧 Fix: Added a `Content-Security-Policy-Report-Only` header in `next.config.ts`. It allows inline scripts/styles (common for Next.js features like HMR) and explicitly whitelists Map basemap providers (`*.basemaps.cartocdn.com`) and data URIs. Used `Report-Only` to safely monitor violations without breaking existing integrations.
✅ Verification: Ran `pnpm build` and verified that the header applies correctly and does not break static site generation or testing.

---
*PR created automatically by Jules for task [15185922887852588971](https://jules.google.com/task/15185922887852588971) started by @ralksta*