### PR TITLE
🎨 Palette: Improve accessibility of image grid items

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-26 - Interactive Card ARIA Labels
 **Learning:** When building interactive card components that contain multiple pieces of text or badges (like titles and photo counts), screen readers may announce them in a fragmented or confusing way.
 **Action:** Always apply a comprehensive `aria-label` to the parent link/container that encompasses all meaningful visual data (e.g., titles and item counts). Use `aria-hidden="true"` on redundant text or visual child elements, and set `alt=""` on decorative images to consolidate screen reader announcements into a single, accurate interaction point.
+
+## 2026-05-02 - Lightbox Trigger Accessibility
+**Learning:** Interactive elements that trigger a modal or lightbox (like image grid items) must use `aria-haspopup="dialog"`. Additionally, when an interactive component has a comprehensive `aria-label`, child text containers (like EXIF data overlays) should use `aria-hidden="true"` to prevent redundant screen reader announcements.
+**Action:** When building interactive card components that open modals, always include `aria-haspopup="dialog"` and explicitly hide supplementary text elements to keep screen reader announcements concise.

--- a/app/[...path]/PhotoGrid.tsx
+++ b/app/[...path]/PhotoGrid.tsx
@@ -154,6 +154,7 @@ export function PhotoGrid({ assets, layout = 'masonry', gridStyle }: PhotoGridPr
           }}
           role="button"
           tabIndex={0}
+          aria-haspopup="dialog"
           aria-label={`View photo ${index + 1}`}
           style={{
             ...(asset.dominantColor ? { backgroundColor: asset.dominantColor } : {}),
@@ -173,7 +174,7 @@ export function PhotoGrid({ assets, layout = 'masonry', gridStyle }: PhotoGridPr
               : {})}
           />
           {(asset.camera || asset.lens) && (
-            <div className="photo-grid__item-exif">
+            <div className="photo-grid__item-exif" aria-hidden="true">
               {[asset.camera, asset.lens, asset.focalLength].filter(Boolean).join(' · ')}
             </div>
           )}


### PR DESCRIPTION
* 💡 What: Added `aria-haspopup="dialog"` to image grid items and `aria-hidden="true"` to the EXIF data overlay.
* 🎯 Why: Improves screen reader experience by properly identifying elements that trigger a lightbox modal and preventing redundant/fragmented announcements of EXIF data when the parent element already has a comprehensive `aria-label`.
* 📸 Before/After: Visuals remain unchanged.
* ♿ Accessibility: Screen readers now correctly announce the items as opening a dialog and won't redundantly read the EXIF text inside the button.

---
*PR created automatically by Jules for task [12045425264332088664](https://jules.google.com/task/12045425264332088664) started by @ralksta*