### PR TITLE
🎨 Palette: [UX improvement] Consolidate EXIF data announcements in PhotoGrid

### DIFF
--- a/app/[...path]/PhotoGrid.tsx
+++ b/app/[...path]/PhotoGrid.tsx
@@ -154,7 +154,12 @@ export function PhotoGrid({ assets, layout = 'masonry', gridStyle }: PhotoGridPr
           }}
           role="button"
           tabIndex={0}
-          aria-label={`View photo ${index + 1}`}
+          aria-label={
+            `View photo ${index + 1}` +
+            (asset.camera || asset.lens
+              ? ` - ${[asset.camera, asset.lens, asset.focalLength].filter(Boolean).join(' · ')}`
+              : '')
+          }
           style={{
             ...(asset.dominantColor ? { backgroundColor: asset.dominantColor } : {}),
             ...((layout === 'masonry' || layout === 'showcase') && asset.aspectRatio
@@ -173,7 +178,7 @@ export function PhotoGrid({ assets, layout = 'masonry', gridStyle }: PhotoGridPr
               : {})}
           />
           {(asset.camera || asset.lens) && (
-            <div className="photo-grid__item-exif">
+            <div className="photo-grid__item-exif" aria-hidden="true">
               {[asset.camera, asset.lens, asset.focalLength].filter(Boolean).join(' · ')}
             </div>
           )}


### PR DESCRIPTION
💡 What:
Appended camera EXIF metadata directly to the parent button's `aria-label` and applied `aria-hidden="true"` to the visual EXIF container in the `PhotoGrid` component.

🎯 Why:
To prevent fragmented screen reader announcements on interactive grid items. Sighted users see the photo thumbnail and the EXIF text (camera, lens, focal length) overlaid. Previously, screen reader users either didn't hear the EXIF text or heard it as confusing fragmented content nested inside a button. Consolidating the information into a single `aria-label` gives screen reader users the same contextual information smoothly.

📸 Before/After:
*Before*: Button label was "View photo 1", visual text (e.g., "Canon EOS R5 · 50mm") might be ignored or read disjointedly.
*After*: Button label is "View photo 1 - Canon EOS R5 · 50mm".

♿ Accessibility:
* Screen readers announce the image intent and metadata concisely.
* `aria-hidden="true"` ensures the visual text doesn't cause redundant or confusing announcements.

---
*PR created automatically by Jules for task [6675633924341837418](https://jules.google.com/task/6675633924341837418) started by @ralksta*