### PR TITLE
🛡️ Sentinel: [HIGH] Fix Stored XSS in Image Proxy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -21,3 +21,8 @@
 **Vulnerability:** The plaintext password fallback logic incorrectly generated a recommended `scrypt` hash using the SHA256 hashed password rather than the raw `storedPassword`. This leads to generating an invalid `scrypt` hash that would fail authentication if the user updated their configuration with it. Furthermore, hashing variable-length secrets with SHA256 before `crypto.timingSafeEqual` prevents timing attacks, but using a non-keyed hash like SHA256 may leave it vulnerable. HMAC-SHA256 keyed with a secret provides better security.
 **Learning:** When generating a secure hash recommendation for users migrating from plaintext, ensure the raw input is used, not an intermediate hash intended for timing-safe comparison.
 **Prevention:** Generate the `scrypt` hash directly from the raw secret string (`storedPassword`). Always use HMAC keyed with a secret for hashing variable-length passwords prior to constant-time comparison.
+
+## 2024-05-24 - API Routes Excluded from Next.js CSP
+**Vulnerability:** Stored XSS via Image Proxy Content-Type bypass.
+**Learning:** The Content Security Policy (CSP) defined in `middleware.ts` uses a matcher that excludes API routes (`/api/*`). Therefore, endpoints serving user-controlled content (like `app/api/image/[id]/route.ts`) are not protected by CSP and must strictly validate `Content-Type`.
+**Prevention:** Implement strict positive validation of `Content-Type` headers in API routes (e.g., blocking `svg`/`xml`, enforcing `image/` or `video/`, falling back to `application/octet-stream`) using lowercase normalization to prevent case-sensitive bypasses.

--- a/app/api/image/[id]/route.ts
+++ b/app/api/image/[id]/route.ts
@@ -81,10 +81,17 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     return NextResponse.json({ error: 'Asset not found' }, { status: 404 });
   }
 
+  let safeContentType = result.contentType.toLowerCase();
+  if (safeContentType.includes('application/octet-stream')) {
+    safeContentType = 'image/jpeg';
+  } else if (safeContentType.includes('svg') || safeContentType.includes('xml')) {
+    safeContentType = 'application/octet-stream';
+  } else if (!safeContentType.startsWith('image/') && !safeContentType.startsWith('video/')) {
+    safeContentType = 'application/octet-stream';
+  }
+
   const headers: Record<string, string> = {
-    'Content-Type': result.contentType.includes('application/octet-stream')
-      ? 'image/jpeg'
-      : result.contentType,
+    'Content-Type': safeContentType,
     // Images are immutable once uploaded to Immich — cache aggressively
     'Cache-Control': 'public, max-age=31536000, immutable',
     ETag: etag,


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Stored XSS via unsanitized Content-Type in image proxy endpoint (`app/api/image/[id]/route.ts`).
🎯 Impact: Attackers could upload malicious SVG or HTML files disguised as images, which would be served directly from our API domain, bypassing the Next.js Content Security Policy (which excludes `/api/*` routes). This could lead to account takeover or data theft.
🔧 Fix: Implemented strict, case-insensitive `Content-Type` validation. Blocked `svg` and `xml`, enforced `image/` or `video/` prefixes, and defaulted to `application/octet-stream` for unknown or malicious types.
✅ Verification: Review the code changes. Run `pnpm lint` and `pnpm test`.

---
*PR created automatically by Jules for task [4694760567006145505](https://jules.google.com/task/4694760567006145505) started by @ralksta*