### PR TITLE
🎨 Palette: [UX improvement] Consolidate screen reader announcements for album cards

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-25 - SVG Icon Accessibility
 **Learning:** Adding `aria-hidden="true"` to decorative `<svg>` icons within interactive elements (like `<button>` or `<a>`) that already have an `aria-label` is crucial. Otherwise, screen readers may read the raw vector nodes or fall back to confusing announcements in addition to the label. Similarly, when adding text to visual spinners, use `role="alert"` and `aria-live="polite"` on the container while hiding the SVG graphic.
 **Action:** When adding or modifying interactive elements with icon graphics, always ensure the graphic is explicitly hidden from screen readers using `aria-hidden="true"` if a text alternative (`aria-label`) is provided.
+
+## 2024-05-26 - Interactive Card Component Accessibility
+**Learning:** For complex interactive card components (like the `SubpageGridView` album cards), screen readers will announce every child text element and image individually, creating a very noisy and confusing experience for users.
+**Action:** Consolidate the announcement by applying a comprehensive `aria-label` to the parent container/link that summarizes the visual data (e.g., title and count), and use `aria-hidden="true"` or `alt=""` on all child text and decorative images to ensure the screen reader reads the interaction point clearly and succinctly.

--- a/app/[...path]/SubpageGridView.tsx
+++ b/app/[...path]/SubpageGridView.tsx
@@ -27,12 +27,10 @@ interface SubpageGridViewProps {
 
 function AlbumGrid({
   albums,
-  albumMap,
   placeholderMap,
   slug,
 }: {
   albums: SubpageAlbum[];
-  albumMap: Map<string, SubpageAlbum>;
   placeholderMap: Map<string, Placeholder | null>;
   slug: string;
 }) {
@@ -46,23 +44,28 @@ function AlbumGrid({
             href={`/${slug}/${album.slug}`}
             className="subpage-grid__item"
             style={ph?.dominantColor ? { backgroundColor: ph.dominantColor } : undefined}
+            aria-label={`${album.albumName}, ${album.assetCount} ${album.assetCount === 1 ? 'photo' : 'photos'}`}
           >
             {album.albumThumbnailAssetId ? (
               <Image
                 src={imageUrl(album.albumThumbnailAssetId, 'preview')}
-                alt={album.albumName}
+                alt=""
                 fill
                 sizes="(max-width: 600px) 100vw, (max-width: 1000px) 50vw, 33vw"
                 loading="lazy"
                 {...(ph ? { placeholder: 'blur' as const, blurDataURL: ph.blurDataURL } : {})}
               />
             ) : (
-              <div className="skeleton" style={{ width: '100%', height: '100%' }} />
+              <div
+                className="skeleton"
+                style={{ width: '100%', height: '100%' }}
+                aria-hidden="true"
+              />
             )}
-            <span className="subpage-grid__item-badge">
+            <span className="subpage-grid__item-badge" aria-hidden="true">
               {album.assetCount} {album.assetCount === 1 ? 'photo' : 'photos'}
             </span>
-            <div className="subpage-grid__item-overlay">
+            <div className="subpage-grid__item-overlay" aria-hidden="true">
               <span className="subpage-grid__item-title">{album.albumName}</span>
               <span className="subpage-grid__item-count">
                 {album.assetCount} {album.assetCount === 1 ? 'photo' : 'photos'}
@@ -126,23 +129,13 @@ export function SubpageGridView({
                 {sec.description && <p className="subpage-section__desc">{sec.description}</p>}
                 <div className="subpage-section__rule" aria-hidden="true" />
               </header>
-              <AlbumGrid
-                albums={sectionAlbums}
-                albumMap={albumMap}
-                placeholderMap={placeholderMap}
-                slug={slug}
-              />
+              <AlbumGrid albums={sectionAlbums} placeholderMap={placeholderMap} slug={slug} />
             </section>
           );
         })
       ) : (
         /* Flat layout (no sections) */
-        <AlbumGrid
-          albums={albums}
-          albumMap={albumMap}
-          placeholderMap={placeholderMap}
-          slug={slug}
-        />
+        <AlbumGrid albums={albums} placeholderMap={placeholderMap} slug={slug} />
       )}
     </div>
   );


### PR DESCRIPTION
💡 What: Added a comprehensive `aria-label` to the album card `Link` component in `SubpageGridView` and hid its internal child nodes (`alt=""` for images, `aria-hidden="true"` for text). Also removed an unused `albumMap` variable that was creating lint errors.
🎯 Why: Screen readers previously announced every inner text and image element separately when users focused the card, creating a noisy and disjointed interaction point.
📸 Before/After: N/A (visuals unchanged)
♿ Accessibility: Ensures the screen reader reads the card's interaction point (album name + count) clearly and succinctly as a single unit.

---
*PR created automatically by Jules for task [11061546224024948351](https://jules.google.com/task/11061546224024948351) started by @ralksta*