### PR TITLE
⚡ Bolt: Memoize map auth checks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -18,3 +18,7 @@
 ## 2024-05-30 - [O(1) Memory Bucketing for Coordinate Aggregation]
 **Learning:** When bucketing or grouping large datasets (e.g., thousands of map coordinates into geographical clusters), array allocations (`[].push()`) followed by `reduce` operations create an O(N) memory overhead per bucket and expensive post-processing loops.
 **Action:** Replace memory-heavy array collections with running statistical accumulators (e.g., `latSum`, `lngSum`, `count`) directly on the bucket. This reduces bucket memory from O(N) to O(1).
+
+## 2024-05-31 - [Memoize request-scoped auth checks]
+**Learning:** When processing data collections where multiple items share the same authorization context (e.g., subpageSlug), redundant `isAuthenticated` calls cause expensive operations like HMAC calculations and configuration lookups to be repeated.
+**Action:** Use a request-scoped `Map` to memoize `isAuthenticated` results within map/filter loops, avoiding redundant cryptographic operations and improving API performance.

--- a/app/api/map/route.ts
+++ b/app/api/map/route.ts
@@ -43,13 +43,25 @@ export async function GET(request: NextRequest) {
 
   const locations = await getMapData();
 
+  // ⚡ Bolt: Memoize auth checks to avoid redundant HMAC calculations
+  // when multiple locations/albums share the same subpage slug.
+  const authCache = new Map<string, boolean>();
+  const isSubpageAuthenticated = (slug: string) => {
+    let result = authCache.get(slug);
+    if (result === undefined) {
+      result = isAuthenticated(slug, getCookie);
+      authCache.set(slug, result);
+    }
+    return result;
+  };
+
   // Filter locations and albums based on auth
   const publicLocations = locations
     .map((loc) => {
       // Only keep albums the user is allowed to see
       const allowedAlbums = loc.albums.filter((a) => {
         if (!a.subpageSlug) return true; // Standalone albums are public
-        return isAuthenticated(a.subpageSlug, getCookie);
+        return isSubpageAuthenticated(a.subpageSlug);
       });
 
       if (allowedAlbums.length === 0) return null;


### PR DESCRIPTION
💡 What: Implemented a request-scoped `Map` in `app/api/map/route.ts` to memoize `isAuthenticated` calls.
🎯 Why: To prevent redundant, expensive HMAC-SHA256 calculations and configuration array lookups when checking authorization for thousands of map markers that share the same `subpageSlug`.
📊 Impact: Reduces redundant cryptographic operations from O(N) per map marker to O(1) per subpage context, significantly speeding up the Map API response for large datasets.
🔬 Measurement: Check the map data endpoint performance via `/api/map` with large numbers of geotagged assets.

---
*PR created automatically by Jules for task [5595557198699578797](https://jules.google.com/task/5595557198699578797) started by @ralksta*