### PR TITLE
🎨 Palette: [UX improvement] Make lightbox counter screen-reader accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-26 - Interactive Card ARIA Labels
 **Learning:** When building interactive card components that contain multiple pieces of text or badges (like titles and photo counts), screen readers may announce them in a fragmented or confusing way.
 **Action:** Always apply a comprehensive `aria-label` to the parent link/container that encompasses all meaningful visual data (e.g., titles and item counts). Use `aria-hidden="true"` on redundant text or visual child elements, and set `alt=""` on decorative images to consolidate screen reader announcements into a single, accurate interaction point.
+
+## 2024-05-27 - Lightbox Counter Accessibility
+**Learning:** To ensure screen readers correctly announce numeric text changes during navigation (like '1 / 5' in a lightbox counter), the counter must be wrapped in an element with `aria-live="polite"` and `aria-atomic="true"`. Additionally, a visually hidden span with context-rich text (e.g., 'Photo 1 of 5') should be included while hiding the visual slash notation with `aria-hidden="true"`.
+**Action:** When implementing numeric counters or pagination indicators, always use `aria-live` and provide context-rich screen reader text using visually hidden elements to ensure accessible announcements.

--- a/components/Lightbox.tsx
+++ b/components/Lightbox.tsx
@@ -200,8 +200,23 @@ export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev }: Ligh
       </button>
 
       {/* Counter */}
-      <div className={styles.counter}>
-        {currentIndex + 1} / {assets.length}
+      <div className={styles.counter} aria-live="polite" aria-atomic="true">
+        <span
+          style={{
+            position: 'absolute',
+            width: 1,
+            height: 1,
+            overflow: 'hidden',
+            clip: 'rect(0, 0, 0, 0)',
+            whiteSpace: 'nowrap',
+            borderWidth: 0,
+          }}
+        >
+          Photo {currentIndex + 1} of {assets.length}
+        </span>
+        <span aria-hidden="true">
+          {currentIndex + 1} / {assets.length}
+        </span>
       </div>
 
       {/* EXIF toggle */}


### PR DESCRIPTION
- 💡 What: Added `aria-live` and visually hidden context text to the lightbox counter.
- 🎯 Why: Screen readers previously would read '1 / 5' without context, or not announce the change during navigation.
- 📸 Before/After: Visuals remain unchanged, but screen reader announces "Photo 1 of 5".
- ♿ Accessibility: Wrapped the counter in an element with `aria-live="polite"` and `aria-atomic="true"`, included a visually hidden span with "Photo N of M", and hid the visual "N / M" text using `aria-hidden="true"`.

---
*PR created automatically by Jules for task [3612485888952887909](https://jules.google.com/task/3612485888952887909) started by @ralksta*