### PR TITLE
🎨 Palette: Improve Lightbox counter accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-26 - Interactive Card ARIA Labels
 **Learning:** When building interactive card components that contain multiple pieces of text or badges (like titles and photo counts), screen readers may announce them in a fragmented or confusing way.
 **Action:** Always apply a comprehensive `aria-label` to the parent link/container that encompasses all meaningful visual data (e.g., titles and item counts). Use `aria-hidden="true"` on redundant text or visual child elements, and set `alt=""` on decorative images to consolidate screen reader announcements into a single, accurate interaction point.
+
+## 2025-02-12 - Lightbox Counter Accessibility
+**Learning:** Simple numeric counters like "1 / 5" in lightboxes are announced poorly by screen readers during navigation.
+**Action:** Wrap counters with aria-live="polite" and aria-atomic="true", and provide a descriptive hidden span (e.g., "Photo 1 of 5") while hiding the visual string.

--- a/app/globals.css
+++ b/app/globals.css
@@ -1573,3 +1573,16 @@
     font-size: 2rem;
   }
 }
+
+/* ── Screen Reader Only ──────────────────────────── */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/components/Lightbox.tsx
+++ b/components/Lightbox.tsx
@@ -200,8 +200,13 @@ export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev }: Ligh
       </button>
 
       {/* Counter */}
-      <div className={styles.counter}>
-        {currentIndex + 1} / {assets.length}
+      <div className={styles.counter} aria-live="polite" aria-atomic="true">
+        <span className="sr-only">
+          Photo {currentIndex + 1} of {assets.length}
+        </span>
+        <span aria-hidden="true">
+          {currentIndex + 1} / {assets.length}
+        </span>
       </div>
 
       {/* EXIF toggle */}

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -33,12 +33,7 @@ export function getClientIp(request: NextRequest): string {
 
   // Fallback for self-hosted environments without explicit trusted proxies:
   // We have to trust headers as a best-effort, but this is vulnerable to spoofing.
-  return (
-    directIp ??
-    xRealIp ??
-    xForwardedFor?.split(',')[0].trim() ??
-    'unknown'
-  );
+  return directIp ?? xRealIp ?? xForwardedFor?.split(',')[0].trim() ?? 'unknown';
 }
 
 interface RateLimitEntry {


### PR DESCRIPTION
💡 What: Wrapped the Lightbox photo counter with `aria-live="polite"` and added a visually hidden text span while hiding the literal format.
🎯 Why: Simple numeric counters like '1 / 5' are poorly announced by screen readers during sequential photo navigation.
📸 Before/After: Visuals are unchanged; screen readers now announce 'Photo 1 of 5' instead of '1 slash 5'.
♿ Accessibility: Ensures the counter updates are announced dynamically and understandably when users navigate between photos in the Lightbox.

---
*PR created automatically by Jules for task [7241669640522326447](https://jules.google.com/task/7241669640522326447) started by @ralksta*