### PR TITLE
🎨 Palette: [UX improvement] Add ARIA attributes to photo grid items

### DIFF
--- a/app/[...path]/PhotoGrid.tsx
+++ b/app/[...path]/PhotoGrid.tsx
@@ -155,6 +155,7 @@ export function PhotoGrid({ assets, layout = 'masonry', gridStyle }: PhotoGridPr
           role="button"
           tabIndex={0}
           aria-label={`View photo ${index + 1}`}
+          aria-haspopup="dialog"
           style={{
             ...(asset.dominantColor ? { backgroundColor: asset.dominantColor } : {}),
             ...((layout === 'masonry' || layout === 'showcase') && asset.aspectRatio
@@ -173,7 +174,7 @@ export function PhotoGrid({ assets, layout = 'masonry', gridStyle }: PhotoGridPr
               : {})}
           />
           {(asset.camera || asset.lens) && (
-            <div className="photo-grid__item-exif">
+            <div className="photo-grid__item-exif" aria-hidden="true">
               {[asset.camera, asset.lens, asset.focalLength].filter(Boolean).join(' · ')}
             </div>
           )}


### PR DESCRIPTION
💡 **What:** Added `aria-haspopup="dialog"` to the `.photo-grid__item` element and `aria-hidden="true"` to the inner EXIF text overlay.
🎯 **Why:** To inform screen reader users that clicking an image grid item will open a modal dialogue (the Lightbox) and to prevent screen readers from reading the internal EXIF info redundantly, as the grid item already has a clean `aria-label`.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Yes, significantly improves the experience for assistive technology users navigating the grid.

---
*PR created automatically by Jules for task [10031905511910149117](https://jules.google.com/task/10031905511910149117) started by @ralksta*