### PR TITLE
⚡ Bolt: [performance improvement] Deduplicate getAssetInfo requests

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,8 @@
 
 **Learning:** When using `Promise.all` to fetch dependent data in parallel (e.g., getting multiple subpages and standalone albums that internally call a shared `getAlbums` function), the internal cache might not be populated in time. This leads to redundant concurrent network requests to the upstream server.
 **Action:** Implement Promise deduplication (request coalescing) by caching the pending Promise itself (e.g., in a `this.pendingPromise` class field) rather than just the final result. Return the pending Promise to subsequent callers until it resolves, ensuring only one network request is made.
+
+## 2024-05-29 - [Deduplicate parameter-based API requests via Promise Map caching]
+
+**Learning:** When adding Promise deduplication for API methods that take parameters (like `getAssetInfo(assetId)`), using a single class-level Promise field (like `pendingAlbumsPromise`) is insufficient and causes race conditions across different IDs.
+**Action:** Use a `Map<string, Promise<T | null>>` (e.g., `this.pendingAssetPromises`) to cache promises by their unique argument ID. Ensure the promise is removed from the Map in a `finally` block to prevent memory leaks and stuck states.

--- a/lib/immich.ts
+++ b/lib/immich.ts
@@ -74,6 +74,7 @@ class ImmichClient {
   private hasLoggedAlbums = false;
   private pendingAlbumsPromise: Promise<ImmichAlbum[]> | null = null;
   private pendingAlbumPromises = new Map<string, Promise<ImmichAlbum | null>>();
+  private pendingAssetPromises = new Map<string, Promise<ImmichAsset | null>>();
 
   private get config() {
     return getConfig();
@@ -344,11 +345,26 @@ class ImmichClient {
     const cached = cache.get<ImmichAsset>(cacheKey);
     if (cached) return cached;
 
-    const asset = await this.request<ImmichAsset>(`/assets/${encodeURIComponent(assetId)}`);
-    if (!asset) return null;
+    // Promise deduplication: prevent concurrent requests for the same asset
+    // by returning the pending promise to subsequent callers.
+    if (this.pendingAssetPromises.has(assetId)) {
+      return this.pendingAssetPromises.get(assetId)!;
+    }
 
-    cache.set(cacheKey, asset, this.config.cacheTtl);
-    return asset;
+    const promise = (async () => {
+      try {
+        const asset = await this.request<ImmichAsset>(`/assets/${encodeURIComponent(assetId)}`);
+        if (!asset) return null;
+
+        cache.set(cacheKey, asset, this.config.cacheTtl);
+        return asset;
+      } finally {
+        this.pendingAssetPromises.delete(assetId);
+      }
+    })();
+
+    this.pendingAssetPromises.set(assetId, promise);
+    return promise;
   }
 
   /**


### PR DESCRIPTION
💡 What: Added Promise deduplication to the `getAssetInfo` method in the `ImmichClient`.
🎯 Why: When an album loads, multiple components may simultaneously request information for the same asset (e.g., thumbnail). Without deduplication, these simultaneous requests would all bypass the empty cache and hit the upstream Immich server concurrently.
📊 Impact: Eliminates redundant concurrent network requests to the Immich server for identical assets, reducing server load and improving response times when rendering galleries.
🔬 Measurement: Verify by checking network request logs or mocking `fetch` to ensure only one request is fired when `getAssetInfo` is called concurrently with the same ID.

---
*PR created automatically by Jules for task [15496890057301787353](https://jules.google.com/task/15496890057301787353) started by @ralksta*