### PR TITLE
⚡ Bolt: Memoize auth checks in map data API

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -18,3 +18,6 @@
 ## 2024-05-30 - [O(1) Memory Bucketing for Coordinate Aggregation]
 **Learning:** When bucketing or grouping large datasets (e.g., thousands of map coordinates into geographical clusters), array allocations (`[].push()`) followed by `reduce` operations create an O(N) memory overhead per bucket and expensive post-processing loops.
 **Action:** Replace memory-heavy array collections with running statistical accumulators (e.g., `latSum`, `lngSum`, `count`) directly on the bucket. This reduces bucket memory from O(N) to O(1).
+## 2024-05-06 - Memoize Authentication Checks in Data Loops
+**Learning:** When filtering large datasets containing items that share the same authorization context (like albums sharing a `subpageSlug`), redundant authentication checks per item result in repetitive and expensive operations (like HMAC calculations).
+**Action:** Use a request-scoped `Map` to memoize the results of `isAuthenticated` within loops to eliminate redundant computations and improve performance.

--- a/app/api/map/route.ts
+++ b/app/api/map/route.ts
@@ -43,13 +43,22 @@ export async function GET(request: NextRequest) {
 
   const locations = await getMapData();
 
+  // Memoize auth checks to prevent redundant HMAC calculations
+  const authCache = new Map<string, boolean>();
+
   // Filter locations and albums based on auth
   const publicLocations = locations
     .map((loc) => {
       // Only keep albums the user is allowed to see
       const allowedAlbums = loc.albums.filter((a) => {
         if (!a.subpageSlug) return true; // Standalone albums are public
-        return isAuthenticated(a.subpageSlug, getCookie);
+
+        let isAuth = authCache.get(a.subpageSlug);
+        if (isAuth === undefined) {
+          isAuth = isAuthenticated(a.subpageSlug, getCookie);
+          authCache.set(a.subpageSlug, isAuth);
+        }
+        return isAuth;
       });
 
       if (allowedAlbums.length === 0) return null;


### PR DESCRIPTION
💡 What: Added a request-scoped `Map` to memoize the results of `isAuthenticated` within `app/api/map/route.ts`.
🎯 Why: When fetching and filtering locations for the map API, multiple albums can belong to the same subpage. Previously, `isAuthenticated` (which includes expensive HMAC operations) was called repeatedly for the same `subpageSlug`.
📊 Impact: Reduces repetitive HMAC calculations and configuration lookups during map data filtering, lowering CPU usage and speeding up the API response.
🔬 Measurement: Verified that tests pass and the logic handles both memoized hits and misses correctly.

---
*PR created automatically by Jules for task [8929724023177945951](https://jules.google.com/task/8929724023177945951) started by @ralksta*