### PR TITLE
⚡ Bolt: Memoize auth checks in map route

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -18,3 +18,7 @@
 ## 2024-05-30 - [O(1) Memory Bucketing for Coordinate Aggregation]
 **Learning:** When bucketing or grouping large datasets (e.g., thousands of map coordinates into geographical clusters), array allocations (`[].push()`) followed by `reduce` operations create an O(N) memory overhead per bucket and expensive post-processing loops.
 **Action:** Replace memory-heavy array collections with running statistical accumulators (e.g., `latSum`, `lngSum`, `count`) directly on the bucket. This reduces bucket memory from O(N) to O(1).
+
+## 2026-05-19 - [Memoize expensive auth checks inside data loops]
+**Learning:** When processing data collections where multiple items share the same authorization context (e.g., `subpageSlug`), redundant calls to `isAuthenticated` can cause severe performance issues due to expensive operations like HMAC calculations and configuration lookups.
+**Action:** Use a request-scoped `Map` to memoize `isAuthenticated` results. This avoids redundant expensive operations and significantly speeds up request processing.

--- a/app/api/map/route.ts
+++ b/app/api/map/route.ts
@@ -44,12 +44,21 @@ export async function GET(request: NextRequest) {
   const locations = await getMapData();
 
   // Filter locations and albums based on auth
+  const authCache = new Map<string, boolean>();
+
   const publicLocations = locations
     .map((loc) => {
       // Only keep albums the user is allowed to see
       const allowedAlbums = loc.albums.filter((a) => {
         if (!a.subpageSlug) return true; // Standalone albums are public
-        return isAuthenticated(a.subpageSlug, getCookie);
+
+        if (authCache.has(a.subpageSlug)) {
+          return authCache.get(a.subpageSlug)!;
+        }
+
+        const isAuth = isAuthenticated(a.subpageSlug, getCookie);
+        authCache.set(a.subpageSlug, isAuth);
+        return isAuth;
       });
 
       if (allowedAlbums.length === 0) return null;

--- a/docs/gallery-config.md
+++ b/docs/gallery-config.md
@@ -193,26 +193,27 @@ Your bio text here. Supports full Markdown.
 
 - **Album UUIDs**: In Immich, go to Albums → click an album → the UUID is in the URL bar
 - **Asset UUIDs**: Click any photo → the UUID is in the URL bar
- 
+
 ## System & Security
- 
+
 Advanced system settings are configured via environment variables in your `.env` or `.env.local` file.
- 
+
 ### Rate Limiting
- 
+
 To protect against brute-force attacks and resource exhaustion, Immich Folio includes an in-memory rate limiter.
- 
+
 - `RATE_LIMIT_RPM`: Maximum requests per minute per IP (default: `1500` for general API, `120` for map data).
- 
+
 ### Trusted Proxies
- 
+
 If you are running Immich Folio behind a reverse proxy (like Nginx, Traefik, Caddy, or Cloudflare), you should configure trusted proxies to prevent IP spoofing.
- 
+
 - `TRUSTED_PROXIES`: A comma-separated list of IP addresses of your proxies.
- 
+
 Example:
+
 ```bash
 TRUSTED_PROXIES=127.0.0.1,172.18.0.1
 ```
- 
+
 When set, the rate limiter will only trust `X-Forwarded-For` and `X-Real-IP` headers if the request directly comes from one of these IPs. If not set, headers are trusted as a best-effort, which is less secure in public-facing environments.

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -33,12 +33,7 @@ export function getClientIp(request: NextRequest): string {
 
   // Fallback for self-hosted environments without explicit trusted proxies:
   // We have to trust headers as a best-effort, but this is vulnerable to spoofing.
-  return (
-    directIp ??
-    xRealIp ??
-    xForwardedFor?.split(',')[0].trim() ??
-    'unknown'
-  );
+  return directIp ?? xRealIp ?? xForwardedFor?.split(',')[0].trim() ?? 'unknown';
 }
 
 interface RateLimitEntry {


### PR DESCRIPTION
💡 What: Added a request-scoped memoization `Map` for `isAuthenticated` calls in the `/api/map` route.
🎯 Why: When processing thousands of locations for the map, many locations reference the same `subpageSlug`. Redundant calls to `isAuthenticated` resulted in unnecessary HMAC-SHA256 operations and configuration lookups, slowing down the endpoint.
📊 Impact: Reduces redundant HMAC calculations and speeds up the `/api/map` endpoint significantly when the map contains lots of locations from the same subpage.
🔬 Measurement: Run the test-auth-memo benchmark script or time the `/api/map` endpoint to see the number of duplicate auth checks eliminated.

---
*PR created automatically by Jules for task [12904430655988523653](https://jules.google.com/task/12904430655988523653) started by @ralksta*