### PR TITLE
🎨 Palette: Add focus-visible styles for custom buttons

### DIFF
--- a/app/api/auth/route.ts
+++ b/app/api/auth/route.ts
@@ -41,9 +41,12 @@ export async function POST(request: NextRequest) {
     }
 
     if (!isProtected(slug, type)) {
-      return NextResponse.json({
-        error: `${type === 'subpage' ? 'Subpage' : 'Album'} is not password-protected`,
-      }, { status: 400 });
+      return NextResponse.json(
+        {
+          error: `${type === 'subpage' ? 'Subpage' : 'Album'} is not password-protected`,
+        },
+        { status: 400 },
+      );
     }
 
     const setCookie = authenticate(slug, password, type);

--- a/app/tokens.css
+++ b/app/tokens.css
@@ -248,7 +248,8 @@ img {
 
 a:focus-visible,
 button:focus-visible,
-input:focus-visible {
+input:focus-visible,
+[role='button']:focus-visible {
   outline: 2px solid var(--text-primary);
   outline-offset: 2px;
 }

--- a/docs/gallery-config.md
+++ b/docs/gallery-config.md
@@ -64,8 +64,8 @@ subpages:
     albums:
       - 55555555-5555-5555-5555-555555555555
       - 66666666-6666-6666-6666-666666666666:
-          title: "Private Highlights"
-          password: "album-secret-123" # Optional: album-level protection
+          title: 'Private Highlights'
+          password: 'album-secret-123' # Optional: album-level protection
 ```
 
 Alternatively, you can use the object notation (recommended):
@@ -99,7 +99,7 @@ albums:
   - 'album-uuid': My Title # → displays "My Title" instead
   - 'album-uuid':
       title: My Private Title
-      password: "secure-password" # → adds a password gate to this specific album
+      password: 'secure-password' # → adds a password gate to this specific album
 ```
 
 **Full example:**


### PR DESCRIPTION
💡 **What:** Added `[role="button"]:focus-visible` to the global focus styles in `app/tokens.css`.
🎯 **Why:** To ensure custom interactive elements that act as buttons (using the `role="button"` ARIA role) have proper keyboard focus indicators, improving overall accessibility.
📸 **Before/After:** Not visually tested against a live production page due to the simplicity of the CSS addition, but verified visually with Playwright using a standalone HTML page.
♿ **Accessibility:** This directly improves keyboard accessibility for users relying on keyboard navigation by providing clear visual feedback when non-native button elements are focused.

---
*PR created automatically by Jules for task [12100664464481003862](https://jules.google.com/task/12100664464481003862) started by @ralksta*