### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/lib/immich.ts
+++ b/lib/immich.ts
@@ -74,6 +74,7 @@ class ImmichClient {
   private hasLoggedAlbums = false;
   private pendingAlbumsPromise: Promise<ImmichAlbum[]> | null = null;
   private pendingAlbumPromises = new Map<string, Promise<ImmichAlbum | null>>();
+  private pendingAssetPromises = new Map<string, Promise<ImmichAsset | null>>();
 
   private get config() {
     return getConfig();
@@ -344,11 +345,24 @@ class ImmichClient {
     const cached = cache.get<ImmichAsset>(cacheKey);
     if (cached) return cached;
 
-    const asset = await this.request<ImmichAsset>(`/assets/${encodeURIComponent(assetId)}`);
-    if (!asset) return null;
+    if (this.pendingAssetPromises.has(assetId)) {
+      return this.pendingAssetPromises.get(assetId)!;
+    }
 
-    cache.set(cacheKey, asset, this.config.cacheTtl);
-    return asset;
+    const promise = (async () => {
+      try {
+        const asset = await this.request<ImmichAsset>(`/assets/${encodeURIComponent(assetId)}`);
+        if (!asset) return null;
+
+        cache.set(cacheKey, asset, this.config.cacheTtl);
+        return asset;
+      } finally {
+        this.pendingAssetPromises.delete(assetId);
+      }
+    })();
+
+    this.pendingAssetPromises.set(assetId, promise);
+    return promise;
   }
 
   /**


### PR DESCRIPTION
💡 **What**: Implemented Promise deduplication (request coalescing) in `getAssetInfo` within `ImmichClient` in `lib/immich.ts`.

🎯 **Why**: When identical calls to `getAssetInfo` for the same asset are made concurrently (e.g. within a map location builder looping over multiple identical cover assets), it bypassed the in-memory cache which hadn't yet populated. This caused multiple concurrent and identical downstream requests to the Immich server, causing unnecessary network overhead.

📊 **Impact**: This drastically reduces network overhead to the upstream Immich server on concurrent asset fetches before the cache can settle. Instead of executing N identical requests to Immich server, only 1 request is made and shared among the callers.

🔬 **Measurement**: Verified unit tests to confirm correct mapping and cache population. This optimization closely mirrors the deduplication strategy already implemented successfully in `getAlbum`.

---
*PR created automatically by Jules for task [12018720753763156776](https://jules.google.com/task/12018720753763156776) started by @ralksta*