### PR TITLE
⚡ Bolt: [Memoize authentication checks]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -18,3 +18,7 @@
 ## 2024-05-30 - [O(1) Memory Bucketing for Coordinate Aggregation]
 **Learning:** When bucketing or grouping large datasets (e.g., thousands of map coordinates into geographical clusters), array allocations (`[].push()`) followed by `reduce` operations create an O(N) memory overhead per bucket and expensive post-processing loops.
 **Action:** Replace memory-heavy array collections with running statistical accumulators (e.g., `latSum`, `lngSum`, `count`) directly on the bucket. This reduces bucket memory from O(N) to O(1).
+
+## 2024-05-31 - [Memoize repeated authorization context checks]
+**Learning:** When processing data collections where multiple items share the same authorization context (e.g., `subpageSlug`), redundant expensive operations like HMAC calculations and configuration lookups inside map/filter loops can cause significant overhead.
+**Action:** Use a request-scoped `Map` to memoize `isAuthenticated` results to avoid repeated expensive calculations for the same context.

--- a/app/api/map/route.ts
+++ b/app/api/map/route.ts
@@ -43,13 +43,24 @@ export async function GET(request: NextRequest) {
 
   const locations = await getMapData();
 
+  // ⚡ Bolt: Memoize authentication checks per subpageSlug using a request-scoped Map.
+  // This avoids redundant expensive operations like HMAC calculations and configuration
+  // lookups within the map/filter loop when multiple items share the same context.
+  const authCache = new Map<string, boolean>();
+
   // Filter locations and albums based on auth
   const publicLocations = locations
     .map((loc) => {
       // Only keep albums the user is allowed to see
       const allowedAlbums = loc.albums.filter((a) => {
         if (!a.subpageSlug) return true; // Standalone albums are public
-        return isAuthenticated(a.subpageSlug, getCookie);
+
+        let isAuthed = authCache.get(a.subpageSlug);
+        if (isAuthed === undefined) {
+          isAuthed = isAuthenticated(a.subpageSlug, getCookie);
+          authCache.set(a.subpageSlug, isAuthed);
+        }
+        return isAuthed;
       });
 
       if (allowedAlbums.length === 0) return null;

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -33,12 +33,7 @@ export function getClientIp(request: NextRequest): string {
 
   // Fallback for self-hosted environments without explicit trusted proxies:
   // We have to trust headers as a best-effort, but this is vulnerable to spoofing.
-  return (
-    directIp ??
-    xRealIp ??
-    xForwardedFor?.split(',')[0].trim() ??
-    'unknown'
-  );
+  return directIp ?? xRealIp ?? xForwardedFor?.split(',')[0].trim() ?? 'unknown';
 }
 
 interface RateLimitEntry {


### PR DESCRIPTION
💡 What: Implemented a request-scoped `Map` to memoize `isAuthenticated` checks for `subpageSlug`s in the map route.
🎯 Why: To prevent redundant expensive operations like HMAC calculations and configuration lookups for multiple albums sharing the same subpage.
📊 Impact: Reduces CPU time per request scaling with the number of locations, resulting in faster map API response times.
🔬 Measurement: Measure the execution time of `/api/map` before and after this change, particularly with many geotagged albums.

---
*PR created automatically by Jules for task [14492437551611628364](https://jules.google.com/task/14492437551611628364) started by @ralksta*