### PR TITLE
⚡ Bolt: Add Promise deduplication to getAssetInfo

### DIFF
--- a/lib/immich.ts
+++ b/lib/immich.ts
@@ -74,6 +74,7 @@ class ImmichClient {
   private hasLoggedAlbums = false;
   private pendingAlbumsPromise: Promise<ImmichAlbum[]> | null = null;
   private pendingAlbumPromises = new Map<string, Promise<ImmichAlbum | null>>();
+  private pendingAssetPromises = new Map<string, Promise<ImmichAsset | null>>();
 
   private get config() {
     return getConfig();
@@ -344,11 +345,24 @@ class ImmichClient {
     const cached = cache.get<ImmichAsset>(cacheKey);
     if (cached) return cached;
 
-    const asset = await this.request<ImmichAsset>(`/assets/${encodeURIComponent(assetId)}`);
-    if (!asset) return null;
+    if (this.pendingAssetPromises.has(assetId)) {
+      return this.pendingAssetPromises.get(assetId)!;
+    }
 
-    cache.set(cacheKey, asset, this.config.cacheTtl);
-    return asset;
+    const promise = (async () => {
+      try {
+        const asset = await this.request<ImmichAsset>(`/assets/${encodeURIComponent(assetId)}`);
+        if (!asset) return null;
+
+        cache.set(cacheKey, asset, this.config.cacheTtl);
+        return asset;
+      } finally {
+        this.pendingAssetPromises.delete(assetId);
+      }
+    })();
+
+    this.pendingAssetPromises.set(assetId, promise);
+    return promise;
   }
 
   /**


### PR DESCRIPTION
💡 What: Implemented promise deduplication for `ImmichClient.getAssetInfo()`.
🎯 Why: When a page needs asset metadata (e.g., ThumbHash data or EXIF) and triggers multiple simultaneous requests for the same asset ID, or if multiple users request the same image concurrently on a cache miss, the application was performing redundant network requests to the upstream API.
📊 Impact: Prevents N concurrent redundant requests to the upstream API for the same asset, saving server bandwidth and execution time.
🔬 Measurement: Verified by unit tests. If multiple `getAssetInfo()` calls run concurrently, only one HTTP request will be fired.

---
*PR created automatically by Jules for task [9697294457417769792](https://jules.google.com/task/9697294457417769792) started by @ralksta*