### PR TITLE
🎨 Palette: Add focus visible styles for role=button keyboard navigation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-25 - SVG Icon Accessibility
 **Learning:** Adding `aria-hidden="true"` to decorative `<svg>` icons within interactive elements (like `<button>` or `<a>`) that already have an `aria-label` is crucial. Otherwise, screen readers may read the raw vector nodes or fall back to confusing announcements in addition to the label. Similarly, when adding text to visual spinners, use `role="alert"` and `aria-live="polite"` on the container while hiding the SVG graphic.
 **Action:** When adding or modifying interactive elements with icon graphics, always ensure the graphic is explicitly hidden from screen readers using `aria-hidden="true"` if a text alternative (`aria-label`) is provided.
+
+## 2026-04-13 - Focus-Visible for Custom Elements
+**Learning:** Custom interactive elements semantically marked as buttons (e.g., `<div role="button" tabIndex={0}>`) do not automatically inherit native `<button>` focus-visible styles. This breaks keyboard accessibility visually because users cannot tell which item is focused.
+**Action:** When creating custom elements with `role="button"` or other interactive roles, explicitly add them to the focus-visible style definitions (e.g., `[role="button"]:focus-visible`) alongside native elements to ensure clear visual feedback.

--- a/app/api/auth/route.ts
+++ b/app/api/auth/route.ts
@@ -41,9 +41,12 @@ export async function POST(request: NextRequest) {
     }
 
     if (!isProtected(slug, type)) {
-      return NextResponse.json({
-        error: `${type === 'subpage' ? 'Subpage' : 'Album'} is not password-protected`,
-      }, { status: 400 });
+      return NextResponse.json(
+        {
+          error: `${type === 'subpage' ? 'Subpage' : 'Album'} is not password-protected`,
+        },
+        { status: 400 },
+      );
     }
 
     const setCookie = authenticate(slug, password, type);

--- a/app/tokens.css
+++ b/app/tokens.css
@@ -248,6 +248,7 @@ img {
 
 a:focus-visible,
 button:focus-visible,
+[role='button']:focus-visible,
 input:focus-visible {
   outline: 2px solid var(--text-primary);
   outline-offset: 2px;


### PR DESCRIPTION
### 💡 What
Added `[role="button"]:focus-visible` to the global focus styles alongside native `button:focus-visible`.

### 🎯 Why
Custom interactive elements semantically marked as buttons (like the photo grid items using `role="button"`) do not automatically inherit native `<button>` focus-visible styles in modern browsers. This breaks keyboard navigation because users cannot tell which item is focused when tabbing through the gallery. Adding the ARIA role to the CSS selector fixes this globally.

### 📸 Before/After
Before: Tabbing onto a photo grid item showed no visual change.
After: Tabbing onto a photo grid item displays the same 2px outline as native buttons.

### ♿ Accessibility
This directly fixes a WCAG 2.4.7 Focus Visible violation for custom interactive elements across the application, making keyboard navigation predictable and usable.

---
*PR created automatically by Jules for task [15066109617147400747](https://jules.google.com/task/15066109617147400747) started by @ralksta*