### PR TITLE
⚡ Bolt: Memoize auth checks in map API

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -18,3 +18,7 @@
 ## 2024-05-30 - [O(1) Memory Bucketing for Coordinate Aggregation]
 **Learning:** When bucketing or grouping large datasets (e.g., thousands of map coordinates into geographical clusters), array allocations (`[].push()`) followed by `reduce` operations create an O(N) memory overhead per bucket and expensive post-processing loops.
 **Action:** Replace memory-heavy array collections with running statistical accumulators (e.g., `latSum`, `lngSum`, `count`) directly on the bucket. This reduces bucket memory from O(N) to O(1).
+
+## 2026-05-22 - [Memoize expensive auth checks in map/filter loops]
+**Learning:** When processing data collections where multiple items share the same authorization context (e.g., `subpageSlug`), redundant calls to `isAuthenticated` cause expensive operations like HMAC calculations and configuration lookups to repeat.
+**Action:** Use a request-scoped `Map` to memoize `isAuthenticated` results to avoid redundant CPU overhead.

--- a/app/api/map/route.ts
+++ b/app/api/map/route.ts
@@ -44,12 +44,16 @@ export async function GET(request: NextRequest) {
   const locations = await getMapData();
 
   // Filter locations and albums based on auth
+  const authCache = new Map<string, boolean>();
   const publicLocations = locations
     .map((loc) => {
       // Only keep albums the user is allowed to see
       const allowedAlbums = loc.albums.filter((a) => {
         if (!a.subpageSlug) return true; // Standalone albums are public
-        return isAuthenticated(a.subpageSlug, getCookie);
+        if (authCache.has(a.subpageSlug)) return authCache.get(a.subpageSlug);
+        const authed = isAuthenticated(a.subpageSlug, getCookie);
+        authCache.set(a.subpageSlug, authed);
+        return authed;
       });
 
       if (allowedAlbums.length === 0) return null;


### PR DESCRIPTION
💡 What: The `isAuthenticated` result is now memoized per `subpageSlug` within the `/api/map` request using a `Map`.
🎯 Why: `isAuthenticated` performs O(N) configuration lookups and expensive HMAC calculations. Running this inside a double loop causes redundant CPU work for albums sharing the same subpage.
📊 Impact: Reduces redundant HMAC computations and config lookups from O(Locations * Albums) to O(Unique Subpages) per request, improving map endpoint response times for large galleries.
🔬 Measurement: Load the map view with many albums in the same subpage; the server response time for `/api/map` should be faster due to reduced CPU overhead.

---
*PR created automatically by Jules for task [14510111261119180202](https://jules.google.com/task/14510111261119180202) started by @ralksta*