### PR TITLE
⚡ Bolt: Memoize map API auth checks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -18,3 +18,6 @@
 ## 2024-05-30 - [O(1) Memory Bucketing for Coordinate Aggregation]
 **Learning:** When bucketing or grouping large datasets (e.g., thousands of map coordinates into geographical clusters), array allocations (`[].push()`) followed by `reduce` operations create an O(N) memory overhead per bucket and expensive post-processing loops.
 **Action:** Replace memory-heavy array collections with running statistical accumulators (e.g., `latSum`, `lngSum`, `count`) directly on the bucket. This reduces bucket memory from O(N) to O(1).
+## 2024-05-31 - [Memoize expensive auth operations in collections]
+**Learning:** When processing data collections where multiple items share the same authorization context (e.g., `subpageSlug`), evaluating the auth status for each item individually leads to redundant expensive operations like HMAC calculations.
+**Action:** Use a request-scoped `Map` to memoize `isAuthenticated` results. This avoids repetitive configuration lookups and crypto operations within map/filter loops.

--- a/app/api/map/route.ts
+++ b/app/api/map/route.ts
@@ -43,13 +43,22 @@ export async function GET(request: NextRequest) {
 
   const locations = await getMapData();
 
+  // Memoize auth checks to avoid redundant HMAC calculations
+  const authCache = new Map<string, boolean>();
+  const isAuthMemoized = (slug: string) => {
+    if (!authCache.has(slug)) {
+      authCache.set(slug, isAuthenticated(slug, getCookie));
+    }
+    return authCache.get(slug)!;
+  };
+
   // Filter locations and albums based on auth
   const publicLocations = locations
     .map((loc) => {
       // Only keep albums the user is allowed to see
       const allowedAlbums = loc.albums.filter((a) => {
         if (!a.subpageSlug) return true; // Standalone albums are public
-        return isAuthenticated(a.subpageSlug, getCookie);
+        return isAuthMemoized(a.subpageSlug);
       });
 
       if (allowedAlbums.length === 0) return null;


### PR DESCRIPTION
💡 What: Memoized the result of isAuthenticated calls in the map locations API route using a request-scoped Map.
🎯 Why: When filtering map locations, many albums belong to the same subpage. The previous implementation checked the authentication status repeatedly for the same subpageSlug, redundantly invoking the HMAC token validation which is an expensive cryptographic operation.
📊 Impact: Reduces CPU time spent on HMAC token verification from O(N) to O(U) where N is the total number of albums and U is the unique number of subpage slugs. Considerably speeds up map API response times for large galleries.
🔬 Measurement: Verify by measuring API response times before and after this change, particularly for large photo collections with protected subpages.

---
*PR created automatically by Jules for task [5680451122493073041](https://jules.google.com/task/5680451122493073041) started by @ralksta*