### PR TITLE
🎨 Palette: [UX improvement] Enhance PhotoGrid accessibility with ARIA attributes

### DIFF
--- a/app/[...path]/PhotoGrid.tsx
+++ b/app/[...path]/PhotoGrid.tsx
@@ -155,6 +155,7 @@ export function PhotoGrid({ assets, layout = 'masonry', gridStyle }: PhotoGridPr
           role="button"
           tabIndex={0}
           aria-label={`View photo ${index + 1}`}
+          aria-haspopup="dialog"
           style={{
             ...(asset.dominantColor ? { backgroundColor: asset.dominantColor } : {}),
             ...((layout === 'masonry' || layout === 'showcase') && asset.aspectRatio
@@ -173,7 +174,7 @@ export function PhotoGrid({ assets, layout = 'masonry', gridStyle }: PhotoGridPr
               : {})}
           />
           {(asset.camera || asset.lens) && (
-            <div className="photo-grid__item-exif">
+            <div className="photo-grid__item-exif" aria-hidden="true">
               {[asset.camera, asset.lens, asset.focalLength].filter(Boolean).join(' · ')}
             </div>
           )}


### PR DESCRIPTION
💡 **What**: Added `aria-haspopup="dialog"` to the main button element of photo grid items, and `aria-hidden="true"` to the inner EXIF text overlay.
🎯 **Why**: When a user navigates via keyboard or screen reader, clicking an image opens a modal Lightbox. Screen readers need `aria-haspopup="dialog"` to understand this interaction model. Furthermore, because the button already features a clear, unified `aria-label` ("View photo X"), the inner raw EXIF text (e.g., "Camera · Lens · Focal length") caused redundant and fragmented read-outs, confusing the user context. Hiding the EXIF specifically from the screen reader solves this while keeping the visual overlay intact.
📸 **Before/After**: N/A (Non-visual change)
♿ **Accessibility**: Significant improvement to screen reader navigation over interactive grid items. Screen readers will now correctly identify the interactive target as a dialog trigger, and announce a clean, concise label without noisy internal text.

---
*PR created automatically by Jules for task [16281235129542552782](https://jules.google.com/task/16281235129542552782) started by @ralksta*