### PR TITLE
⚡ Bolt: [performance improvement] Memoize map authorization checks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -18,3 +18,6 @@
 ## 2024-05-30 - [O(1) Memory Bucketing for Coordinate Aggregation]
 **Learning:** When bucketing or grouping large datasets (e.g., thousands of map coordinates into geographical clusters), array allocations (`[].push()`) followed by `reduce` operations create an O(N) memory overhead per bucket and expensive post-processing loops.
 **Action:** Replace memory-heavy array collections with running statistical accumulators (e.g., `latSum`, `lngSum`, `count`) directly on the bucket. This reduces bucket memory from O(N) to O(1).
+## 2026-05-21 - Memoize Authorization Checks in Map Loops
+**Learning:** In endpoints that process large collections (like map clusters) where many items share the same authorization context (e.g., `subpageSlug`), evaluating the same HMAC-based `isAuthenticated` check in a loop causes redundant, expensive operations.
+**Action:** Always use a request-scoped `Map` to memoize repetitive authorization results when iterating through lists that share parent access controls.

--- a/app/api/map/route.ts
+++ b/app/api/map/route.ts
@@ -43,13 +43,19 @@ export async function GET(request: NextRequest) {
 
   const locations = await getMapData();
 
+  // Memoize auth checks to avoid redundant expensive HMAC operations
+  const authCache = new Map<string, boolean>();
+
   // Filter locations and albums based on auth
   const publicLocations = locations
     .map((loc) => {
       // Only keep albums the user is allowed to see
       const allowedAlbums = loc.albums.filter((a) => {
         if (!a.subpageSlug) return true; // Standalone albums are public
-        return isAuthenticated(a.subpageSlug, getCookie);
+        if (authCache.has(a.subpageSlug)) return authCache.get(a.subpageSlug);
+        const isAuth = isAuthenticated(a.subpageSlug, getCookie);
+        authCache.set(a.subpageSlug, isAuth);
+        return isAuth;
       });
 
       if (allowedAlbums.length === 0) return null;


### PR DESCRIPTION
💡 What: Added a request-scoped `Map` to cache `isAuthenticated` results by `subpageSlug` within the `/api/map` endpoint.
🎯 Why: When rendering the map, the application loops through numerous geographic markers, each containing albums associated with subpages. Previously, `isAuthenticated`—which involves an expensive crypto computation—was called redundantly for every single album in a subpage across all markers.
📊 Impact: Reduces computational overhead significantly on the map endpoint by minimizing redundant cryptographic hashes and configuration lookups, shifting the operation cost from O(N) where N is the total number of albums to O(M) where M is the number of unique subpages.
🔬 Measurement: Execute `pnpm test` and `pnpm lint` to verify correctness; monitor map loading times for improved TTFB on galleries with high photo densities.

---
*PR created automatically by Jules for task [1407916604475140579](https://jules.google.com/task/1407916604475140579) started by @ralksta*