### PR TITLE
🎨 Palette: Improve PhotoGrid screen reader accessibility

### DIFF
--- a/app/[...path]/PhotoGrid.tsx
+++ b/app/[...path]/PhotoGrid.tsx
@@ -155,6 +155,7 @@ export function PhotoGrid({ assets, layout = 'masonry', gridStyle }: PhotoGridPr
           role="button"
           tabIndex={0}
           aria-label={`View photo ${index + 1}`}
+          aria-haspopup="dialog"
           style={{
             ...(asset.dominantColor ? { backgroundColor: asset.dominantColor } : {}),
             ...((layout === 'masonry' || layout === 'showcase') && asset.aspectRatio
@@ -173,7 +174,7 @@ export function PhotoGrid({ assets, layout = 'masonry', gridStyle }: PhotoGridPr
               : {})}
           />
           {(asset.camera || asset.lens) && (
-            <div className="photo-grid__item-exif">
+            <div className="photo-grid__item-exif" aria-hidden="true">
               {[asset.camera, asset.lens, asset.focalLength].filter(Boolean).join(' · ')}
             </div>
           )}


### PR DESCRIPTION
💡 What: Added `aria-haspopup="dialog"` to the photo grid item buttons and `aria-hidden="true"` to their inner EXIF data overlay.
🎯 Why: To properly inform assistive technologies that the photo grid items trigger a lightbox dialog, and to prevent screen readers from redundantly announcing the inner EXIF text alongside the item's `aria-label`.
📸 Before/After: N/A (Non-visual accessibility change)
♿ Accessibility: Ensures grid items are correctly identified as dialog triggers and consolidates screen reader announcements for interactive elements.

---
*PR created automatically by Jules for task [229903867177194839](https://jules.google.com/task/229903867177194839) started by @ralksta*