### PR TITLE
⚡ Bolt: Optimize map clustering memory

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -14,3 +14,7 @@
 ## 2026-04-24 - [OOM prevention through promise chunking]
 **Learning:** When fetching unbounded large collections (like photo albums and their assets), using concurrent `Promise.all` over the entire array can cause Node.js Out of Memory (OOM) crashes.
 **Action:** Instead of `Promise.all(array.map(...))`, use a chunked data fetching approach (e.g., `Promise.all` within a `for` loop processing chunks of e.g. 10 items) to balance memory constraints with concurrent network speed.
+
+## 2024-05-30 - Optimize map clustering memory
+**Learning:** When bucketing or grouping large datasets (e.g., thousands of map coordinates into geographical clusters), replace memory-heavy array allocations (`[].push()`) followed by a `reduce` operation with running statistical accumulators (e.g., `latSum`, `lngSum`, `count`) directly on the bucket.
+**Action:** This reduces bucket memory from O(N) to O(1) and eliminates expensive post-processing loops.

--- a/lib/mapService.ts
+++ b/lib/mapService.ts
@@ -45,9 +45,10 @@ export async function getMapData(): Promise<MapLocation[]> {
   }
 
   // Bucket assets by city+country
+  // Optimized: use running latSum/lngSum instead of arrays to reduce O(N) memory overhead to O(1)
   const buckets = new Map<
     string,
-    { lats: number[]; lngs: number[]; count: number; coverAssetId: string; albumIds: Set<string> }
+    { latSum: number; lngSum: number; count: number; coverAssetId: string; albumIds: Set<string> }
   >();
 
   for (const album of fullAlbums) {
@@ -59,11 +60,11 @@ export async function getMapData(): Promise<MapLocation[]> {
       const key = `${exif.city}|${exif.country}`;
       let bucket = buckets.get(key);
       if (!bucket) {
-        bucket = { lats: [], lngs: [], count: 0, coverAssetId: asset.id, albumIds: new Set() };
+        bucket = { latSum: 0, lngSum: 0, count: 0, coverAssetId: asset.id, albumIds: new Set() };
         buckets.set(key, bucket);
       }
-      bucket.lats.push(exif.latitude);
-      bucket.lngs.push(exif.longitude);
+      bucket.latSum += exif.latitude;
+      bucket.lngSum += exif.longitude;
       bucket.count++;
       bucket.albumIds.add(album.id);
     }
@@ -73,8 +74,8 @@ export async function getMapData(): Promise<MapLocation[]> {
   const locations: MapLocation[] = [];
   for (const [key, bucket] of buckets) {
     const [city, country] = key.split('|');
-    const lat = bucket.lats.reduce((a, b) => a + b, 0) / bucket.lats.length;
-    const lng = bucket.lngs.reduce((a, b) => a + b, 0) / bucket.lngs.length;
+    const lat = bucket.latSum / bucket.count;
+    const lng = bucket.lngSum / bucket.count;
     locations.push({
       city,
       country,


### PR DESCRIPTION
💡 What: Replaced array-based bucketing (`lats: number[]`, `lngs: number[]`) with running sums (`latSum`, `lngSum`) in `getMapData`.
🎯 Why: Storing every single coordinate for thousands of photos in arrays before taking the average consumes O(N) memory and requires an expensive `.reduce` iteration.
📊 Impact: Reduces bucket memory overhead from O(N) to O(1) per location and removes the post-processing loop.
🔬 Measurement: Verify tests still pass and map loads correctly.

---
*PR created automatically by Jules for task [3575691858724784292](https://jules.google.com/task/3575691858724784292) started by @ralksta*