### PR TITLE
🎨 Palette: Improve PhotoGrid accessibility with ARIA attributes

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-26 - Interactive Card ARIA Labels
 **Learning:** When building interactive card components that contain multiple pieces of text or badges (like titles and photo counts), screen readers may announce them in a fragmented or confusing way.
 **Action:** Always apply a comprehensive `aria-label` to the parent link/container that encompasses all meaningful visual data (e.g., titles and item counts). Use `aria-hidden="true"` on redundant text or visual child elements, and set `alt=""` on decorative images to consolidate screen reader announcements into a single, accurate interaction point.
+
+## 2024-05-27 - Lightbox Trigger ARIA Attributes
+**Learning:** Interactive elements that trigger a modal or lightbox (such as image grid items) must include the `aria-haspopup="dialog"` attribute to correctly inform assistive technologies of their behavior.
+**Action:** When creating custom interactive items that open a dialog or lightbox, always ensure `aria-haspopup="dialog"` is present on the triggering element to provide proper context to screen reader users.

--- a/app/[...path]/PhotoGrid.tsx
+++ b/app/[...path]/PhotoGrid.tsx
@@ -155,6 +155,7 @@ export function PhotoGrid({ assets, layout = 'masonry', gridStyle }: PhotoGridPr
           role="button"
           tabIndex={0}
           aria-label={`View photo ${index + 1}`}
+          aria-haspopup="dialog"
           style={{
             ...(asset.dominantColor ? { backgroundColor: asset.dominantColor } : {}),
             ...((layout === 'masonry' || layout === 'showcase') && asset.aspectRatio
@@ -173,7 +174,7 @@ export function PhotoGrid({ assets, layout = 'masonry', gridStyle }: PhotoGridPr
               : {})}
           />
           {(asset.camera || asset.lens) && (
-            <div className="photo-grid__item-exif">
+            <div className="photo-grid__item-exif" aria-hidden="true">
               {[asset.camera, asset.lens, asset.focalLength].filter(Boolean).join(' · ')}
             </div>
           )}


### PR DESCRIPTION
💡 **What:** Added `aria-haspopup="dialog"` to the photo grid items and `aria-hidden="true"` to their inner EXIF data overlays.
🎯 **Why:** To improve the screen reader experience. The `aria-haspopup` attribute correctly informs assistive technologies that clicking the image will open a modal lightbox. Hiding the EXIF data overlay prevents fragmented and redundant screen reader announcements, as the parent element already provides a comprehensive `aria-label`.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Screen readers will now announce the grid items as triggering a dialog, and will not read the inner EXIF text redundantly, providing a cleaner and more accurate audible experience.

---
*PR created automatically by Jules for task [12156948782768741098](https://jules.google.com/task/12156948782768741098) started by @ralksta*