### PR TITLE
🛡️ Sentinel: [HIGH] Fix Stored XSS in Image Proxy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -21,3 +21,8 @@
 **Vulnerability:** The plaintext password fallback logic incorrectly generated a recommended `scrypt` hash using the SHA256 hashed password rather than the raw `storedPassword`. This leads to generating an invalid `scrypt` hash that would fail authentication if the user updated their configuration with it. Furthermore, hashing variable-length secrets with SHA256 before `crypto.timingSafeEqual` prevents timing attacks, but using a non-keyed hash like SHA256 may leave it vulnerable. HMAC-SHA256 keyed with a secret provides better security.
 **Learning:** When generating a secure hash recommendation for users migrating from plaintext, ensure the raw input is used, not an intermediate hash intended for timing-safe comparison.
 **Prevention:** Generate the `scrypt` hash directly from the raw secret string (`storedPassword`). Always use HMAC keyed with a secret for hashing variable-length passwords prior to constant-time comparison.
+
+## 2024-05-12 - [Strict Content-Type Validation for Stored XSS Prevention]
+**Vulnerability:** The image proxy API endpoint served user-uploaded content (like SVGs or HTML) with its original content type, which could execute malicious scripts since API routes are excluded from Next.js CSP.
+**Learning:** Endpoints proxying user-generated files must strictly validate and sanitize the `Content-Type` header (forcing safe types or falling back to `application/octet-stream`) to prevent Stored XSS.
+**Prevention:** Always implement an explicit allowlist or strict fallback logic for `Content-Type` headers on proxied user content, evaluating positive mappings before negative fallbacks.

--- a/app/api/image/[id]/route.ts
+++ b/app/api/image/[id]/route.ts
@@ -81,10 +81,19 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     return NextResponse.json({ error: 'Asset not found' }, { status: 404 });
   }
 
+  let safeContentType = result.contentType;
+  if (safeContentType.includes('application/octet-stream')) {
+    safeContentType = 'image/jpeg';
+  } else if (
+    safeContentType.includes('svg') ||
+    safeContentType.includes('xml') ||
+    (!safeContentType.startsWith('image/') && !safeContentType.startsWith('video/'))
+  ) {
+    safeContentType = 'application/octet-stream';
+  }
+
   const headers: Record<string, string> = {
-    'Content-Type': result.contentType.includes('application/octet-stream')
-      ? 'image/jpeg'
-      : result.contentType,
+    'Content-Type': safeContentType,
     // Images are immutable once uploaded to Immich — cache aggressively
     'Cache-Control': 'public, max-age=31536000, immutable',
     ETag: etag,


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The image proxy endpoint allowed serving user-uploaded SVGs and HTML without sanitizing the Content-Type, leading to Stored XSS since `/api/*` routes are excluded from the CSP.
🎯 Impact: An attacker could upload a malicious SVG or HTML file disguised as an image, and when viewed through the proxy, it could execute arbitrary JavaScript in the victim's browser within the application's origin context.
🔧 Fix: Implemented strict Content-Type sanitization. Dangerous types (`svg`, `xml`) and non-media types are explicitly fallen back to `application/octet-stream`, while preserving intended types like `image/jpeg`.
✅ Verification: Verified code handles malicious content types safely and passes lint and test suites.

---
*PR created automatically by Jules for task [7455847763669629202](https://jules.google.com/task/7455847763669629202) started by @ralksta*