### PR TITLE
⚡ Bolt: [improvement] Deduplicate concurrent API requests in getAssetInfo

### DIFF
--- a/app/api/auth/route.ts
+++ b/app/api/auth/route.ts
@@ -41,9 +41,12 @@ export async function POST(request: NextRequest) {
     }
 
     if (!isProtected(slug, type)) {
-      return NextResponse.json({
-        error: `${type === 'subpage' ? 'Subpage' : 'Album'} is not password-protected`,
-      }, { status: 400 });
+      return NextResponse.json(
+        {
+          error: `${type === 'subpage' ? 'Subpage' : 'Album'} is not password-protected`,
+        },
+        { status: 400 },
+      );
     }
 
     const setCookie = authenticate(slug, password, type);

--- a/lib/immich.ts
+++ b/lib/immich.ts
@@ -74,6 +74,7 @@ class ImmichClient {
   private hasLoggedAlbums = false;
   private pendingAlbumsPromise: Promise<ImmichAlbum[]> | null = null;
   private pendingAlbumPromises = new Map<string, Promise<ImmichAlbum | null>>();
+  private pendingAssetPromises = new Map<string, Promise<ImmichAsset | null>>();
 
   private get config() {
     return getConfig();
@@ -344,11 +345,24 @@ class ImmichClient {
     const cached = cache.get<ImmichAsset>(cacheKey);
     if (cached) return cached;
 
-    const asset = await this.request<ImmichAsset>(`/assets/${encodeURIComponent(assetId)}`);
-    if (!asset) return null;
+    if (this.pendingAssetPromises.has(assetId)) {
+      return this.pendingAssetPromises.get(assetId)!;
+    }
 
-    cache.set(cacheKey, asset, this.config.cacheTtl);
-    return asset;
+    const promise = (async () => {
+      try {
+        const asset = await this.request<ImmichAsset>(`/assets/${encodeURIComponent(assetId)}`);
+        if (!asset) return null;
+
+        cache.set(cacheKey, asset, this.config.cacheTtl);
+        return asset;
+      } finally {
+        this.pendingAssetPromises.delete(assetId);
+      }
+    })();
+
+    this.pendingAssetPromises.set(assetId, promise);
+    return promise;
   }
 
   /**


### PR DESCRIPTION
💡 What: Implements Promise deduplication for `getAssetInfo` in `ImmichClient`.
🎯 Why: Prevents redundant concurrent upstream network requests when fetching metadata or thumbnail for the same asset multiple times simultaneously.
📊 Impact: Reduces peak API request load during high concurrency scenarios (such as rendering multiple elements referencing the same asset info before the cache is populated).
🔬 Measurement: Verify by executing parallel `getAssetInfo` calls with the same ID, ensuring `fetch` to Immich is only called once. Tests (unit/linting) continue to pass.

---
*PR created automatically by Jules for task [15073195213224084479](https://jules.google.com/task/15073195213224084479) started by @ralksta*