### PR TITLE
⚡ Bolt: Memoize isAuthenticated in API map route

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -18,3 +18,7 @@
 ## 2024-05-30 - [O(1) Memory Bucketing for Coordinate Aggregation]
 **Learning:** When bucketing or grouping large datasets (e.g., thousands of map coordinates into geographical clusters), array allocations (`[].push()`) followed by `reduce` operations create an O(N) memory overhead per bucket and expensive post-processing loops.
 **Action:** Replace memory-heavy array collections with running statistical accumulators (e.g., `latSum`, `lngSum`, `count`) directly on the bucket. This reduces bucket memory from O(N) to O(1).
+
+## 2024-05-31 - [Memoize Request-Scoped Authentication Results]
+**Learning:** When filtering large datasets (like map locations) where multiple items share the same authorization context (e.g., `subpageSlug`), evaluating `isAuthenticated` on each item leads to redundant and expensive HMAC calculations and config lookups.
+**Action:** Use a request-scoped `Map` to memoize the results of `isAuthenticated` within map/filter loops, avoiding redundant processing and improving response performance.

--- a/app/api/map/route.ts
+++ b/app/api/map/route.ts
@@ -44,12 +44,18 @@ export async function GET(request: NextRequest) {
   const locations = await getMapData();
 
   // Filter locations and albums based on auth
+  const authCache = new Map<string, boolean>();
+
   const publicLocations = locations
     .map((loc) => {
       // Only keep albums the user is allowed to see
       const allowedAlbums = loc.albums.filter((a) => {
         if (!a.subpageSlug) return true; // Standalone albums are public
-        return isAuthenticated(a.subpageSlug, getCookie);
+
+        if (!authCache.has(a.subpageSlug)) {
+          authCache.set(a.subpageSlug, isAuthenticated(a.subpageSlug, getCookie));
+        }
+        return authCache.get(a.subpageSlug)!;
       });
 
       if (allowedAlbums.length === 0) return null;


### PR DESCRIPTION
* 💡 What: Introduced a request-scoped `Map` (`authCache`) in `app/api/map/route.ts` to memoize the result of `isAuthenticated(subpageSlug)`.
* 🎯 Why: When processing large numbers of albums and locations for the map, many albums share the same `subpageSlug`. Previously, `isAuthenticated`—which performs HMAC token generation and verification—was called for each album. This change ensures it's only called once per unique subpage per request.
* 📊 Impact: Significantly reduces CPU overhead during map data generation by avoiding redundant crypto operations and config lookups, improving API response time for the `/api/map` endpoint.
* 🔬 Measurement: Verify `/api/map` endpoint functionality and performance by logging or timing responses, and verify tests continue to pass.

---
*PR created automatically by Jules for task [25188113220404236](https://jules.google.com/task/25188113220404236) started by @ralksta*