### PR TITLE
🎨 Palette: [UX improvement] Improve Lightbox counter accessibility

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1573,3 +1573,16 @@
     font-size: 2rem;
   }
 }
+
+/* ── Accessibility ────────────────────────────────── */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}

--- a/components/Lightbox.tsx
+++ b/components/Lightbox.tsx
@@ -200,8 +200,13 @@ export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev }: Ligh
       </button>
 
       {/* Counter */}
-      <div className={styles.counter}>
-        {currentIndex + 1} / {assets.length}
+      <div className={styles.counter} aria-live="polite" aria-atomic="true">
+        <span className="sr-only">
+          Photo {currentIndex + 1} of {assets.length}
+        </span>
+        <span aria-hidden="true">
+          {currentIndex + 1} / {assets.length}
+        </span>
       </div>
 
       {/* EXIF toggle */}


### PR DESCRIPTION
💡 What: Added screen-reader friendly ARIA attributes (`aria-live="polite"`, `aria-atomic="true"`) to the Lightbox image counter and added a visually hidden descriptive text (`Photo X of Y`) alongside the raw string (`X / Y` which is hidden from screen readers via `aria-hidden="true"`). Added `.sr-only` utility class to `app/globals.css`.
🎯 Why: Screen readers would previously announce the counter string simply as "1 slash 5", lacking context during gallery navigation. The newly structured counter provides immediate, polite, and contextual feedback.
📸 Before/After: Visuals remain unchanged, but screen reader experience is vastly improved.
♿ Accessibility: Ensures correct pronunciation and context for dynamic counter changes, fulfilling WCAG guidelines for live region announcements.

---
*PR created automatically by Jules for task [9754434105896567331](https://jules.google.com/task/9754434105896567331) started by @ralksta*