### PR TITLE
🛡️ Sentinel: [HIGH] Fix rate limit cache flooding vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -9,3 +9,7 @@
 **Vulnerability:** Comparing variable-length plaintext passwords using strict equality (`===`) or `crypto.timingSafeEqual` with unequal lengths, which leaks length information and enables timing attacks.
 **Learning:** When comparing variable-length secrets (like plaintext fallback passwords), both values must be hashed to a fixed-length algorithm (like SHA-256) first to ensure identical input lengths for the secure comparison, preventing side-channel leaks.
 **Prevention:** Always hash variable-length secrets to a fixed length before passing them to `crypto.timingSafeEqual`.
+## 2024-05-18 - Rate Limit Store Flooding and Cache Eviction Vulnerability
+**Vulnerability:** The rate limiter implemented an LRU/FIFO map to track API request limits, evicting the oldest tracked IP when maximum capacity was reached. An attacker could flood the store with randomly spoofed IP headers, continuously evicting legitimate users' IP addresses. This allowed the attacker to effectively bypass their own rate limit and subject the upstream server to DoS.
+**Learning:** Evicting entries from a security control store (like a rate limit map) under pressure turns the limit into a revolving door if an attacker controls the keys (e.g., via IP spoofing headers).
+**Prevention:** Rather than evicting old entries when an in-memory rate limit store is full, the correct security posture is to fail closed (or block new keys) until entries naturally expire, preserving tracking on existing keys.

--- a/app/api/auth/route.ts
+++ b/app/api/auth/route.ts
@@ -41,9 +41,12 @@ export async function POST(request: NextRequest) {
     }
 
     if (!isProtected(slug, type)) {
-      return NextResponse.json({
-        error: `${type === 'subpage' ? 'Subpage' : 'Album'} is not password-protected`,
-      }, { status: 400 });
+      return NextResponse.json(
+        {
+          error: `${type === 'subpage' ? 'Subpage' : 'Album'} is not password-protected`,
+        },
+        { status: 400 },
+      );
     }
 
     const setCookie = authenticate(slug, password, type);

--- a/lib/__tests__/rate-limit.test.ts
+++ b/lib/__tests__/rate-limit.test.ts
@@ -58,18 +58,18 @@ describe('checkRateLimit', () => {
     expect(result.resetAt).toBeLessThanOrEqual(before + 61_000);
   });
 
-  it('does not crash when store is at capacity and still accepts new IPs', () => {
+  it('does not crash when store is at capacity and prevents rate limit bypasses', () => {
     // Fill the store beyond MAX_STORE_ENTRIES (10_000 in prod)
-    // by hammering with unique IPs; evictIfFull must silently evict stale entries.
+    // by hammering with unique IPs.
     const uniqueIps = Array.from({ length: 10005 }, (_, i) => `evict-test-ip-${i}-${Date.now()}`);
     for (const ip of uniqueIps) {
       checkRateLimit(ip, 5);
     }
 
-    // A brand-new IP must still be accepted after potential eviction
+    // A brand-new IP must be blocked to prevent spoofing-based cache floods
     const freshIp = `evict-fresh-${Date.now()}`;
     const result = checkRateLimit(freshIp, 5);
-    expect(result.success).toBe(true);
-    expect(result.remaining).toBe(4);
+    expect(result.success).toBe(false);
+    expect(result.remaining).toBe(0);
   });
 });

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -63,12 +63,10 @@ export function checkRateLimit(
   // New window or expired
   if (!entry || now > entry.expiresAt) {
     if (store.size >= MAX_STORE_ENTRIES) {
-      // Store is full. Evict the oldest entry (FIFO) to prevent a global DoS
-      // where an attacker fills the store with spoofed IPs, locking out legitimate users.
-      const oldestKey = store.keys().next().value;
-      if (oldestKey !== undefined) {
-        store.delete(oldestKey);
-      }
+      // Store is full. Prevent adding new entries to mitigate cache flooding
+      // where an attacker spams spoofed IPs to evict legitimate users.
+      // Deny new unrecognized IPs to fail securely during an active flood.
+      return { success: false, remaining: 0, resetAt: now + windowMs };
     }
     const resetAt = now + windowMs;
     store.set(key, { count: 1, expiresAt: resetAt });


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The in-memory rate limiter tracked limits using a Map with a maximum size (10,000 entries). When full, it evicted the oldest entry (FIFO). Because IP extraction relies on `x-forwarded-for` headers, an attacker could spoof thousands of fake IPs to continuously fill the store, forcing the eviction of their actual tracked IP. This effectively disabled rate limiting and exposed the system to DoS attacks.
🎯 Impact: Attackers could bypass API rate limits, potentially leading to upstream DoS or resource exhaustion.
🔧 Fix: Changed the eviction policy to fail closed. When the store is full, the rate limiter now denies new, unrecognized IPs rather than evicting existing tracked entries.
✅ Verification: Validated via unit tests (`pnpm test:unit`) testing the behavior of the rate limiter under capacity load, and recorded learnings in the `.jules/sentinel.md` journal.

---
*PR created automatically by Jules for task [3669725000860950040](https://jules.google.com/task/3669725000860950040) started by @ralksta*