### PR TITLE
⚡ Bolt: [performance improvement] Return Buffer directly to avoid Uint8Array memory copy

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,7 @@
 
 **Learning:** When using `Promise.all` to fetch dependent data in parallel (e.g., getting multiple subpages and standalone albums that internally call a shared `getAlbums` function), the internal cache might not be populated in time. This leads to redundant concurrent network requests to the upstream server.
 **Action:** Implement Promise deduplication (request coalescing) by caching the pending Promise itself (e.g., in a `this.pendingPromise` class field) rather than just the final result. Return the pending Promise to subsequent callers until it resolves, ensuring only one network request is made.
+## 2024-05-29 - [Buffer inheritance optimization]
+
+**Learning:** `Buffer` inherits from `Uint8Array` in Node.js. Passing a `Buffer` into `new Uint8Array(...)` creates a completely new `ArrayBuffer` and copies all elements, which is an O(N) memory allocation and copy.
+**Action:** When decoding base64 strings or similar byte streams in Node.js where a `Uint8Array` is expected, return `Buffer.from(data, 'base64')` directly instead of wrapping it.

--- a/lib/thumbhash.ts
+++ b/lib/thumbhash.ts
@@ -27,7 +27,10 @@ function setCache<K, V>(map: Map<K, V>, key: K, value: V) {
  */
 function decodeBase64(base64: string): Uint8Array {
   if (typeof Buffer !== 'undefined') {
-    return new Uint8Array(Buffer.from(base64, 'base64'));
+    // ⚡ Bolt: Return Buffer directly instead of wrapping in new Uint8Array.
+    // Buffer inherits from Uint8Array, so returning it directly prevents
+    // unnecessary memory allocation and copying.
+    return Buffer.from(base64, 'base64');
   }
   return Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
 }


### PR DESCRIPTION
💡 **What:** Modified `decodeBase64` in `lib/thumbhash.ts` to return `Buffer.from(...)` directly instead of wrapping it in a `new Uint8Array(...)`.
🎯 **Why:** In Node.js, `Buffer` is a subclass of `Uint8Array`. Passing a `Buffer` to the `Uint8Array` constructor allocates a brand new `ArrayBuffer` and copies all the bytes over. Returning the `Buffer` directly skips this unnecessary O(N) memory allocation and copy step, saving CPU cycles and memory.
📊 **Impact:** Reduces memory allocations and copies by ~50% per ThumbHash processed on the backend.
🔬 **Measurement:** Verify tests run successfully with `pnpm test:unit`, ensuring that `Buffer` instances are treated seamlessly as `Uint8Array` downstream.

---
*PR created automatically by Jules for task [11066231432858235145](https://jules.google.com/task/11066231432858235145) started by @ralksta*