### PR TITLE
⚡ Bolt: Memoize auth checks in map data

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -18,3 +18,6 @@
 ## 2024-05-30 - [O(1) Memory Bucketing for Coordinate Aggregation]
 **Learning:** When bucketing or grouping large datasets (e.g., thousands of map coordinates into geographical clusters), array allocations (`[].push()`) followed by `reduce` operations create an O(N) memory overhead per bucket and expensive post-processing loops.
 **Action:** Replace memory-heavy array collections with running statistical accumulators (e.g., `latSum`, `lngSum`, `count`) directly on the bucket. This reduces bucket memory from O(N) to O(1).
+## 2024-05-31 - [Memoize expensive auth checks in map loops]
+**Learning:** When processing data collections where multiple items share the same authorization context (e.g., `subpageSlug`), repeating `isAuthenticated` checks for every item causes redundant and expensive operations like HMAC calculations and configuration lookups.
+**Action:** Use a request-scoped `Map` to memoize `isAuthenticated` results. This avoids recalculations within map/filter loops and improves response times for large datasets.

--- a/app/api/map/route.ts
+++ b/app/api/map/route.ts
@@ -44,12 +44,22 @@ export async function GET(request: NextRequest) {
   const locations = await getMapData();
 
   // Filter locations and albums based on auth
+  // ⚡ Bolt: Memoize isAuthenticated checks to avoid redundant HMAC calculations
+  // across thousands of location markers sharing the same subpage context.
+  const authCache = new Map<string, boolean>();
+
   const publicLocations = locations
     .map((loc) => {
       // Only keep albums the user is allowed to see
       const allowedAlbums = loc.albums.filter((a) => {
         if (!a.subpageSlug) return true; // Standalone albums are public
-        return isAuthenticated(a.subpageSlug, getCookie);
+
+        let isAuth = authCache.get(a.subpageSlug);
+        if (isAuth === undefined) {
+          isAuth = isAuthenticated(a.subpageSlug, getCookie);
+          authCache.set(a.subpageSlug, isAuth);
+        }
+        return isAuth;
       });
 
       if (allowedAlbums.length === 0) return null;


### PR DESCRIPTION
💡 What: Added a request-scoped Map to memoize `isAuthenticated` checks in the map locations filter.
🎯 Why: To avoid redundant HMAC calculations and config lookups for items sharing the same authorization context (e.g., `subpageSlug`).
📊 Impact: Significantly reduces processing time for map data endpoints when dealing with thousands of locations, improving response times.
🔬 Measurement: Can be verified by measuring the execution time of `app/api/map/route.ts` with thousands of locations.

---
*PR created automatically by Jules for task [5348834987934139398](https://jules.google.com/task/5348834987934139398) started by @ralksta*