### PR TITLE
🛡️ Sentinel: [HIGH] Fix rate limit IP spoofing vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -9,3 +9,7 @@
 **Vulnerability:** Comparing variable-length plaintext passwords using strict equality (`===`) or `crypto.timingSafeEqual` with unequal lengths, which leaks length information and enables timing attacks.
 **Learning:** When comparing variable-length secrets (like plaintext fallback passwords), both values must be hashed to a fixed-length algorithm (like SHA-256) first to ensure identical input lengths for the secure comparison, preventing side-channel leaks.
 **Prevention:** Always hash variable-length secrets to a fixed length before passing them to `crypto.timingSafeEqual`.
+## 2024-05-25 - Rate Limit IP Spoofing
+**Vulnerability:** The rate limiter and Map API used `x-real-ip` and `x-forwarded-for` HTTP headers to determine the client IP without checking `request.ip`.
+**Learning:** This allows an attacker to easily spoof their IP address by injecting a custom `x-forwarded-for` header, bypassing rate limiting mechanisms, including the critical 10 RPM brute-force protection on the auth endpoint. `request.ip` represents the actual TCP connection IP or the IP populated by a trusted edge proxy (like Vercel/Next.js).
+**Prevention:** Always prioritize `request.ip` over HTTP headers for rate limiting and IP-based security controls. Centralize IP retrieval into a single, verified function (`getClientIp`) rather than inline header reading.

--- a/app/api/auth/route.ts
+++ b/app/api/auth/route.ts
@@ -41,9 +41,12 @@ export async function POST(request: NextRequest) {
     }
 
     if (!isProtected(slug, type)) {
-      return NextResponse.json({
-        error: `${type === 'subpage' ? 'Subpage' : 'Album'} is not password-protected`,
-      }, { status: 400 });
+      return NextResponse.json(
+        {
+          error: `${type === 'subpage' ? 'Subpage' : 'Album'} is not password-protected`,
+        },
+        { status: 400 },
+      );
     }
 
     const setCookie = authenticate(slug, password, type);

--- a/app/api/map/route.ts
+++ b/app/api/map/route.ts
@@ -10,16 +10,13 @@ import { getConfig } from '@/lib/config';
 import { imageUrl } from '@/lib/urls';
 import { isAuthenticated } from '@/lib/auth';
 import { getMapData } from '@/lib/mapService';
-import { checkRateLimit } from '@/lib/rate-limit';
+import { checkRateLimit, getClientIp } from '@/lib/rate-limit';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(request: NextRequest) {
   // Rate limit: 120 requests/minute per IP (map data is cached client-side; this guards against abuse)
-  const ip =
-    request.headers.get('x-forwarded-for')?.split(',')[0].trim() ??
-    request.headers.get('x-real-ip') ??
-    '127.0.0.1';
+  const ip = getClientIp(request);
   const rl = checkRateLimit(ip, 120);
   if (!rl.success) {
     return NextResponse.json(

--- a/lib/__tests__/rate-limit.test.ts
+++ b/lib/__tests__/rate-limit.test.ts
@@ -1,5 +1,48 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { checkRateLimit } from '@/lib/rate-limit';
+import { checkRateLimit, getClientIp } from '@/lib/rate-limit';
+import { NextRequest } from 'next/server';
+
+describe('getClientIp', () => {
+  it('prioritizes request.ip', () => {
+    const request = new NextRequest('http://localhost', {
+      headers: {
+        'x-real-ip': '2.2.2.2',
+        'x-forwarded-for': '3.3.3.3',
+      },
+    });
+    // @ts-expect-error - overriding read-only property for testing
+    request.ip = '1.1.1.1';
+
+    expect(getClientIp(request)).toBe('1.1.1.1');
+  });
+
+  it('falls back to x-real-ip if request.ip is absent', () => {
+    const request = new NextRequest('http://localhost', {
+      headers: {
+        'x-real-ip': '2.2.2.2',
+        'x-forwarded-for': '3.3.3.3',
+      },
+    });
+
+    expect(getClientIp(request)).toBe('2.2.2.2');
+  });
+
+  it('falls back to x-forwarded-for if request.ip and x-real-ip are absent', () => {
+    const request = new NextRequest('http://localhost', {
+      headers: {
+        'x-forwarded-for': '3.3.3.3, 4.4.4.4',
+      },
+    });
+
+    expect(getClientIp(request)).toBe('3.3.3.3');
+  });
+
+  it('falls back to unknown if no IP is found', () => {
+    const request = new NextRequest('http://localhost');
+
+    expect(getClientIp(request)).toBe('unknown');
+  });
+});
 
 describe('checkRateLimit', () => {
   // Use unique IP prefixes per test to avoid cross-contamination

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -13,6 +13,7 @@ import { NextRequest } from 'next/server';
 
 export function getClientIp(request: NextRequest): string {
   return (
+    request.ip ??
     request.headers.get('x-real-ip') ??
     request.headers.get('x-forwarded-for')?.split(',')[0].trim() ??
     'unknown'

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -12,8 +12,11 @@
 import { NextRequest } from 'next/server';
 
 export function getClientIp(request: NextRequest): string {
+  // @ts-expect-error - request.ip may be populated by Vercel/proxies but was removed from NextRequest types
+  const ip = request.ip as string | undefined;
+
   return (
-    request.ip ??
+    ip ??
     request.headers.get('x-real-ip') ??
     request.headers.get('x-forwarded-for')?.split(',')[0].trim() ??
     'unknown'


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The rate limiter and Map API relied on `x-real-ip` and `x-forwarded-for` HTTP headers to determine the client IP without checking the trusted runtime-provided `request.ip`. This allowed an attacker to bypass rate limiting (including auth brute-force protection) by simply injecting a custom `x-forwarded-for` header.
🎯 Impact: Attackers could easily perform DoS attacks or brute-force album passwords by spoofing their IP to reset their rate limit buckets.
🔧 Fix: Updated the `getClientIp` function in `lib/rate-limit.ts` to prioritize `request.ip` over HTTP headers. Also standardized IP retrieval in the Map API to use this helper. Added unit tests to verify the fallback behavior.
✅ Verification: Ran `pnpm test` and ensured all unit tests pass, including the newly added IP fallback precedence tests.

---
*PR created automatically by Jules for task [7171979113086274298](https://jules.google.com/task/7171979113086274298) started by @ralksta*