### PR TITLE
⚡ Bolt: Remove unnecessary Uint8Array memory allocation for decoding base64

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,8 @@
 
 **Learning:** When using `Promise.all` to fetch dependent data in parallel (e.g., getting multiple subpages and standalone albums that internally call a shared `getAlbums` function), the internal cache might not be populated in time. This leads to redundant concurrent network requests to the upstream server.
 **Action:** Implement Promise deduplication (request coalescing) by caching the pending Promise itself (e.g., in a `this.pendingPromise` class field) rather than just the final result. Return the pending Promise to subsequent callers until it resolves, ensuring only one network request is made.
+
+## 2025-02-12 - [Remove unnecessary memory allocation for Buffer]
+
+**Learning:** When using `Buffer.from` to decode base64 strings in a Node.js context, passing the resulting `Buffer` object to `new Uint8Array(buffer)` incurs a redundant memory allocation and an O(n) array element copying operation. Because Node's `Buffer` inherits from `Uint8Array`, any API that expects a `Uint8Array` can simply accept a `Buffer` instance directly.
+**Action:** Always return the bare `Buffer` directly rather than unnecessarily wrapping it.

--- a/lib/thumbhash.ts
+++ b/lib/thumbhash.ts
@@ -27,7 +27,7 @@ function setCache<K, V>(map: Map<K, V>, key: K, value: V) {
  */
 function decodeBase64(base64: string): Uint8Array {
   if (typeof Buffer !== 'undefined') {
-    return new Uint8Array(Buffer.from(base64, 'base64'));
+    return Buffer.from(base64, 'base64');
   }
   return Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
 }


### PR DESCRIPTION
💡 **What:** Modified `decodeBase64` in `lib/thumbhash.ts` to return the `Buffer` instance directly instead of wrapping it in a new `Uint8Array`.
🎯 **Why:** In Node.js environments, `Buffer` is already a subclass of `Uint8Array`. Passing a buffer into `new Uint8Array(buffer)` forces the V8 engine to allocate a second underlying `ArrayBuffer` and perform an O(N) copy of the bytes.
📊 **Impact:** Reduces CPU cycle consumption and garbage collection pressure when decoding image placeholder hashes.
🔬 **Measurement:** Code logic confirmed safe (as Buffer behaves precisely as Uint8Array). Verified the optimization by successfully running `pnpm test:unit` where all ThumbHash parsing tests passed seamlessly.

---
*PR created automatically by Jules for task [2529881709187901697](https://jules.google.com/task/2529881709187901697) started by @ralksta*