### PR TITLE
⚡ Bolt: Memoize auth checks in map route

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -18,3 +18,7 @@
 ## 2024-05-30 - [O(1) Memory Bucketing for Coordinate Aggregation]
 **Learning:** When bucketing or grouping large datasets (e.g., thousands of map coordinates into geographical clusters), array allocations (`[].push()`) followed by `reduce` operations create an O(N) memory overhead per bucket and expensive post-processing loops.
 **Action:** Replace memory-heavy array collections with running statistical accumulators (e.g., `latSum`, `lngSum`, `count`) directly on the bucket. This reduces bucket memory from O(N) to O(1).
+
+## 2024-05-31 - [Memoize Repeated Auth Checks in Loops]
+**Learning:** Checking authentication inside a loop (like `Array.prototype.filter`) over a large dataset can trigger redundant, expensive operations such as cryptographic comparisons (e.g. `crypto.timingSafeEqual`) or repeated configuration reads, particularly when many items share the same authorization context (e.g., `subpageSlug`).
+**Action:** Use a local, request-scoped `Map` to memoize the result of authentication checks. Store the check result against the shared context key (e.g., the slug) so subsequent items with the same context bypass the expensive logic.

--- a/app/api/map/route.ts
+++ b/app/api/map/route.ts
@@ -43,13 +43,22 @@ export async function GET(request: NextRequest) {
 
   const locations = await getMapData();
 
+  // Memoize authentication results per subpage to avoid redundant HMAC calculations
+  // during the map/filter loops over potentially thousands of locations/albums.
+  const authCache = new Map<string, boolean>();
+
   // Filter locations and albums based on auth
   const publicLocations = locations
     .map((loc) => {
       // Only keep albums the user is allowed to see
       const allowedAlbums = loc.albums.filter((a) => {
         if (!a.subpageSlug) return true; // Standalone albums are public
-        return isAuthenticated(a.subpageSlug, getCookie);
+        let isAuth = authCache.get(a.subpageSlug);
+        if (isAuth === undefined) {
+          isAuth = isAuthenticated(a.subpageSlug, getCookie);
+          authCache.set(a.subpageSlug, isAuth);
+        }
+        return isAuth;
       });
 
       if (allowedAlbums.length === 0) return null;


### PR DESCRIPTION
💡 **What:** Memoized `isAuthenticated` checks within the `/api/map` location filtering loop.
🎯 **Why:** To prevent redundant and expensive cryptographic operations (`crypto.timingSafeEqual`) and configuration lookups inside `Array.prototype.filter` over thousands of map locations/albums sharing the same context (e.g., `subpageSlug`).
📊 **Impact:** Significantly reduces CPU overhead and latency on the `/api/map` endpoint for galleries with large map datasets.
🔬 **Measurement:** Verify that rendering the Map view functions correctly with and without password-protected subpages, and observe improved API response times.

---
*PR created automatically by Jules for task [4701396546647594039](https://jules.google.com/task/4701396546647594039) started by @ralksta*