### PR TITLE
🎨 Palette: Add focus states for custom button elements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-25 - SVG Icon Accessibility
 **Learning:** Adding `aria-hidden="true"` to decorative `<svg>` icons within interactive elements (like `<button>` or `<a>`) that already have an `aria-label` is crucial. Otherwise, screen readers may read the raw vector nodes or fall back to confusing announcements in addition to the label. Similarly, when adding text to visual spinners, use `role="alert"` and `aria-live="polite"` on the container while hiding the SVG graphic.
 **Action:** When adding or modifying interactive elements with icon graphics, always ensure the graphic is explicitly hidden from screen readers using `aria-hidden="true"` if a text alternative (`aria-label`) is provided.
+
+## 2026-04-19 - Focus Visible Styles for Custom Buttons
+**Learning:** Custom interactive elements semantically marked as buttons (e.g., `<div role="button" tabIndex={0}>`) do not automatically inherit native `<button>` focus-visible styles.
+**Action:** Explicitly add `[role="button"]:focus-visible` alongside other focus states to ensure keyboard users receive clear visual feedback.

--- a/app/tokens.css
+++ b/app/tokens.css
@@ -248,6 +248,7 @@ img {
 
 a:focus-visible,
 button:focus-visible,
+[role='button']:focus-visible,
 input:focus-visible {
   outline: 2px solid var(--text-primary);
   outline-offset: 2px;


### PR DESCRIPTION
### 💡 What
Added `[role="button"]:focus-visible` to `app/tokens.css` alongside existing anchor and native button focus styles.

### 🎯 Why
Custom interactive elements semantically marked as buttons (e.g., `<div role="button" tabIndex={0}>`) such as the main masonry photo grid items do not automatically inherit native `<button>` focus-visible styles. This creates a critical accessibility issue where keyboard users cannot easily see which photo is currently focused when tabbing through the gallery grid.

### ♿ Accessibility
Improves keyboard navigation accessibility by ensuring all elements acting as buttons have a clear, high-contrast visual focus indicator.

---
*PR created automatically by Jules for task [4850025281676828325](https://jules.google.com/task/4850025281676828325) started by @ralksta*