### PR TITLE
🎨 Palette: Add focus visible styles for keyboard navigation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 ## 2024-05-25 - SVG Icon Accessibility
 **Learning:** Adding `aria-hidden="true"` to decorative `<svg>` icons within interactive elements (like `<button>` or `<a>`) that already have an `aria-label` is crucial. Otherwise, screen readers may read the raw vector nodes or fall back to confusing announcements in addition to the label. Similarly, when adding text to visual spinners, use `role="alert"` and `aria-live="polite"` on the container while hiding the SVG graphic.
 **Action:** When adding or modifying interactive elements with icon graphics, always ensure the graphic is explicitly hidden from screen readers using `aria-hidden="true"` if a text alternative (`aria-label`) is provided.
+## 2026-04-18 - Focus styles for custom buttons
+**Learning:** Custom interactive elements semantically marked as buttons (e.g., `<div role="button" tabIndex={0}>`) do not automatically inherit native `<button>` focus-visible styles.
+**Action:** Explicitly add `[role="button"]:focus-visible` alongside other focus states to ensure keyboard users receive clear visual feedback.

--- a/app/api/auth/route.ts
+++ b/app/api/auth/route.ts
@@ -41,9 +41,12 @@ export async function POST(request: NextRequest) {
     }
 
     if (!isProtected(slug, type)) {
-      return NextResponse.json({
-        error: `${type === 'subpage' ? 'Subpage' : 'Album'} is not password-protected`,
-      }, { status: 400 });
+      return NextResponse.json(
+        {
+          error: `${type === 'subpage' ? 'Subpage' : 'Album'} is not password-protected`,
+        },
+        { status: 400 },
+      );
     }
 
     const setCookie = authenticate(slug, password, type);

--- a/app/tokens.css
+++ b/app/tokens.css
@@ -248,7 +248,8 @@ img {
 
 a:focus-visible,
 button:focus-visible,
-input:focus-visible {
+input:focus-visible,
+[role='button']:focus-visible {
   outline: 2px solid var(--text-primary);
   outline-offset: 2px;
 }


### PR DESCRIPTION
💡 What: Added `[role="button"]:focus-visible` to the global focus styles in `app/tokens.css`.
🎯 Why: Custom interactive elements that act as buttons (like the photo grid items) were not showing a visual outline when focused via keyboard navigation, making the app hard to navigate for keyboard users.
📸 Before/After: Not easily visible in static screenshots, but the focus outline now correctly appears on custom elements.
♿ Accessibility: Improved keyboard navigation by ensuring all elements acting as buttons receive the standard visual focus indicator.

---
*PR created automatically by Jules for task [16587659272526228662](https://jules.google.com/task/16587659272526228662) started by @ralksta*