### PR TITLE
⚡ Bolt: [performance improvement] Reduce map bucketing memory from O(N) to O(1)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -14,3 +14,6 @@
 ## 2026-04-24 - [OOM prevention through promise chunking]
 **Learning:** When fetching unbounded large collections (like photo albums and their assets), using concurrent `Promise.all` over the entire array can cause Node.js Out of Memory (OOM) crashes.
 **Action:** Instead of `Promise.all(array.map(...))`, use a chunked data fetching approach (e.g., `Promise.all` within a `for` loop processing chunks of e.g. 10 items) to balance memory constraints with concurrent network speed.
+## 2024-05-24 - Reduce map bucketing memory from O(N) to O(1)
+**Learning:** Large memory allocations can happen when grouping array elements for mathematical averages using array pushes (`[].push()`). It's more performant to maintain running statistical accumulators (e.g. `sum` and `count`).
+**Action:** When bucketing or grouping datasets for summary stats, use running accumulators directly in the bucket to prevent expensive allocations and post-processing loops.

--- a/lib/mapService.ts
+++ b/lib/mapService.ts
@@ -45,9 +45,10 @@ export async function getMapData(): Promise<MapLocation[]> {
   }
 
   // Bucket assets by city+country
+  // ⚡ Bolt: Use running sum accumulators instead of arrays to reduce memory from O(N) to O(1)
   const buckets = new Map<
     string,
-    { lats: number[]; lngs: number[]; count: number; coverAssetId: string; albumIds: Set<string> }
+    { latSum: number; lngSum: number; count: number; coverAssetId: string; albumIds: Set<string> }
   >();
 
   for (const album of fullAlbums) {
@@ -59,11 +60,11 @@ export async function getMapData(): Promise<MapLocation[]> {
       const key = `${exif.city}|${exif.country}`;
       let bucket = buckets.get(key);
       if (!bucket) {
-        bucket = { lats: [], lngs: [], count: 0, coverAssetId: asset.id, albumIds: new Set() };
+        bucket = { latSum: 0, lngSum: 0, count: 0, coverAssetId: asset.id, albumIds: new Set() };
         buckets.set(key, bucket);
       }
-      bucket.lats.push(exif.latitude);
-      bucket.lngs.push(exif.longitude);
+      bucket.latSum += exif.latitude;
+      bucket.lngSum += exif.longitude;
       bucket.count++;
       bucket.albumIds.add(album.id);
     }
@@ -73,8 +74,8 @@ export async function getMapData(): Promise<MapLocation[]> {
   const locations: MapLocation[] = [];
   for (const [key, bucket] of buckets) {
     const [city, country] = key.split('|');
-    const lat = bucket.lats.reduce((a, b) => a + b, 0) / bucket.lats.length;
-    const lng = bucket.lngs.reduce((a, b) => a + b, 0) / bucket.lngs.length;
+    const lat = bucket.latSum / bucket.count;
+    const lng = bucket.lngSum / bucket.count;
     locations.push({
       city,
       country,


### PR DESCRIPTION
💡 What: Replaced array allocations (`lats`, `lngs`) with running accumulators (`latSum`, `lngSum`) in the map data bucketing logic.
🎯 Why: Storing an array of all coordinates in every map cluster scales memory usage linearly (O(N)) with the number of photos in that location. It also requires an expensive `.reduce` loop during final conversion. By tracking a running sum and count directly in the bucket, memory overhead becomes O(1).
📊 Impact: Considerably lowers memory usage when calculating map clusters for thousands of photos and removes O(N) computational complexity at the conversion step.
🔬 Measurement: Profile the node process memory footprint while running `getMapData()` on a gallery with a large dataset.

---
*PR created automatically by Jules for task [3950822618349650419](https://jules.google.com/task/3950822618349650419) started by @ralksta*