### PR TITLE
⚡ Bolt: Optimize base64 decoding buffer allocation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,8 @@
 
 **Learning:** When using `Promise.all` to fetch dependent data in parallel (e.g., getting multiple subpages and standalone albums that internally call a shared `getAlbums` function), the internal cache might not be populated in time. This leads to redundant concurrent network requests to the upstream server.
 **Action:** Implement Promise deduplication (request coalescing) by caching the pending Promise itself (e.g., in a `this.pendingPromise` class field) rather than just the final result. Return the pending Promise to subsequent callers until it resolves, ensuring only one network request is made.
+
+## 2024-05-29 - [Buffer vs Uint8Array allocation in Node.js]
+
+**Learning:** When creating a typed array from a base64 string using `Buffer.from(base64, 'base64')` in Node.js, wrapping it with `new Uint8Array(...)` is unnecessary because `Buffer` already inherits from `Uint8Array`.
+**Action:** Avoid re-wrapping `Buffer` instances as `Uint8Array` to prevent an additional memory allocation and data copy step. Return the `Buffer` instance directly for performance optimizations.

--- a/app/api/auth/route.ts
+++ b/app/api/auth/route.ts
@@ -41,9 +41,12 @@ export async function POST(request: NextRequest) {
     }
 
     if (!isProtected(slug, type)) {
-      return NextResponse.json({
-        error: `${type === 'subpage' ? 'Subpage' : 'Album'} is not password-protected`,
-      }, { status: 400 });
+      return NextResponse.json(
+        {
+          error: `${type === 'subpage' ? 'Subpage' : 'Album'} is not password-protected`,
+        },
+        { status: 400 },
+      );
     }
 
     const setCookie = authenticate(slug, password, type);

--- a/lib/thumbhash.ts
+++ b/lib/thumbhash.ts
@@ -27,7 +27,10 @@ function setCache<K, V>(map: Map<K, V>, key: K, value: V) {
  */
 function decodeBase64(base64: string): Uint8Array {
   if (typeof Buffer !== 'undefined') {
-    return new Uint8Array(Buffer.from(base64, 'base64'));
+    // Optimization: Buffer inherits from Uint8Array in Node.js.
+    // Returning the Buffer directly avoids an unnecessary memory allocation
+    // and data copy that would occur if wrapped in `new Uint8Array(...)`.
+    return Buffer.from(base64, 'base64');
   }
   return Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
 }


### PR DESCRIPTION
💡 What: Modified `decodeBase64` in `lib/thumbhash.ts` to return the Node.js `Buffer` instance directly instead of re-wrapping it in `new Uint8Array(...)`.
🎯 Why: `Buffer` already inherits from `Uint8Array` in Node.js. Wrapping a Buffer in `new Uint8Array(Buffer.from(...))` forces V8 to allocate a new ArrayBuffer of the same size and copy all bytes from the original Buffer to the new one, which creates unnecessary garbage collection pressure and CPU overhead on a hot path like image decoding.
📊 Impact: Avoids an unnecessary memory allocation (e.g. 21 bytes) and an O(n) data copy for every single Base64 thumbhash string that gets decoded in the proxy server.
🔬 Measurement: Run `pnpm test:unit` to ensure tests continue to pass and `thumbhashToBlurDataUrl` logic handles the buffer exactly identically.

---
*PR created automatically by Jules for task [6491853847433329076](https://jules.google.com/task/6491853847433329076) started by @ralksta*