### PR TITLE
⚡ Bolt: [memoize auth checks in map API]

### DIFF
--- a/app/api/map/route.ts
+++ b/app/api/map/route.ts
@@ -43,13 +43,22 @@ export async function GET(request: NextRequest) {
 
   const locations = await getMapData();
 
+  // Memoize auth checks to prevent O(N) redundant HMAC calculations
+  // for multiple albums that share the same subpageSlug within this request.
+  const authCache = new Map<string, boolean>();
+
   // Filter locations and albums based on auth
   const publicLocations = locations
     .map((loc) => {
       // Only keep albums the user is allowed to see
       const allowedAlbums = loc.albums.filter((a) => {
         if (!a.subpageSlug) return true; // Standalone albums are public
-        return isAuthenticated(a.subpageSlug, getCookie);
+        let authed = authCache.get(a.subpageSlug);
+        if (authed === undefined) {
+          authed = isAuthenticated(a.subpageSlug, getCookie);
+          authCache.set(a.subpageSlug, authed);
+        }
+        return authed;
       });
 
       if (allowedAlbums.length === 0) return null;


### PR DESCRIPTION
💡 What: Introduced a request-scoped memoization Map for the `isAuthenticated` check in `app/api/map/route.ts` along with an explanatory comment.
🎯 Why: The `isAuthenticated` function performs expensive operations like hashing (HMAC-SHA256) and configuration array lookups. When generating the map view, this was being called repeatedly for every album across every location. Since many albums share the same subpageSlug, this resulted in numerous redundant hashing operations for the same input during a single API request.
📊 Impact: Converts O(N) redundant HMAC calculations to O(1) by evaluating authentication state only once per unique subpageSlug per request, resulting in faster API responses when the map contains thousands of photos/albums.
🔬 Measurement: The `/api/map` endpoint will consume significantly less CPU time when generating map data.

---
*PR created automatically by Jules for task [10434922050716446974](https://jules.google.com/task/10434922050716446974) started by @ralksta*