### PR TITLE
🎨 Palette: [UX improvement] Add focus styles for custom button elements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-25 - SVG Icon Accessibility
 **Learning:** Adding `aria-hidden="true"` to decorative `<svg>` icons within interactive elements (like `<button>` or `<a>`) that already have an `aria-label` is crucial. Otherwise, screen readers may read the raw vector nodes or fall back to confusing announcements in addition to the label. Similarly, when adding text to visual spinners, use `role="alert"` and `aria-live="polite"` on the container while hiding the SVG graphic.
 **Action:** When adding or modifying interactive elements with icon graphics, always ensure the graphic is explicitly hidden from screen readers using `aria-hidden="true"` if a text alternative (`aria-label`) is provided.
+
+## 2025-02-12 - Focus Styles on role="button"
+**Learning:** Custom interactive elements semantically marked as buttons (e.g., `<div role="button" tabIndex={0}>`) do not automatically inherit native `<button>` focus-visible styles. This means keyboard users navigating to these elements won't see a focus indicator unless explicitly styled.
+**Action:** Always add `[role="button"]:focus-visible` alongside native `button:focus-visible` styles to ensure custom interactive elements receive the same clear visual focus feedback.

--- a/app/api/auth/route.ts
+++ b/app/api/auth/route.ts
@@ -41,9 +41,12 @@ export async function POST(request: NextRequest) {
     }
 
     if (!isProtected(slug, type)) {
-      return NextResponse.json({
-        error: `${type === 'subpage' ? 'Subpage' : 'Album'} is not password-protected`,
-      }, { status: 400 });
+      return NextResponse.json(
+        {
+          error: `${type === 'subpage' ? 'Subpage' : 'Album'} is not password-protected`,
+        },
+        { status: 400 },
+      );
     }
 
     const setCookie = authenticate(slug, password, type);

--- a/app/tokens.css
+++ b/app/tokens.css
@@ -248,7 +248,8 @@ img {
 
 a:focus-visible,
 button:focus-visible,
-input:focus-visible {
+input:focus-visible,
+[role="button"]:focus-visible {
   outline: 2px solid var(--text-primary);
   outline-offset: 2px;
 }


### PR DESCRIPTION
**💡 What**: Added `[role="button"]:focus-visible` to the global CSS rule that handles focus outlines. Also formatted `api/auth/route.ts` via standard tooling.
**🎯 Why**: The photo grid masonry layout uses `<div>` tags with `role="button"` and `tabIndex={0}` to allow users to click/navigate to photos. However, standard focus styles were previously applied only to `button`, `a`, and `input` tags. This meant keyboard users had no visual indicator when focusing on photo thumbnails, creating an accessibility barrier. 
**📸 Before/After**: 
Before: Navigating with Tab over `role="button"` elements like the photo grid items provided no visual focus ring. 
After: Navigating with Tab now triggers the same 2px solid primary text colored outline offset by 2px that native interactive elements receive.
**♿ Accessibility**: This provides crucial visual feedback for keyboard users, making custom interactive elements compliant with focus visibility guidelines. Also added a critical learning entry to the `.Jules/palette.md` journal.

---
*PR created automatically by Jules for task [2866735319059585560](https://jules.google.com/task/2866735319059585560) started by @ralksta*