### PR TITLE
⚡ Bolt: Memoize expensive auth checks in map route

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -18,3 +18,6 @@
 ## 2024-05-30 - [O(1) Memory Bucketing for Coordinate Aggregation]
 **Learning:** When bucketing or grouping large datasets (e.g., thousands of map coordinates into geographical clusters), array allocations (`[].push()`) followed by `reduce` operations create an O(N) memory overhead per bucket and expensive post-processing loops.
 **Action:** Replace memory-heavy array collections with running statistical accumulators (e.g., `latSum`, `lngSum`, `count`) directly on the bucket. This reduces bucket memory from O(N) to O(1).
+## 2024-05-31 - [Memoize expensive auth checks in map/filter loops]
+**Learning:** When processing data collections where multiple items share the same authorization context (e.g., `subpageSlug`), repeatedly calling `isAuthenticated` inside map/filter loops causes redundant expensive operations like HMAC calculations and configuration lookups.
+**Action:** Use a request-scoped `Map` to memoize `isAuthenticated` results.

--- a/app/api/map/route.ts
+++ b/app/api/map/route.ts
@@ -43,13 +43,19 @@ export async function GET(request: NextRequest) {
 
   const locations = await getMapData();
 
+  // Memoize auth checks per request to avoid redundant expensive HMAC operations
+  const authCache = new Map<string, boolean>();
+
   // Filter locations and albums based on auth
   const publicLocations = locations
     .map((loc) => {
       // Only keep albums the user is allowed to see
       const allowedAlbums = loc.albums.filter((a) => {
         if (!a.subpageSlug) return true; // Standalone albums are public
-        return isAuthenticated(a.subpageSlug, getCookie);
+        if (authCache.has(a.subpageSlug)) return authCache.get(a.subpageSlug);
+        const authed = isAuthenticated(a.subpageSlug, getCookie);
+        authCache.set(a.subpageSlug, authed);
+        return authed;
       });
 
       if (allowedAlbums.length === 0) return null;


### PR DESCRIPTION
💡 What: Memoized the result of isAuthenticated in the map route.
🎯 Why: Repeatedly calling isAuthenticated inside map/filter loops causes redundant expensive operations like HMAC calculations and configuration lookups.
📊 Impact: Reduces CPU time when loading the map data by preventing duplicate password checking for the same subpages.
🔬 Measurement: Verify loading time of /api/map or the map UI.

---
*PR created automatically by Jules for task [5113555517869972513](https://jules.google.com/task/5113555517869972513) started by @ralksta*