### PR TITLE
🛡️ Sentinel: [HIGH] Fix IP spoofing vulnerability in rate limiter

### DIFF
--- a/app/api/auth/route.ts
+++ b/app/api/auth/route.ts
@@ -41,9 +41,12 @@ export async function POST(request: NextRequest) {
     }
 
     if (!isProtected(slug, type)) {
-      return NextResponse.json({
-        error: `${type === 'subpage' ? 'Subpage' : 'Album'} is not password-protected`,
-      }, { status: 400 });
+      return NextResponse.json(
+        {
+          error: `${type === 'subpage' ? 'Subpage' : 'Album'} is not password-protected`,
+        },
+        { status: 400 },
+      );
     }
 
     const setCookie = authenticate(slug, password, type);

--- a/docs/gallery-config.md
+++ b/docs/gallery-config.md
@@ -64,8 +64,8 @@ subpages:
     albums:
       - 55555555-5555-5555-5555-555555555555
       - 66666666-6666-6666-6666-666666666666:
-          title: "Private Highlights"
-          password: "album-secret-123" # Optional: album-level protection
+          title: 'Private Highlights'
+          password: 'album-secret-123' # Optional: album-level protection
 ```
 
 Alternatively, you can use the object notation (recommended):
@@ -99,7 +99,7 @@ albums:
   - 'album-uuid': My Title # → displays "My Title" instead
   - 'album-uuid':
       title: My Private Title
-      password: "secure-password" # → adds a password gate to this specific album
+      password: 'secure-password' # → adds a password gate to this specific album
 ```
 
 **Full example:**

--- a/lib/__tests__/rate-limit.test.ts
+++ b/lib/__tests__/rate-limit.test.ts
@@ -1,5 +1,50 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { checkRateLimit } from '@/lib/rate-limit';
+import { NextRequest } from 'next/server';
+import { checkRateLimit, getClientIp } from '@/lib/rate-limit';
+
+describe('getClientIp', () => {
+  it('prioritizes request.ip when present', () => {
+    const req = {
+      ip: '1.2.3.4',
+      headers: new Headers({
+        'x-real-ip': '5.6.7.8',
+        'x-forwarded-for': '9.10.11.12',
+      }),
+    } as unknown as NextRequest;
+
+    expect(getClientIp(req)).toBe('1.2.3.4');
+  });
+
+  it('falls back to x-real-ip if request.ip is missing', () => {
+    const req = {
+      headers: new Headers({
+        'x-real-ip': '5.6.7.8',
+        'x-forwarded-for': '9.10.11.12',
+      }),
+    } as unknown as NextRequest;
+
+    expect(getClientIp(req)).toBe('5.6.7.8');
+  });
+
+  it('falls back to x-forwarded-for if request.ip and x-real-ip are missing', () => {
+    const req = {
+      headers: new Headers({
+        'x-forwarded-for': '9.10.11.12, 13.14.15.16',
+      }),
+    } as unknown as NextRequest;
+
+    // Should take the first IP from x-forwarded-for list
+    expect(getClientIp(req)).toBe('9.10.11.12');
+  });
+
+  it('returns unknown if no IP headers are present', () => {
+    const req = {
+      headers: new Headers(),
+    } as unknown as NextRequest;
+
+    expect(getClientIp(req)).toBe('unknown');
+  });
+});
 
 describe('checkRateLimit', () => {
   // Use unique IP prefixes per test to avoid cross-contamination

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -12,7 +12,11 @@
 import { NextRequest } from 'next/server';
 
 export function getClientIp(request: NextRequest): string {
+  // @ts-expect-error - Next.js 15 removed request.ip but hosting platforms like Vercel still populate it
+  const ip = request.ip as string | undefined;
+
   return (
+    ip ??
     request.headers.get('x-real-ip') ??
     request.headers.get('x-forwarded-for')?.split(',')[0].trim() ??
     'unknown'


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `getClientIp` function in `lib/rate-limit.ts` relied solely on easily-spoofed HTTP headers (`x-real-ip`, `x-forwarded-for`) rather than the actual connection IP provided by the Next.js runtime. This allowed attackers to bypass rate limits by injecting forged headers.
🎯 Impact: Attackers could execute Denial of Service (DoS) attacks or brute-force passwords by simply spoofing their IP headers, effectively rendering the rate limiting useless.
🔧 Fix: Prioritized the framework-provided `request.ip` over HTTP headers. Uses an `@ts-expect-error` to safely access `request.ip` which was removed from NextRequest types in Next.js 15 but is still populated by platforms like Vercel. Also added comprehensive test coverage for `getClientIp`.
✅ Verification: Ran unit tests specifically testing `getClientIp` behavior to ensure `request.ip` is prioritized and all fallback paths work correctly.

---
*PR created automatically by Jules for task [6793026054968056938](https://jules.google.com/task/6793026054968056938) started by @ralksta*