### PR TITLE
🛡️ Sentinel: [improvement] Improve rate-limit headers in auth API

### DIFF
--- a/app/api/auth/route.ts
+++ b/app/api/auth/route.ts
@@ -13,10 +13,20 @@ const AUTH_RPM = 10;
 export async function POST(request: NextRequest) {
   // ── Rate limiting (brute-force protection) ──────────
   const ip = getClientIp(request);
-  const { success } = checkRateLimit(`auth:${ip}`, AUTH_RPM);
+  const { success, remaining, resetAt } = checkRateLimit(`auth:${ip}`, AUTH_RPM);
 
   if (!success) {
-    return NextResponse.json({ error: 'Too many attempts, try again later' }, { status: 429 });
+    return NextResponse.json(
+      { error: 'Too many attempts, try again later' },
+      {
+        status: 429,
+        headers: {
+          'Retry-After': String(Math.ceil((resetAt - Date.now()) / 1000)),
+          'X-RateLimit-Limit': String(AUTH_RPM),
+          'X-RateLimit-Remaining': String(remaining),
+        },
+      },
+    );
   }
 
   try {
@@ -41,9 +51,12 @@ export async function POST(request: NextRequest) {
     }
 
     if (!isProtected(slug, type)) {
-      return NextResponse.json({
-        error: `${type === 'subpage' ? 'Subpage' : 'Album'} is not password-protected`,
-      }, { status: 400 });
+      return NextResponse.json(
+        {
+          error: `${type === 'subpage' ? 'Subpage' : 'Album'} is not password-protected`,
+        },
+        { status: 400 },
+      );
     }
 
     const setCookie = authenticate(slug, password, type);

--- a/docs/gallery-config.md
+++ b/docs/gallery-config.md
@@ -64,8 +64,8 @@ subpages:
     albums:
       - 55555555-5555-5555-5555-555555555555
       - 66666666-6666-6666-6666-666666666666:
-          title: "Private Highlights"
-          password: "album-secret-123" # Optional: album-level protection
+          title: 'Private Highlights'
+          password: 'album-secret-123' # Optional: album-level protection
 ```
 
 Alternatively, you can use the object notation (recommended):
@@ -99,7 +99,7 @@ albums:
   - 'album-uuid': My Title # → displays "My Title" instead
   - 'album-uuid':
       title: My Private Title
-      password: "secure-password" # → adds a password gate to this specific album
+      password: 'secure-password' # → adds a password gate to this specific album
 ```
 
 **Full example:**


### PR DESCRIPTION
🚨 **Severity:** LOW
💡 **Vulnerability:** The authentication rate limiter returned a generic 429 response without standard headers to communicate the limit parameters.
🎯 **Impact:** Well-behaved clients or intermediate proxies (WAFs, API gateways) could not automatically understand the rate limit or know how long to back off, potentially leading to unnecessary retries or proxy misbehavior.
🔧 **Fix:** Destructured the `remaining` and `resetAt` values from the `checkRateLimit` call and appended `Retry-After`, `X-RateLimit-Limit`, and `X-RateLimit-Remaining` to the 429 response.
✅ **Verification:** Verified that tests pass via `pnpm test:unit` and linted the modified route.

---
*PR created automatically by Jules for task [14347956912640898003](https://jules.google.com/task/14347956912640898003) started by @ralksta*