### PR TITLE
⚡ Bolt: [performance improvement] Request coalescing for getAssetInfo

### DIFF
--- a/lib/immich.ts
+++ b/lib/immich.ts
@@ -74,6 +74,7 @@ class ImmichClient {
   private hasLoggedAlbums = false;
   private pendingAlbumsPromise: Promise<ImmichAlbum[]> | null = null;
   private pendingAlbumPromises = new Map<string, Promise<ImmichAlbum | null>>();
+  private pendingAssetPromises = new Map<string, Promise<ImmichAsset | null>>();
 
   private get config() {
     return getConfig();
@@ -344,11 +345,24 @@ class ImmichClient {
     const cached = cache.get<ImmichAsset>(cacheKey);
     if (cached) return cached;
 
-    const asset = await this.request<ImmichAsset>(`/assets/${encodeURIComponent(assetId)}`);
-    if (!asset) return null;
+    if (this.pendingAssetPromises.has(assetId)) {
+      return this.pendingAssetPromises.get(assetId)!;
+    }
 
-    cache.set(cacheKey, asset, this.config.cacheTtl);
-    return asset;
+    const promise = (async () => {
+      try {
+        const asset = await this.request<ImmichAsset>(`/assets/${encodeURIComponent(assetId)}`);
+        if (!asset) return null;
+
+        cache.set(cacheKey, asset, this.config.cacheTtl);
+        return asset;
+      } finally {
+        this.pendingAssetPromises.delete(assetId);
+      }
+    })();
+
+    this.pendingAssetPromises.set(assetId, promise);
+    return promise;
   }
 
   /**


### PR DESCRIPTION
💡 What: Implemented request coalescing (Promise deduplication) for `getAssetInfo` in the `ImmichClient`.
🎯 Why: To prevent redundant concurrent network requests to the backend Immich server when identical assets (e.g., album cover thumbnails) are requested simultaneously before the first request finishes and populates the cache.
📊 Impact: Reduces peak load and redundant network I/O. For subpages showing multiple identical albums (or multiple sections displaying the same album cover), only one upstream request per unique asset ID will be dispatched, regardless of how many components mount concurrently.
🔬 Measurement: Verify by checking network logs in the sandbox or unit tests to ensure `fetch` to `/assets/...` is only called once per ID under concurrent load. Tests (`pnpm test:unit`) continue to pass.

---
*PR created automatically by Jules for task [1774866602546226440](https://jules.google.com/task/1774866602546226440) started by @ralksta*