### PR TITLE
🎨 Palette: Improve screen reader announcement for lightbox counter

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-26 - Interactive Card ARIA Labels
 **Learning:** When building interactive card components that contain multiple pieces of text or badges (like titles and photo counts), screen readers may announce them in a fragmented or confusing way.
 **Action:** Always apply a comprehensive `aria-label` to the parent link/container that encompasses all meaningful visual data (e.g., titles and item counts). Use `aria-hidden="true"` on redundant text or visual child elements, and set `alt=""` on decorative images to consolidate screen reader announcements into a single, accurate interaction point.
+
+## 2024-05-27 - Lightbox Counter Screen Reader Announcement
+**Learning:** Screen readers often announce numeric counters (like "1 / 5") literally (e.g., "one slash five"), which lacks context. Further, without `aria-live`, changes during keyboard navigation aren't announced dynamically.
+**Action:** Always wrap dynamically updating counters in `aria-live="polite"` and `aria-atomic="true"`. Use a visually hidden span for a descriptive screen-reader-only announcement (e.g., "Photo 1 of 5") and hide the literal visual text with `aria-hidden="true"`.

--- a/components/Lightbox.tsx
+++ b/components/Lightbox.tsx
@@ -200,8 +200,23 @@ export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev }: Ligh
       </button>
 
       {/* Counter */}
-      <div className={styles.counter}>
-        {currentIndex + 1} / {assets.length}
+      <div className={styles.counter} aria-live="polite" aria-atomic="true">
+        <span
+          style={{
+            position: 'absolute',
+            width: 1,
+            height: 1,
+            overflow: 'hidden',
+            clip: 'rect(0, 0, 0, 0)',
+            whiteSpace: 'nowrap',
+            borderWidth: 0,
+          }}
+        >
+          Photo {currentIndex + 1} of {assets.length}
+        </span>
+        <span aria-hidden="true">
+          {currentIndex + 1} / {assets.length}
+        </span>
       </div>
 
       {/* EXIF toggle */}


### PR DESCRIPTION
💡 What: Added `aria-live="polite"`, `aria-atomic="true"`, and screen-reader-only text ("Photo X of Y") to the lightbox image counter.
🎯 Why: Screen readers announce literal symbols like "1 / 5" as "one slash five" without context, and don't announce changes dynamically when navigating photos.
📸 Before/After: Visuals remain unchanged, but the DOM now includes proper ARIA live regions and visually hidden descriptive text.
♿ Accessibility: Improved screen reader announcements for numeric counters during lightbox navigation, providing context and dynamic updates.

---
*PR created automatically by Jules for task [17397574974417646505](https://jules.google.com/task/17397574974417646505) started by @ralksta*