### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix Authenticated Encryption for Asset ID Tokens

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -9,3 +9,7 @@
 **Vulnerability:** Comparing variable-length plaintext passwords using strict equality (`===`) or `crypto.timingSafeEqual` with unequal lengths, which leaks length information and enables timing attacks.
 **Learning:** When comparing variable-length secrets (like plaintext fallback passwords), both values must be hashed to a fixed-length algorithm (like SHA-256) first to ensure identical input lengths for the secure comparison, preventing side-channel leaks.
 **Prevention:** Always hash variable-length secrets to a fixed length before passing them to `crypto.timingSafeEqual`.
+## 2026-04-09 - Upgrade AES-CBC to Authenticated AES-GCM for tokens
+**Vulnerability:** Deterministic AES-256-CBC without a MAC (Message Authentication Code) was used for encoding Asset IDs. This configuration is vulnerable to padding oracle attacks and ciphertext tampering.
+**Learning:** Legacy tokens in production will break if the decryption algorithm length checks are not handled gracefully. Since AES-256-CBC payloads are 64 bytes (base64url decoded) and AES-256-GCM (with 16-byte auth tag) are 68 bytes, we can safely fallback to AES-CBC for exactly 64-byte payloads without needing explicit versioning bytes in the payload.
+**Prevention:** Always use authenticated encryption (like AES-GCM or ChaCha20-Poly1305) when encrypting data, even if it is simply for obfuscation.

--- a/lib/__tests__/tokens.test.ts
+++ b/lib/__tests__/tokens.test.ts
@@ -40,10 +40,25 @@ describe('tokens', () => {
   });
 
   describe('decodeAssetId', () => {
-    it('round-trips a valid UUID', () => {
+    it('round-trips a valid UUID (aes-256-gcm)', () => {
       const token = encodeAssetId(SAMPLE_UUID);
       const decoded = decodeAssetId(token);
       expect(decoded).toBe(SAMPLE_UUID);
+    });
+
+    it('correctly decodes legacy aes-256-cbc tokens', () => {
+      // This token was generated with aes-256-cbc for SAMPLE_UUID with the mock authSecret
+      // 'test-auth-secret-32-chars-long-min'
+      const legacyToken = 'o6nh7ZcyyrKIaBJ74A8c6RIsO99JKNIh96zjIqE8bl9VLmdQBiqVXAbjpZvJ9-d1beN1PCjzeeyhFcewCM8Szw';
+      const decoded = decodeAssetId(legacyToken);
+      expect(decoded).toBe(SAMPLE_UUID);
+    });
+
+    it('returns null for an invalid gcm token (bad tag/ciphertext)', () => {
+      const token = encodeAssetId(SAMPLE_UUID);
+      // Mangle the last character
+      const badToken = token.slice(0, -1) + (token.endsWith('a') ? 'b' : 'a');
+      expect(decodeAssetId(badToken)).toBeNull();
     });
 
     it('returns null for a garbage string', () => {

--- a/lib/tokens.ts
+++ b/lib/tokens.ts
@@ -31,10 +31,11 @@ export function encodeAssetId(assetId: string): string {
   // Deterministic IV from asset ID (same input → same token).
   // SHA-256 slice → first 16 bytes. MD5 was deprecated for cryptographic use.
   const iv = crypto.createHash('sha256').update(assetId).digest().subarray(0, 16);
-  const cipher = crypto.createCipheriv('aes-256-cbc', key, iv);
+  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
   const encrypted = Buffer.concat([cipher.update(assetId, 'utf8'), cipher.final()]);
-  // Compact: base64url(iv + ciphertext)
-  return Buffer.concat([iv, encrypted]).toString('base64url');
+  const authTag = cipher.getAuthTag();
+  // Compact: base64url(iv + authTag + ciphertext)
+  return Buffer.concat([iv, authTag, encrypted]).toString('base64url');
 }
 
 /**
@@ -48,11 +49,22 @@ export function decodeAssetId(token: string): string | null {
     if (data.length < 17) return null; // iv(16) + at least 1 byte
 
     const iv = data.subarray(0, 16);
-    const encrypted = data.subarray(16);
-    const decipher = crypto.createDecipheriv('aes-256-cbc', key, iv);
-    const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]).toString(
-      'utf8',
-    );
+    let decrypted: string;
+
+    // aes-256-gcm: iv(16) + authTag(16) + ciphertext(36) = 68 bytes
+    // aes-256-cbc: iv(16) + ciphertext(48) = 64 bytes
+    // Legacy fallback based on length:
+    if (data.length === 64) {
+      const encrypted = data.subarray(16);
+      const decipher = crypto.createDecipheriv('aes-256-cbc', key, iv);
+      decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]).toString('utf8');
+    } else {
+      const authTag = data.subarray(16, 32);
+      const encrypted = data.subarray(32);
+      const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+      decipher.setAuthTag(authTag);
+      decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]).toString('utf8');
+    }
 
     // Validate it looks like a UUID
     const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Asset IDs were being encoded using AES-256-CBC without a Message Authentication Code (MAC). This is vulnerable to padding oracle attacks and allows attackers to tamper with the ciphertext undetected.
🎯 Impact: An attacker could theoretically modify the ciphertext of token URLs to derive valid encrypted asset IDs, bypassing obfuscation and accessing assets not intended for public sharing.
🔧 Fix: Upgraded token encoding from AES-256-CBC to AES-256-GCM. Implemented a seamless and backward-compatible fallback for decoding based on payload length, ensuring previously generated CBC tokens still function while all new tokens use GCM with a 16-byte authentication tag.
✅ Verification: Covered by comprehensive unit tests running on `lib/tokens.ts` (vitest suite). Legacy tokens resolve correctly, and tampered GCM tokens are securely rejected. Run `pnpm test:unit` to verify.

---
*PR created automatically by Jules for task [8684542726127986690](https://jules.google.com/task/8684542726127986690) started by @ralksta*