### PR TITLE
⚡ Bolt: Memoize request-scoped authorization checks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -18,3 +18,6 @@
 ## 2024-05-30 - [O(1) Memory Bucketing for Coordinate Aggregation]
 **Learning:** When bucketing or grouping large datasets (e.g., thousands of map coordinates into geographical clusters), array allocations (`[].push()`) followed by `reduce` operations create an O(N) memory overhead per bucket and expensive post-processing loops.
 **Action:** Replace memory-heavy array collections with running statistical accumulators (e.g., `latSum`, `lngSum`, `count`) directly on the bucket. This reduces bucket memory from O(N) to O(1).
+## 2024-05-31 - [Memoize request-scoped authorization checks]
+**Learning:** In collections where multiple items share an authorization context (like albums within subpages), running `isAuthenticated` inside map/filter loops redundantly executes expensive HMAC calculations and configuration lookups per item.
+**Action:** Use a request-scoped `Map` to memoize `isAuthenticated` results for each context (e.g., `subpageSlug`), reducing expensive crypto operations from O(N) to O(unique_contexts).

--- a/app/api/map/route.ts
+++ b/app/api/map/route.ts
@@ -43,13 +43,22 @@ export async function GET(request: NextRequest) {
 
   const locations = await getMapData();
 
+  // ⚡ Bolt: Memoize expensive auth checks (HMAC calculations) per subpage
+  // to prevent redundant computations when multiple albums share a subpage.
+  const authCache = new Map<string, boolean>();
+
   // Filter locations and albums based on auth
   const publicLocations = locations
     .map((loc) => {
       // Only keep albums the user is allowed to see
       const allowedAlbums = loc.albums.filter((a) => {
         if (!a.subpageSlug) return true; // Standalone albums are public
-        return isAuthenticated(a.subpageSlug, getCookie);
+        let isAuth = authCache.get(a.subpageSlug);
+        if (isAuth === undefined) {
+          isAuth = isAuthenticated(a.subpageSlug, getCookie);
+          authCache.set(a.subpageSlug, isAuth);
+        }
+        return isAuth;
       });
 
       if (allowedAlbums.length === 0) return null;


### PR DESCRIPTION
💡 What: Added a request-scoped Map to memoize `isAuthenticated` checks for subpages in the map API route.
🎯 Why: Prevents redundant HMAC crypto calculations and configuration lookups when multiple map locations belong to the same subpage.
📊 Impact: Reduces CPU overhead on the API route from O(N) (where N is the number of locations mapped) to O(U) (where U is unique subpages).
🔬 Measurement: Verify by navigating to the map view with many albums in shared subpages and observing a reduction in TTFB on `/api/map`.

---
*PR created automatically by Jules for task [3523997745022111142](https://jules.google.com/task/3523997745022111142) started by @ralksta*