### PR TITLE
🎨 Palette: Add accessible screen reader announcement for Lightbox counter

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-05-15 - Add accessible announcements to dynamic pagination counters
+**Learning:** Numeric state changes (like '1 / 5') in dynamic carousels or lightboxes aren't meaningfully announced to screen readers during navigation, leading to a loss of context.
+**Action:** Wrap dynamic counters in `aria-live="polite"` and `aria-atomic="true"`, providing a visually hidden, context-rich string (e.g., "Photo 1 of 5") while hiding the raw numbers (`aria-hidden="true"`) to prevent disjointed reading.

--- a/components/Lightbox.tsx
+++ b/components/Lightbox.tsx
@@ -200,8 +200,23 @@ export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev }: Ligh
       </button>
 
       {/* Counter */}
-      <div className={styles.counter}>
-        {currentIndex + 1} / {assets.length}
+      <div className={styles.counter} aria-live="polite" aria-atomic="true">
+        <span
+          style={{
+            position: 'absolute',
+            width: 1,
+            height: 1,
+            overflow: 'hidden',
+            clip: 'rect(0, 0, 0, 0)',
+            whiteSpace: 'nowrap',
+            borderWidth: 0,
+          }}
+        >
+          Photo {currentIndex + 1} of {assets.length}
+        </span>
+        <span aria-hidden="true">
+          {currentIndex + 1} / {assets.length}
+        </span>
       </div>
 
       {/* EXIF toggle */}

--- a/docs/gallery-config.md
+++ b/docs/gallery-config.md
@@ -193,26 +193,27 @@ Your bio text here. Supports full Markdown.
 
 - **Album UUIDs**: In Immich, go to Albums → click an album → the UUID is in the URL bar
 - **Asset UUIDs**: Click any photo → the UUID is in the URL bar
- 
+
 ## System & Security
- 
+
 Advanced system settings are configured via environment variables in your `.env` or `.env.local` file.
- 
+
 ### Rate Limiting
- 
+
 To protect against brute-force attacks and resource exhaustion, Immich Folio includes an in-memory rate limiter.
- 
+
 - `RATE_LIMIT_RPM`: Maximum requests per minute per IP (default: `1500` for general API, `120` for map data).
- 
+
 ### Trusted Proxies
- 
+
 If you are running Immich Folio behind a reverse proxy (like Nginx, Traefik, Caddy, or Cloudflare), you should configure trusted proxies to prevent IP spoofing.
- 
+
 - `TRUSTED_PROXIES`: A comma-separated list of IP addresses of your proxies.
- 
+
 Example:
+
 ```bash
 TRUSTED_PROXIES=127.0.0.1,172.18.0.1
 ```
- 
+
 When set, the rate limiter will only trust `X-Forwarded-For` and `X-Real-IP` headers if the request directly comes from one of these IPs. If not set, headers are trusted as a best-effort, which is less secure in public-facing environments.

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -33,12 +33,7 @@ export function getClientIp(request: NextRequest): string {
 
   // Fallback for self-hosted environments without explicit trusted proxies:
   // We have to trust headers as a best-effort, but this is vulnerable to spoofing.
-  return (
-    directIp ??
-    xRealIp ??
-    xForwardedFor?.split(',')[0].trim() ??
-    'unknown'
-  );
+  return directIp ?? xRealIp ?? xForwardedFor?.split(',')[0].trim() ?? 'unknown';
 }
 
 interface RateLimitEntry {


### PR DESCRIPTION
💡 What: Added `aria-live="polite"` and `aria-atomic="true"` to the Lightbox photo counter, wrapping the raw text in `aria-hidden` and providing a visually hidden, context-rich string (e.g., "Photo 1 of 5").
🎯 Why: Screen readers previously lacked context when navigating photos, often reading just disconnected numbers.
📸 Before/After: Visuals are unchanged (visually hidden text using inline styles).
♿ Accessibility: Drastically improves the auditory experience for screen reader users by clearly announcing photo progression during keyboard navigation.

---
*PR created automatically by Jules for task [12393998152090979705](https://jules.google.com/task/12393998152090979705) started by @ralksta*