### PR TITLE
🛡️ Sentinel: [HIGH] Fix Stored XSS in Image Proxy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -21,3 +21,8 @@
 **Vulnerability:** The plaintext password fallback logic incorrectly generated a recommended `scrypt` hash using the SHA256 hashed password rather than the raw `storedPassword`. This leads to generating an invalid `scrypt` hash that would fail authentication if the user updated their configuration with it. Furthermore, hashing variable-length secrets with SHA256 before `crypto.timingSafeEqual` prevents timing attacks, but using a non-keyed hash like SHA256 may leave it vulnerable. HMAC-SHA256 keyed with a secret provides better security.
 **Learning:** When generating a secure hash recommendation for users migrating from plaintext, ensure the raw input is used, not an intermediate hash intended for timing-safe comparison.
 **Prevention:** Generate the `scrypt` hash directly from the raw secret string (`storedPassword`). Always use HMAC keyed with a secret for hashing variable-length passwords prior to constant-time comparison.
+
+## 2026-05-09 - Stored XSS in API Routes bypassing CSP
+**Vulnerability:** The `/api/image/[id]` proxy endpoint blindly trusted and reflected the upstream `Content-Type` from Immich. Because Next.js global CSP typically excludes `/api/*` routes, an attacker uploading an SVG or XML could achieve Stored XSS.
+**Learning:** API proxy routes that serve user-uploaded content but are exempt from the global CSP are highly vulnerable to Stored XSS if `Content-Type` headers are not strictly validated.
+**Prevention:** Always enforce strict `Content-Type` allowlists (e.g., `image/jpeg`, `video/mp4`) on proxy endpoints. Block or downgrade potentially executable MIME types (`svg`, `xml`, `html`) to `application/octet-stream`.

--- a/app/api/image/[id]/route.ts
+++ b/app/api/image/[id]/route.ts
@@ -81,10 +81,24 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     return NextResponse.json({ error: 'Asset not found' }, { status: 404 });
   }
 
+  // 🛡️ SECURITY: Prevent Stored XSS by enforcing strict Content-Type validation
+  // API routes are excluded from CSP, so we must block potentially executable types
+  let safeContentType = result.contentType;
+  if (safeContentType.includes('application/octet-stream')) {
+    safeContentType = 'image/jpeg';
+  }
+
+  if (
+    safeContentType.includes('svg') ||
+    safeContentType.includes('xml') ||
+    safeContentType.includes('html') ||
+    (!safeContentType.startsWith('image/') && !safeContentType.startsWith('video/'))
+  ) {
+    safeContentType = 'application/octet-stream';
+  }
+
   const headers: Record<string, string> = {
-    'Content-Type': result.contentType.includes('application/octet-stream')
-      ? 'image/jpeg'
-      : result.contentType,
+    'Content-Type': safeContentType,
     // Images are immutable once uploaded to Immich — cache aggressively
     'Cache-Control': 'public, max-age=31536000, immutable',
     ETag: etag,


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `/api/image/[id]` proxy endpoint blindly trusted and reflected the upstream `Content-Type` from Immich without validation. Because Next.js global CSP excludes API routes, an attacker uploading an SVG, XML, or HTML file could bypass CSP and execute malicious scripts.
🎯 Impact: An attacker could achieve Stored Cross-Site Scripting (XSS) by uploading a malicious SVG file to Immich and accessing it via the application's proxy, potentially stealing user sessions or modifying data.
🔧 Fix: Implemented strict `Content-Type` validation. If the returned type contains executable formats (`svg`, `xml`, `html`) or is not an `image/` or `video/`, it is safely downgraded to `application/octet-stream`.
✅ Verification: Ran `pnpm exec eslint` and `pnpm test` successfully.

---
*PR created automatically by Jules for task [5191412472979989629](https://jules.google.com/task/5191412472979989629) started by @ralksta*