### PR TITLE
🎨 Palette: [UX improvement] Add screen reader announcements for Lightbox navigation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-13 - Lightbox Image Counter Announcements
+**Learning:** Screen readers do not announce numeric text changes like "1 / 5" by default when users navigate images in a custom modal or lightbox.
+**Action:** Add `aria-live="polite"` and `aria-atomic="true"` with visually hidden, context-rich text (e.g., "Photo 1 of 5") to image counters to ensure seamless accessibility for keyboard/swipe navigation.

--- a/components/Lightbox.tsx
+++ b/components/Lightbox.tsx
@@ -200,8 +200,23 @@ export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev }: Ligh
       </button>
 
       {/* Counter */}
-      <div className={styles.counter}>
-        {currentIndex + 1} / {assets.length}
+      <div className={styles.counter} aria-live="polite" aria-atomic="true">
+        <span
+          style={{
+            position: 'absolute',
+            width: 1,
+            height: 1,
+            overflow: 'hidden',
+            clip: 'rect(0, 0, 0, 0)',
+            whiteSpace: 'nowrap',
+            borderWidth: 0,
+          }}
+        >
+          Photo {currentIndex + 1} of {assets.length}
+        </span>
+        <span aria-hidden="true">
+          {currentIndex + 1} / {assets.length}
+        </span>
       </div>
 
       {/* EXIF toggle */}


### PR DESCRIPTION
💡 **What:** Added `aria-live="polite"` and `aria-atomic="true"` to the Lightbox image counter, along with visually hidden contextual text ("Photo X of Y").
🎯 **Why:** Screen readers previously did not announce when the active photo changed via keyboard navigation (Left/Right arrows) or swiping. This update ensures users are seamlessly aware of their current position in the gallery.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Users relying on screen readers now receive explicit updates ("Photo 2 of 10") instead of silence or confusing fragmented numeric reads when changing images.

---
*PR created automatically by Jules for task [10145328160544705](https://jules.google.com/task/10145328160544705) started by @ralksta*