### PR TITLE
⚡ Bolt: [performance improvement] Add request coalescing to getAssetInfo

### DIFF
--- a/app/api/auth/route.ts
+++ b/app/api/auth/route.ts
@@ -41,9 +41,12 @@ export async function POST(request: NextRequest) {
     }
 
     if (!isProtected(slug, type)) {
-      return NextResponse.json({
-        error: `${type === 'subpage' ? 'Subpage' : 'Album'} is not password-protected`,
-      }, { status: 400 });
+      return NextResponse.json(
+        {
+          error: `${type === 'subpage' ? 'Subpage' : 'Album'} is not password-protected`,
+        },
+        { status: 400 },
+      );
     }
 
     const setCookie = authenticate(slug, password, type);

--- a/docs/gallery-config.md
+++ b/docs/gallery-config.md
@@ -64,8 +64,8 @@ subpages:
     albums:
       - 55555555-5555-5555-5555-555555555555
       - 66666666-6666-6666-6666-666666666666:
-          title: "Private Highlights"
-          password: "album-secret-123" # Optional: album-level protection
+          title: 'Private Highlights'
+          password: 'album-secret-123' # Optional: album-level protection
 ```
 
 Alternatively, you can use the object notation (recommended):
@@ -99,7 +99,7 @@ albums:
   - 'album-uuid': My Title # → displays "My Title" instead
   - 'album-uuid':
       title: My Private Title
-      password: "secure-password" # → adds a password gate to this specific album
+      password: 'secure-password' # → adds a password gate to this specific album
 ```
 
 **Full example:**

--- a/lib/immich.ts
+++ b/lib/immich.ts
@@ -74,6 +74,7 @@ class ImmichClient {
   private hasLoggedAlbums = false;
   private pendingAlbumsPromise: Promise<ImmichAlbum[]> | null = null;
   private pendingAlbumPromises = new Map<string, Promise<ImmichAlbum | null>>();
+  private pendingAssetPromises = new Map<string, Promise<ImmichAsset | null>>();
 
   private get config() {
     return getConfig();
@@ -344,11 +345,24 @@ class ImmichClient {
     const cached = cache.get<ImmichAsset>(cacheKey);
     if (cached) return cached;
 
-    const asset = await this.request<ImmichAsset>(`/assets/${encodeURIComponent(assetId)}`);
-    if (!asset) return null;
+    if (this.pendingAssetPromises.has(assetId)) {
+      return this.pendingAssetPromises.get(assetId)!;
+    }
 
-    cache.set(cacheKey, asset, this.config.cacheTtl);
-    return asset;
+    const promise = (async () => {
+      try {
+        const asset = await this.request<ImmichAsset>(`/assets/${encodeURIComponent(assetId)}`);
+        if (!asset) return null;
+
+        cache.set(cacheKey, asset, this.config.cacheTtl);
+        return asset;
+      } finally {
+        this.pendingAssetPromises.delete(assetId);
+      }
+    })();
+
+    this.pendingAssetPromises.set(assetId, promise);
+    return promise;
   }
 
   /**


### PR DESCRIPTION
💡 What:
Added a `pendingAssetPromises` Map to `ImmichClient` in `lib/immich.ts`. `getAssetInfo` now checks this map before making a network request. If a request for the given asset ID is already in flight, it returns the pending promise.

🎯 Why:
To prevent multiple components or simultaneous user actions from triggering concurrent, identical API requests to the Immich server when an asset's information is not yet in the in-memory cache. 

📊 Impact:
Reduces redundant outbound network calls to the upstream Immich server under high-concurrency situations (e.g. initial grid load where multiple instances of the same asset ID might theoretically be requested, or fast toggling). It safely ensures requests are deduped without risking stuck promises due to the `finally` block cleanup.

🔬 Measurement:
Run the application and verify no redundant `/assets/:id` network requests are dispatched for the exact same asset simultaneously. Unit tests pass cleanly verifying there are no regressions.

---
*PR created automatically by Jules for task [18091590128085434450](https://jules.google.com/task/18091590128085434450) started by @ralksta*