### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure AUTH_SECRET fallback

### DIFF
--- a/lib/config/index.ts
+++ b/lib/config/index.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 import { env } from '../env';
 import { loadYaml, validateUuid } from './parser';
 import { resolveTheme, VALID_LAYOUTS } from './theme';
@@ -16,6 +17,7 @@ export * from './schema';
 export * from './theme';
 
 let _config: AppConfig | null = null;
+let _devAuthSecret: string | null = null;
 
 /** Converts raw YAML grid overrides into a typed partial GridConfig. */
 export function buildSubpageGrid(raw?: {
@@ -55,9 +57,12 @@ export function getConfig(): AppConfig {
       );
     }
     console.warn(
-      '\n⚠️  SECURITY WARNING: AUTH_SECRET is not set. Falling back to IMMICH_API_KEY.\n   Please set a long random string as AUTH_SECRET in your .env for better security.\n',
+      '\n⚠️  SECURITY WARNING: AUTH_SECRET is not set. Using a temporary random secret.\n   Please set a long random string as AUTH_SECRET in your .env for persistent sessions.\n',
     );
-    AUTH_SECRET = apiKey;
+    if (!_devAuthSecret) {
+      _devAuthSecret = crypto.randomBytes(32).toString('hex');
+    }
+    AUTH_SECRET = _devAuthSecret;
   }
   const authSecret = AUTH_SECRET;
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The application insecurely reused `IMMICH_API_KEY` as a fallback when `AUTH_SECRET` was not provided in non-production environments. Reusing an API key as a session signing secret could potentially leak the API key or allow trivial forging of tokens if the HMAC is compromised.
🎯 Impact: An attacker could potentially deduce the `IMMICH_API_KEY` from signed session cookies, allowing unauthorized access directly to the user's Immich backend.
🔧 Fix: Replaced the `apiKey` fallback in `lib/config/index.ts` with a secure, process-stable randomly generated 32-byte hex string (`crypto.randomBytes(32).toString('hex')`). This guarantees the `AUTH_SECRET` is strong while keeping active sessions stable for the lifetime of the process.
✅ Verification: Ran `pnpm test` and `pnpm lint` and all checks passed. Verified the changes in the source code.

---
*PR created automatically by Jules for task [14041504822163999976](https://jules.google.com/task/14041504822163999976) started by @ralksta*