### PR TITLE
🎨 Palette: Add keyboard focus-visible styles for custom role="button" elements

### DIFF
--- a/app/tokens.css
+++ b/app/tokens.css
@@ -248,6 +248,7 @@ img {
 
 a:focus-visible,
 button:focus-visible,
+[role='button']:focus-visible,
 input:focus-visible {
   outline: 2px solid var(--text-primary);
   outline-offset: 2px;


### PR DESCRIPTION
**💡 What:** Added `:focus-visible` CSS rules for elements with `[role="button"]` to the global focus styles.
**🎯 Why:** Keyboard users navigating the application were not receiving visual focus indicators when tabbing onto custom button elements (like the photo grid thumbnails), making it difficult to understand where keyboard focus was located.
**📸 Before/After:** Before, native links and buttons had an outline but custom `div`s with `role="button"` did not. After, they receive the identical 2px solid primary text outline on focus.
**♿ Accessibility:** Greatly improves WCAG 2.4.7 Focus Visible compliance by ensuring all interactive elements explicitly modeled as buttons clearly indicate keyboard focus.

---
*PR created automatically by Jules for task [16683061978420623991](https://jules.google.com/task/16683061978420623991) started by @ralksta*