### PR TITLE
⚡ Bolt: [performance improvement] Cache parsed YAML files in memory

### DIFF
--- a/lib/config/parser.ts
+++ b/lib/config/parser.ts
@@ -2,15 +2,36 @@ import fs from 'fs';
 import path from 'path';
 import yaml from 'js-yaml';
 
+// In-memory cache for parsed YAML objects
+const yamlCache = new Map<string, unknown>();
+
 export function loadYaml<T>(filename: string): T | null {
+  const isDev = process.env.NODE_ENV !== 'production';
+
+  // Check cache first in production
+  if (!isDev && yamlCache.has(filename)) {
+    const cached = yamlCache.get(filename);
+    return cached === null ? null : structuredClone(cached as T);
+  }
+
   const yamlPath = path.join(process.cwd(), 'content', filename);
 
   if (!fs.existsSync(yamlPath)) {
+    if (!isDev) {
+      // Negative caching for missing files
+      yamlCache.set(filename, null);
+    }
     return null;
   }
 
   const raw = fs.readFileSync(yamlPath, 'utf8');
-  return (yaml.load(raw) || {}) as T;
+  const parsed = (yaml.load(raw) || {}) as T;
+
+  if (!isDev) {
+    yamlCache.set(filename, parsed);
+  }
+
+  return isDev ? parsed : structuredClone(parsed);
 }
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;


### PR DESCRIPTION
💡 What: Implemented a global in-memory Map cache inside `lib/config/parser.ts` to cache the results of `yaml.load()` calls.
🎯 Why: In production environments, files like `gallery.yaml` or `settings.yaml` are loaded continuously through dynamic APIs and rendering loops. Hitting `fs.readFileSync` and re-running expensive yaml parsing blocks the main Node.js thread on every call. This cache bypasses the disk entirely after the first read.
📊 Impact: Expected to significantly reduce latency on configuration lookups and decrease memory allocation overhead under concurrent load. Negative caching protects against hidden missing-file disk churn.
🔬 Measurement: Verify by executing `pnpm test:unit` and observing identical function behaviour and test passes, with reduced filesystem calls visible in Node profiling if needed.

---
*PR created automatically by Jules for task [4188252136440042805](https://jules.google.com/task/4188252136440042805) started by @ralksta*