### PR TITLE
🎨 Palette: [UX improvement] Add focus-visible style for custom buttons

### DIFF
--- a/app/api/auth/route.ts
+++ b/app/api/auth/route.ts
@@ -41,9 +41,12 @@ export async function POST(request: NextRequest) {
     }
 
     if (!isProtected(slug, type)) {
-      return NextResponse.json({
-        error: `${type === 'subpage' ? 'Subpage' : 'Album'} is not password-protected`,
-      }, { status: 400 });
+      return NextResponse.json(
+        {
+          error: `${type === 'subpage' ? 'Subpage' : 'Album'} is not password-protected`,
+        },
+        { status: 400 },
+      );
     }
 
     const setCookie = authenticate(slug, password, type);

--- a/app/tokens.css
+++ b/app/tokens.css
@@ -248,7 +248,8 @@ img {
 
 a:focus-visible,
 button:focus-visible,
-input:focus-visible {
+input:focus-visible,
+[role='button']:focus-visible {
   outline: 2px solid var(--text-primary);
   outline-offset: 2px;
 }


### PR DESCRIPTION
💡 What: Added explicit focus-visible styles for custom role="button" elements to the tokens.css rules.
🎯 Why: Elements with role="button" and tabIndex={0} (like the masonry image grid items) weren't inheriting standard button focus visual states, leaving keyboard users without visual feedback while navigating.
📸 Before/After: See associated screenshot test that captures proper focus rings on grid images.
♿ Accessibility: Ensures WCAG standard compliant visual focus indicators exist for keyboard-navigable elements behaving like buttons.

---
*PR created automatically by Jules for task [7330612694519535527](https://jules.google.com/task/7330612694519535527) started by @ralksta*