### PR TITLE
⚡ Bolt: Memoize auth checks in map data API

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -18,3 +18,7 @@
 ## 2024-05-30 - [O(1) Memory Bucketing for Coordinate Aggregation]
 **Learning:** When bucketing or grouping large datasets (e.g., thousands of map coordinates into geographical clusters), array allocations (`[].push()`) followed by `reduce` operations create an O(N) memory overhead per bucket and expensive post-processing loops.
 **Action:** Replace memory-heavy array collections with running statistical accumulators (e.g., `latSum`, `lngSum`, `count`) directly on the bucket. This reduces bucket memory from O(N) to O(1).
+
+## 2024-05-30 - [Memoize repetitive auth checks in loops]
+**Learning:** When processing data collections where multiple items share the same authorization context (e.g., `subpageSlug`), redundant expensive operations like HMAC calculations and configuration lookups occur within map/filter loops.
+**Action:** Use a request-scoped `Map` to memoize `isAuthenticated` results based on the authorization context.

--- a/app/api/map/route.ts
+++ b/app/api/map/route.ts
@@ -43,13 +43,22 @@ export async function GET(request: NextRequest) {
 
   const locations = await getMapData();
 
+  // Memoize auth checks per request to prevent redundant HMAC calculations
+  const authMemo = new Map<string, boolean>();
+
   // Filter locations and albums based on auth
   const publicLocations = locations
     .map((loc) => {
       // Only keep albums the user is allowed to see
       const allowedAlbums = loc.albums.filter((a) => {
         if (!a.subpageSlug) return true; // Standalone albums are public
-        return isAuthenticated(a.subpageSlug, getCookie);
+
+        if (authMemo.has(a.subpageSlug)) {
+          return authMemo.get(a.subpageSlug);
+        }
+        const isAuth = isAuthenticated(a.subpageSlug, getCookie);
+        authMemo.set(a.subpageSlug, isAuth);
+        return isAuth;
       });
 
       if (allowedAlbums.length === 0) return null;

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -33,12 +33,7 @@ export function getClientIp(request: NextRequest): string {
 
   // Fallback for self-hosted environments without explicit trusted proxies:
   // We have to trust headers as a best-effort, but this is vulnerable to spoofing.
-  return (
-    directIp ??
-    xRealIp ??
-    xForwardedFor?.split(',')[0].trim() ??
-    'unknown'
-  );
+  return directIp ?? xRealIp ?? xForwardedFor?.split(',')[0].trim() ?? 'unknown';
 }
 
 interface RateLimitEntry {


### PR DESCRIPTION
💡 What: Added a request-scoped `Map` to memoize the result of `isAuthenticated` checks for `subpageSlug`s during the processing of map location markers in `app/api/map/route.ts`.
🎯 Why: The original implementation performed redundant HMAC calculations and configuration lookups for every album belonging to the same subpage, which could cause a bottleneck when processing large numbers of albums.
📊 Impact: Reduces redundant HMAC calculations and CPU cycles when multiple albums share the same subpage, making the map data API generation faster.
🔬 Measurement: Expected faster response times for the `/api/map` endpoint when containing large volumes of photos grouped by subpages.

---
*PR created automatically by Jules for task [9411585527470689210](https://jules.google.com/task/9411585527470689210) started by @ralksta*