### PR TITLE
🎨 Palette: [UX improvement] Add focus visible styles for custom buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 ## 2024-05-25 - SVG Icon Accessibility
 **Learning:** Adding `aria-hidden="true"` to decorative `<svg>` icons within interactive elements (like `<button>` or `<a>`) that already have an `aria-label` is crucial. Otherwise, screen readers may read the raw vector nodes or fall back to confusing announcements in addition to the label. Similarly, when adding text to visual spinners, use `role="alert"` and `aria-live="polite"` on the container while hiding the SVG graphic.
 **Action:** When adding or modifying interactive elements with icon graphics, always ensure the graphic is explicitly hidden from screen readers using `aria-hidden="true"` if a text alternative (`aria-label`) is provided.
+## 2025-04-10 - Add focus visible styling for ARIA buttons
+**Learning:** Custom interactive elements semantically marked as buttons using ARIA roles (e.g., `<div role="button" tabIndex={0}>`) do not automatically inherit the native CSS `focus-visible` styles applied to standard `<button>` elements, leaving keyboard users without visual focus indicators.
+**Action:** Always verify that global focus styles target semantic roles (e.g., `[role="button"]:focus-visible`) in addition to native tags to ensure consistent accessibility across custom components.

--- a/app/api/auth/route.ts
+++ b/app/api/auth/route.ts
@@ -41,9 +41,12 @@ export async function POST(request: NextRequest) {
     }
 
     if (!isProtected(slug, type)) {
-      return NextResponse.json({
-        error: `${type === 'subpage' ? 'Subpage' : 'Album'} is not password-protected`,
-      }, { status: 400 });
+      return NextResponse.json(
+        {
+          error: `${type === 'subpage' ? 'Subpage' : 'Album'} is not password-protected`,
+        },
+        { status: 400 },
+      );
     }
 
     const setCookie = authenticate(slug, password, type);

--- a/app/tokens.css
+++ b/app/tokens.css
@@ -248,7 +248,8 @@ img {
 
 a:focus-visible,
 button:focus-visible,
-input:focus-visible {
+input:focus-visible,
+[role='button']:focus-visible {
   outline: 2px solid var(--text-primary);
   outline-offset: 2px;
 }

--- a/docs/gallery-config.md
+++ b/docs/gallery-config.md
@@ -64,8 +64,8 @@ subpages:
     albums:
       - 55555555-5555-5555-5555-555555555555
       - 66666666-6666-6666-6666-666666666666:
-          title: "Private Highlights"
-          password: "album-secret-123" # Optional: album-level protection
+          title: 'Private Highlights'
+          password: 'album-secret-123' # Optional: album-level protection
 ```
 
 Alternatively, you can use the object notation (recommended):
@@ -99,7 +99,7 @@ albums:
   - 'album-uuid': My Title # → displays "My Title" instead
   - 'album-uuid':
       title: My Private Title
-      password: "secure-password" # → adds a password gate to this specific album
+      password: 'secure-password' # → adds a password gate to this specific album
 ```
 
 **Full example:**


### PR DESCRIPTION
💡 What: Added `[role="button"]:focus-visible` to global focus styles in `app/tokens.css`.\n🎯 Why: Custom interactive elements serving as buttons (like photo grid items) were not showing visual focus rings during keyboard navigation because they used `role="button"` instead of native `<button>` tags.\n📸 Before/After: N/A\n♿ Accessibility: Restores essential visual focus indication for keyboard and screen reader users navigating interactive custom components.

---
*PR created automatically by Jules for task [3564375997387765261](https://jules.google.com/task/3564375997387765261) started by @ralksta*