### PR TITLE
🎨 Palette: Add focus-visible styles for custom role="button" elements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-25 - SVG Icon Accessibility
 **Learning:** Adding `aria-hidden="true"` to decorative `<svg>` icons within interactive elements (like `<button>` or `<a>`) that already have an `aria-label` is crucial. Otherwise, screen readers may read the raw vector nodes or fall back to confusing announcements in addition to the label. Similarly, when adding text to visual spinners, use `role="alert"` and `aria-live="polite"` on the container while hiding the SVG graphic.
 **Action:** When adding or modifying interactive elements with icon graphics, always ensure the graphic is explicitly hidden from screen readers using `aria-hidden="true"` if a text alternative (`aria-label`) is provided.
+
+## $(date +%Y-%m-%d) - Custom Button Focus Outline
+**Learning:** Custom interactive elements semantically marked as buttons (e.g., `<div role="button" tabIndex={0}>`) do not automatically inherit the native focus-visible styles applied to actual `<button>` elements in global CSS resets. This can lead to custom buttons failing accessibility audits for lack of visible focus indicators.
+**Action:** When creating custom buttons using `role="button"` on non-button HTML elements, ensure that global CSS rules target `[role="button"]:focus-visible` in addition to `button:focus-visible` to maintain consistent keyboard accessibility styling.

--- a/app/tokens.css
+++ b/app/tokens.css
@@ -248,6 +248,7 @@ img {
 
 a:focus-visible,
 button:focus-visible,
+[role='button']:focus-visible,
 input:focus-visible {
   outline: 2px solid var(--text-primary);
   outline-offset: 2px;


### PR DESCRIPTION
💡 **What:** Added `[role="button"]:focus-visible` to the global focus ring styles in `app/tokens.css`.
🎯 **Why:** Custom interactive elements (like `<div>` or `<span>`) that use `role="button"` and `tabIndex={0}` to act as buttons do not automatically inherit the global focus outline applied to native `<button>` elements. This causes keyboard users to lose track of focus when navigating through components like the `PhotoGrid` thumbnails.
📸 **Before/After:** No visual change for mouse users. For keyboard users navigating with Tab, a clear 2px solid outline now appears around focused `role="button"` elements.
♿ **Accessibility:** Fixes a critical WCAG requirement (Success Criterion 2.4.7 Focus Visible) for custom button elements by providing a visible focus indicator.

---
*PR created automatically by Jules for task [9898008214667506167](https://jules.google.com/task/9898008214667506167) started by @ralksta*