### PR TITLE
🎨 Palette: [UX improvement] Improve Lightbox counter accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-26 - Interactive Card ARIA Labels
 **Learning:** When building interactive card components that contain multiple pieces of text or badges (like titles and photo counts), screen readers may announce them in a fragmented or confusing way.
 **Action:** Always apply a comprehensive `aria-label` to the parent link/container that encompasses all meaningful visual data (e.g., titles and item counts). Use `aria-hidden="true"` on redundant text or visual child elements, and set `alt=""` on decorative images to consolidate screen reader announcements into a single, accurate interaction point.
+
+## 2024-05-27 - Lightbox Counter Accessibility
+**Learning:** Raw numeric counters like "1 / 5" in a lightbox are confusing to screen readers, announcing as just "1 slash 5". Wrapping the counter with `aria-live="polite"` and `aria-atomic="true"`, along with visually hiding context-rich text (e.g., "Photo 1 of 5") and hiding the raw numbers from screen readers using `aria-hidden="true"`, ensures proper and contextual announcements as the user navigates between photos.
+**Action:** Always provide context-rich, visually hidden text combined with `aria-live` for dynamic counters, and use `aria-hidden="true"` on the raw visual numbers to prevent confusing announcements.

--- a/components/Lightbox.tsx
+++ b/components/Lightbox.tsx
@@ -200,8 +200,23 @@ export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev }: Ligh
       </button>
 
       {/* Counter */}
-      <div className={styles.counter}>
-        {currentIndex + 1} / {assets.length}
+      <div className={styles.counter} aria-live="polite" aria-atomic="true">
+        <span
+          style={{
+            position: 'absolute',
+            width: 1,
+            height: 1,
+            overflow: 'hidden',
+            clip: 'rect(0, 0, 0, 0)',
+            whiteSpace: 'nowrap',
+            borderWidth: 0,
+          }}
+        >
+          Photo {currentIndex + 1} of {assets.length}
+        </span>
+        <span aria-hidden="true">
+          {currentIndex + 1} / {assets.length}
+        </span>
       </div>
 
       {/* EXIF toggle */}


### PR DESCRIPTION
💡 What: The Lightbox photo counter has been updated to include `aria-live="polite"` and `aria-atomic="true"`. Context-rich text ("Photo X of Y") is now visually hidden for screen readers, while the raw "X / Y" visual text is hidden from screen readers using `aria-hidden="true"`.
🎯 Why: Raw numeric counters like "1 / 5" are confusing when read aloud by screen readers, announcing as just "1 slash 5". This change ensures users relying on assistive technologies understand exactly what the numbers represent as they navigate through the gallery.
📸 Before/After: Visual appearance is identical. Screen reader experience changes from "1 slash 5" to "Photo 1 of 5".
♿ Accessibility: Added `aria-live`, `aria-atomic`, and visually hidden text to improve screen reader context for the dynamic photo counter.

---
*PR created automatically by Jules for task [278433493028386468](https://jules.google.com/task/278433493028386468) started by @ralksta*