### PR TITLE
⚡ Bolt: Memoize authorization checks in map route

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -18,3 +18,6 @@
 ## 2024-05-30 - [O(1) Memory Bucketing for Coordinate Aggregation]
 **Learning:** When bucketing or grouping large datasets (e.g., thousands of map coordinates into geographical clusters), array allocations (`[].push()`) followed by `reduce` operations create an O(N) memory overhead per bucket and expensive post-processing loops.
 **Action:** Replace memory-heavy array collections with running statistical accumulators (e.g., `latSum`, `lngSum`, `count`) directly on the bucket. This reduces bucket memory from O(N) to O(1).
+## 2026-05-09 - [Memoize repetitive authorization checks]
+**Learning:** When processing data collections where multiple items share the same authorization context (e.g., `subpageSlug`), evaluating the auth check repeatedly causes redundant expensive operations like HMAC calculations and configuration lookups.
+**Action:** Use a request-scoped `Map` to memoize `isAuthenticated` results. This avoids redundant expensive operations within map/filter loops.

--- a/app/api/map/route.ts
+++ b/app/api/map/route.ts
@@ -43,13 +43,21 @@ export async function GET(request: NextRequest) {
 
   const locations = await getMapData();
 
+  // ⚡ Bolt: Memoize auth checks to avoid redundant HMAC calculations
+  const authCache = new Map<string, boolean>();
+
   // Filter locations and albums based on auth
   const publicLocations = locations
     .map((loc) => {
       // Only keep albums the user is allowed to see
       const allowedAlbums = loc.albums.filter((a) => {
         if (!a.subpageSlug) return true; // Standalone albums are public
-        return isAuthenticated(a.subpageSlug, getCookie);
+        let isAuth = authCache.get(a.subpageSlug);
+        if (isAuth === undefined) {
+          isAuth = isAuthenticated(a.subpageSlug, getCookie);
+          authCache.set(a.subpageSlug, isAuth);
+        }
+        return isAuth;
       });
 
       if (allowedAlbums.length === 0) return null;


### PR DESCRIPTION
💡 What: Added a request-scoped Map to memoize `isAuthenticated` results in the `/api/map` route.
🎯 Why: Prevent redundant HMAC calculations and configuration lookups when processing large arrays of location data where multiple items share the same `subpageSlug`.
📊 Impact: Eliminates duplicate, expensive cryptographic operations during the map/filter loop.
🔬 Measurement: Profile the `/api/map` endpoint response time before and after for galleries with hundreds of albums.

---
*PR created automatically by Jules for task [15780689810271399309](https://jules.google.com/task/15780689810271399309) started by @ralksta*