### PR TITLE
🎨 Palette: [UX improvement] Add comprehensive aria-labels to SubpageGrid links

### DIFF
--- a/app/[...path]/SubpageGridView.tsx
+++ b/app/[...path]/SubpageGridView.tsx
@@ -27,12 +27,10 @@ interface SubpageGridViewProps {
 
 function AlbumGrid({
   albums,
-  albumMap,
   placeholderMap,
   slug,
 }: {
   albums: SubpageAlbum[];
-  albumMap: Map<string, SubpageAlbum>;
   placeholderMap: Map<string, Placeholder | null>;
   slug: string;
 }) {
@@ -46,11 +44,12 @@ function AlbumGrid({
             href={`/${slug}/${album.slug}`}
             className="subpage-grid__item"
             style={ph?.dominantColor ? { backgroundColor: ph.dominantColor } : undefined}
+            aria-label={`${album.albumName}, ${album.assetCount} ${album.assetCount === 1 ? 'photo' : 'photos'}`}
           >
             {album.albumThumbnailAssetId ? (
               <Image
                 src={imageUrl(album.albumThumbnailAssetId, 'preview')}
-                alt={album.albumName}
+                alt=""
                 fill
                 sizes="(max-width: 600px) 100vw, (max-width: 1000px) 50vw, 33vw"
                 loading="lazy"
@@ -59,10 +58,10 @@ function AlbumGrid({
             ) : (
               <div className="skeleton" style={{ width: '100%', height: '100%' }} />
             )}
-            <span className="subpage-grid__item-badge">
+            <span className="subpage-grid__item-badge" aria-hidden="true">
               {album.assetCount} {album.assetCount === 1 ? 'photo' : 'photos'}
             </span>
-            <div className="subpage-grid__item-overlay">
+            <div className="subpage-grid__item-overlay" aria-hidden="true">
               <span className="subpage-grid__item-title">{album.albumName}</span>
               <span className="subpage-grid__item-count">
                 {album.assetCount} {album.assetCount === 1 ? 'photo' : 'photos'}
@@ -126,23 +125,13 @@ export function SubpageGridView({
                 {sec.description && <p className="subpage-section__desc">{sec.description}</p>}
                 <div className="subpage-section__rule" aria-hidden="true" />
               </header>
-              <AlbumGrid
-                albums={sectionAlbums}
-                albumMap={albumMap}
-                placeholderMap={placeholderMap}
-                slug={slug}
-              />
+              <AlbumGrid albums={sectionAlbums} placeholderMap={placeholderMap} slug={slug} />
             </section>
           );
         })
       ) : (
         /* Flat layout (no sections) */
-        <AlbumGrid
-          albums={albums}
-          albumMap={albumMap}
-          placeholderMap={placeholderMap}
-          slug={slug}
-        />
+        <AlbumGrid albums={albums} placeholderMap={placeholderMap} slug={slug} />
       )}
     </div>
   );


### PR DESCRIPTION
**💡 What:** We updated the `AlbumGrid` component inside `app/[...path]/SubpageGridView.tsx` to include a comprehensive `aria-label` on the parent `<Link>` element, and applied `aria-hidden="true"` to child text elements (like the badge and title overlays). We also set `alt=""` on the thumbnail `<Image>` since the parent link now fully describes the action and context. 

**🎯 Why:** Screen readers often announce card links redundantly, reading the image `alt` text, the visual badge count, and then the overlay title again. This creates a verbose and frustrating experience. By consolidating the text into the parent container's `aria-label`, the interaction point becomes single, clear, and highly contextual ("Vacation, 12 photos").

**📸 Before/After:** Visually identical. The DOM structure remains intact while the accessibility tree is simplified.

**♿ Accessibility:** Greatly reduces auditory clutter for screen reader users by removing repeated context (e.g., hearing "Vacation, 12 photos" three times) and defining the entire card as a single descriptive focus target.

---
*PR created automatically by Jules for task [3578797464630949591](https://jules.google.com/task/3578797464630949591) started by @ralksta*