### PR TITLE
🎨 Palette: [UX improvement] Auto-focus Close button in Lightbox

### DIFF
--- a/app/api/auth/route.ts
+++ b/app/api/auth/route.ts
@@ -41,9 +41,12 @@ export async function POST(request: NextRequest) {
     }
 
     if (!isProtected(slug, type)) {
-      return NextResponse.json({
-        error: `${type === 'subpage' ? 'Subpage' : 'Album'} is not password-protected`,
-      }, { status: 400 });
+      return NextResponse.json(
+        {
+          error: `${type === 'subpage' ? 'Subpage' : 'Album'} is not password-protected`,
+        },
+        { status: 400 },
+      );
     }
 
     const setCookie = authenticate(slug, password, type);

--- a/components/Lightbox.tsx
+++ b/components/Lightbox.tsx
@@ -31,6 +31,7 @@ export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev }: Ligh
   const { exifData, exifLoading, fetchExif, clearExif } = useExif();
   const [imageLoaded, setImageLoaded] = useState(false);
   const overlayRef = useRef<HTMLDivElement>(null);
+  const closeBtnRef = useRef<HTMLButtonElement>(null);
 
   const current = assets[currentIndex];
   const [mounted, setMounted] = useState(false);
@@ -39,6 +40,13 @@ export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev }: Ligh
   useEffect(() => {
     setMounted(true);
   }, []);
+
+  // Auto-focus the close button when the modal mounts
+  useEffect(() => {
+    if (mounted) {
+      closeBtnRef.current?.focus();
+    }
+  }, [mounted]);
 
   // Reset EXIF data when switching images; refetch if panel is open
   useEffect(() => {
@@ -109,7 +117,13 @@ export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev }: Ligh
       aria-label="Image viewer"
     >
       {/* Close button */}
-      <button className={styles.close} onClick={onClose} aria-label="Close" title="Close (Esc)">
+      <button
+        ref={closeBtnRef}
+        className={styles.close}
+        onClick={onClose}
+        aria-label="Close"
+        title="Close (Esc)"
+      >
         <svg
           aria-hidden="true"
           viewBox="0 0 24 24"

--- a/docs/gallery-config.md
+++ b/docs/gallery-config.md
@@ -64,8 +64,8 @@ subpages:
     albums:
       - 55555555-5555-5555-5555-555555555555
       - 66666666-6666-6666-6666-666666666666:
-          title: "Private Highlights"
-          password: "album-secret-123" # Optional: album-level protection
+          title: 'Private Highlights'
+          password: 'album-secret-123' # Optional: album-level protection
 ```
 
 Alternatively, you can use the object notation (recommended):
@@ -99,7 +99,7 @@ albums:
   - 'album-uuid': My Title # → displays "My Title" instead
   - 'album-uuid':
       title: My Private Title
-      password: "secure-password" # → adds a password gate to this specific album
+      password: 'secure-password' # → adds a password gate to this specific album
 ```
 
 **Full example:**


### PR DESCRIPTION
### 💡 What
Added a `ref` and `useEffect` hook to automatically focus the Close button when the `Lightbox` component mounts.

### 🎯 Why
When the Lightbox opens as a modal overlay, it previously did not actively manage keyboard focus. This meant focus remained trapped on the underlying page content beneath the modal, confusing keyboard and screen reader users.

### 📸 Before/After
* **Before:** Opening a photo in the Lightbox left focus on the photo grid behind the modal overlay.
* **After:** Opening a photo immediately places focus onto the Lightbox's "Close" button.

### ♿ Accessibility
Improves keyboard navigation and screen reader orientation by shifting focus inside the new dialog context immediately, fulfilling WAI-ARIA guidelines for `role="dialog"` components.

---
*PR created automatically by Jules for task [5837152664547255018](https://jules.google.com/task/5837152664547255018) started by @ralksta*