### PR TITLE
🎨 Palette: [UX improvement] Lightbox Counter Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-26 - Interactive Card ARIA Labels
 **Learning:** When building interactive card components that contain multiple pieces of text or badges (like titles and photo counts), screen readers may announce them in a fragmented or confusing way.
 **Action:** Always apply a comprehensive `aria-label` to the parent link/container that encompasses all meaningful visual data (e.g., titles and item counts). Use `aria-hidden="true"` on redundant text or visual child elements, and set `alt=""` on decorative images to consolidate screen reader announcements into a single, accurate interaction point.
+
+## 2026-05-14 - Lightbox Counter Accessibility
+**Learning:** To ensure screen readers correctly announce numeric text changes during navigation (like '1 / 5' in a lightbox counter), wrapping the counter in an element with `aria-live="polite"` and `aria-atomic="true"`, and including a visually hidden span with context-rich text (e.g., 'Photo 1 of 5') is required.
+**Action:** When building custom counters or pagination displays, always use `aria-live` regions and context-rich hidden text instead of relying on the raw numeric string.

--- a/components/Lightbox.tsx
+++ b/components/Lightbox.tsx
@@ -200,8 +200,23 @@ export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev }: Ligh
       </button>
 
       {/* Counter */}
-      <div className={styles.counter}>
-        {currentIndex + 1} / {assets.length}
+      <div className={styles.counter} aria-live="polite" aria-atomic="true">
+        <span
+          style={{
+            position: 'absolute',
+            width: 1,
+            height: 1,
+            overflow: 'hidden',
+            clip: 'rect(0, 0, 0, 0)',
+            whiteSpace: 'nowrap',
+            borderWidth: 0,
+          }}
+        >
+          Photo {currentIndex + 1} of {assets.length}
+        </span>
+        <span aria-hidden="true">
+          {currentIndex + 1} / {assets.length}
+        </span>
       </div>
 
       {/* EXIF toggle */}


### PR DESCRIPTION
💡 What: Added `aria-live="polite"` and context-rich hidden text to the Lightbox photo counter.
🎯 Why: Screen readers would previously announce raw numbers like "1 slash 5" when navigating photos, which lacks context. The counter is now announced as "Photo 1 of 5" as the user navigates, improving the experience.
📸 Before/After: Visuals remain unchanged.
♿ Accessibility: Screen reader users now get a clear, context-rich announcement of their position within the photo gallery.

---
*PR created automatically by Jules for task [3259265952749094845](https://jules.google.com/task/3259265952749094845) started by @ralksta*