### PR TITLE
⚡ Bolt: [performance improvement] Promise deduplication for getAssetInfo

### DIFF
--- a/lib/immich.ts
+++ b/lib/immich.ts
@@ -74,6 +74,7 @@ class ImmichClient {
   private hasLoggedAlbums = false;
   private pendingAlbumsPromise: Promise<ImmichAlbum[]> | null = null;
   private pendingAlbumPromises = new Map<string, Promise<ImmichAlbum | null>>();
+  private pendingAssetPromises = new Map<string, Promise<ImmichAsset | null>>();
 
   private get config() {
     return getConfig();
@@ -344,11 +345,27 @@ class ImmichClient {
     const cached = cache.get<ImmichAsset>(cacheKey);
     if (cached) return cached;
 
-    const asset = await this.request<ImmichAsset>(`/assets/${encodeURIComponent(assetId)}`);
-    if (!asset) return null;
+    // ⚡ Bolt: Deduplicate concurrent requests for the same asset ID.
+    // If a request for this asset is already in flight (e.g. from Promise.all in a grid),
+    // return the pending promise instead of triggering a redundant API call.
+    if (this.pendingAssetPromises.has(assetId)) {
+      return this.pendingAssetPromises.get(assetId)!;
+    }
 
-    cache.set(cacheKey, asset, this.config.cacheTtl);
-    return asset;
+    const promise = (async () => {
+      try {
+        const asset = await this.request<ImmichAsset>(`/assets/${encodeURIComponent(assetId)}`);
+        if (!asset) return null;
+
+        cache.set(cacheKey, asset, this.config.cacheTtl);
+        return asset;
+      } finally {
+        this.pendingAssetPromises.delete(assetId);
+      }
+    })();
+
+    this.pendingAssetPromises.set(assetId, promise);
+    return promise;
   }
 
   /**


### PR DESCRIPTION
💡 **What**: Added Promise deduplication (request coalescing) for `getAssetInfo` in the `ImmichClient` (`lib/immich.ts`).
🎯 **Why**: When multiple components concurrently request the same asset info (e.g. via `Promise.all` for hero images or subpage covers), it leads to redundant parallel network calls before the cache is populated.
📊 **Impact**: Reduces redundant network calls to the upstream Immich server when fetching identical assets concurrently, decreasing load and avoiding potential rate limiting issues.
🔬 **Measurement**: Verify that during high-concurrency data fetching phases (e.g. Homepage rendering), only one network call is initiated for a given asset ID. Run `npm run test:unit` to ensure no functionality is broken.

---
*PR created automatically by Jules for task [5360350448365084189](https://jules.google.com/task/5360350448365084189) started by @ralksta*