### PR TITLE
🛡️ Sentinel: [HIGH] Upgrade token encryption to AES-GCM

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -9,3 +9,8 @@
 **Vulnerability:** Comparing variable-length plaintext passwords using strict equality (`===`) or `crypto.timingSafeEqual` with unequal lengths, which leaks length information and enables timing attacks.
 **Learning:** When comparing variable-length secrets (like plaintext fallback passwords), both values must be hashed to a fixed-length algorithm (like SHA-256) first to ensure identical input lengths for the secure comparison, preventing side-channel leaks.
 **Prevention:** Always hash variable-length secrets to a fixed length before passing them to `crypto.timingSafeEqual`.
+
+## 2024-05-20 - Upgrade Token Encryption to AES-256-GCM
+**Vulnerability:** The `lib/tokens.ts` module was using `aes-256-cbc` to encrypt tokens deterministically. Using AES-CBC without an authentication tag (like HMAC) is vulnerable to chosen-ciphertext and padding oracle attacks, which could allow an attacker to forge or decode tokens without the secret key.
+**Learning:** For deterministic tokens meant to be exposed publicly in URLs, authenticated encryption with associated data (AEAD) algorithms like AES-GCM are required to ensure data integrity and prevent tampering.
+**Prevention:** Always use authenticated encryption (e.g., AES-GCM or AES-CBC with HMAC) when encrypting data, especially data exposed to the client. When migrating encryption schemas, use version prefixes (e.g., `v2:`) to safely differentiate new formats and preserve backward compatibility for old tokens.

--- a/lib/__tests__/tokens.test.ts
+++ b/lib/__tests__/tokens.test.ts
@@ -23,7 +23,7 @@ describe('tokens', () => {
       expect(token).toBeTruthy();
       expect(typeof token).toBe('string');
       // base64url characters only
-      expect(token).toMatch(/^[A-Za-z0-9_-]+$/);
+      expect(token).toMatch(/^v2:[A-Za-z0-9_-]+$/);
     });
 
     it('is deterministic — same input yields same token', () => {
@@ -59,5 +59,20 @@ describe('tokens', () => {
       const short = Buffer.from('shortdata').toString('base64url');
       expect(decodeAssetId(short)).toBeNull();
     });
+  });
+});
+
+describe('decodeAssetId legacy v1 support', () => {
+  it('decodes legacy v1 AES-256-CBC token', () => {
+    // Create a legacy v1 token manually since encodeAssetId now creates v2 tokens
+    const crypto = require('crypto');
+    const key = crypto.createHash('sha256').update('test-auth-secret-32-chars-long-min').digest();
+    const iv = crypto.createHash('sha256').update(SAMPLE_UUID).digest().subarray(0, 16);
+    const cipher = crypto.createCipheriv('aes-256-cbc', key, iv);
+    const encrypted = Buffer.concat([cipher.update(SAMPLE_UUID, 'utf8'), cipher.final()]);
+    const legacyToken = Buffer.concat([iv, encrypted]).toString('base64url');
+
+    const decoded = decodeAssetId(legacyToken);
+    expect(decoded).toBe(SAMPLE_UUID);
   });
 });

--- a/lib/tokens.ts
+++ b/lib/tokens.ts
@@ -31,10 +31,11 @@ export function encodeAssetId(assetId: string): string {
   // Deterministic IV from asset ID (same input → same token).
   // SHA-256 slice → first 16 bytes. MD5 was deprecated for cryptographic use.
   const iv = crypto.createHash('sha256').update(assetId).digest().subarray(0, 16);
-  const cipher = crypto.createCipheriv('aes-256-cbc', key, iv);
+  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
   const encrypted = Buffer.concat([cipher.update(assetId, 'utf8'), cipher.final()]);
-  // Compact: base64url(iv + ciphertext)
-  return Buffer.concat([iv, encrypted]).toString('base64url');
+  const authTag = cipher.getAuthTag();
+  // Compact: base64url(iv + authTag + ciphertext) prepended with version identifier
+  return 'v2:' + Buffer.concat([iv, authTag, encrypted]).toString('base64url');
 }
 
 /**
@@ -44,6 +45,24 @@ export function encodeAssetId(assetId: string): string {
 export function decodeAssetId(token: string): string | null {
   try {
     const key = getKey();
+
+    if (token.startsWith('v2:')) {
+      const data = Buffer.from(token.slice(3), 'base64url');
+      if (data.length < 33) return null; // iv(16) + authTag(16) + at least 1 byte
+
+      const iv = data.subarray(0, 16);
+      const authTag = data.subarray(16, 32);
+      const encrypted = data.subarray(32);
+
+      const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+      decipher.setAuthTag(authTag);
+      const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]).toString('utf8');
+
+      const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+      return uuidRegex.test(decrypted) ? decrypted : null;
+    }
+
+    // Fallback to v1 AES-256-CBC
     const data = Buffer.from(token, 'base64url');
     if (data.length < 17) return null; // iv(16) + at least 1 byte
 


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** `lib/tokens.ts` used `aes-256-cbc` without an authentication tag to encrypt asset IDs. This leaves the tokens vulnerable to padding oracle and chosen-ciphertext attacks.
🎯 **Impact:** An attacker could potentially forge or manipulate URL tokens without the secret key.
🛠️ **Fix:** Upgraded the token encryption to use `aes-256-gcm` (Authenticated Encryption). Pre-pended the new tokens with a `v2:` prefix to clearly denote the version, and preserved backward compatibility for existing `v1` (AES-CBC) tokens in decoding.
✅ **Verification:** Verified by updating tests in `lib/__tests__/tokens.test.ts` for the `v2:` format and legacy `v1` support, and confirming all Vitest unit tests pass.

---
*PR created automatically by Jules for task [6238715636945611048](https://jules.google.com/task/6238715636945611048) started by @ralksta*