### PR TITLE
🎨 Palette: Improve screen reader experience for photo grid items

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-26 - Interactive Card ARIA Labels
 **Learning:** When building interactive card components that contain multiple pieces of text or badges (like titles and photo counts), screen readers may announce them in a fragmented or confusing way.
 **Action:** Always apply a comprehensive `aria-label` to the parent link/container that encompasses all meaningful visual data (e.g., titles and item counts). Use `aria-hidden="true"` on redundant text or visual child elements, and set `alt=""` on decorative images to consolidate screen reader announcements into a single, accurate interaction point.
+
+## 2024-05-27 - Lightbox Trigger Accessibility
+**Learning:** Interactive elements that trigger a modal or lightbox must include the `aria-haspopup="dialog"` attribute to correctly inform assistive technologies.
+**Action:** Always add `aria-haspopup="dialog"` to grid items or buttons that open a lightbox.

--- a/app/[...path]/PhotoGrid.tsx
+++ b/app/[...path]/PhotoGrid.tsx
@@ -155,6 +155,7 @@ export function PhotoGrid({ assets, layout = 'masonry', gridStyle }: PhotoGridPr
           role="button"
           tabIndex={0}
           aria-label={`View photo ${index + 1}`}
+          aria-haspopup="dialog"
           style={{
             ...(asset.dominantColor ? { backgroundColor: asset.dominantColor } : {}),
             ...((layout === 'masonry' || layout === 'showcase') && asset.aspectRatio
@@ -173,7 +174,7 @@ export function PhotoGrid({ assets, layout = 'masonry', gridStyle }: PhotoGridPr
               : {})}
           />
           {(asset.camera || asset.lens) && (
-            <div className="photo-grid__item-exif">
+            <div className="photo-grid__item-exif" aria-hidden="true">
               {[asset.camera, asset.lens, asset.focalLength].filter(Boolean).join(' · ')}
             </div>
           )}


### PR DESCRIPTION
💡 **What:** Added `aria-haspopup="dialog"` to the photo grid item buttons and `aria-hidden="true"` to the EXIF data overlay within those buttons.
🎯 **Why:** To ensure screen readers properly announce that interacting with the grid item will open a dialog/lightbox, and to prevent redundant or fragmented text from being read out, as the parent container already has a comprehensive `aria-label` describing the photo.
♿ **Accessibility:** This directly addresses standard WCAG patterns for custom modals and interactive elements with complex internal content.

---
*PR created automatically by Jules for task [10948727756543377540](https://jules.google.com/task/10948727756543377540) started by @ralksta*