### PR TITLE
🎨 Palette: [accessibility improvement] Make lightbox counter screen reader accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-26 - Interactive Card ARIA Labels
 **Learning:** When building interactive card components that contain multiple pieces of text or badges (like titles and photo counts), screen readers may announce them in a fragmented or confusing way.
 **Action:** Always apply a comprehensive `aria-label` to the parent link/container that encompasses all meaningful visual data (e.g., titles and item counts). Use `aria-hidden="true"` on redundant text or visual child elements, and set `alt=""` on decorative images to consolidate screen reader announcements into a single, accurate interaction point.
+
+## 2024-05-27 - Lightbox Counter Accessibility
+**Learning:** To ensure screen readers correctly announce numeric text changes during navigation (like '1 / 5' in a lightbox counter), the counter needs an `aria-live` region (`aria-live="polite"` and `aria-atomic="true"`). Visually hidden text should provide context-rich information (like "Photo 1 of 5") while the visual, less semantic text ("1 / 5") should be hidden from screen readers.
+**Action:** Wrap updating counters in an element with `aria-live="polite"` and `aria-atomic="true"`, and include a visually hidden span with context-rich text (e.g., 'Photo 1 of 5').

--- a/app/globals.css
+++ b/app/globals.css
@@ -1573,3 +1573,16 @@
     font-size: 2rem;
   }
 }
+
+/* Screen Reader Only Utility */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/components/Lightbox.tsx
+++ b/components/Lightbox.tsx
@@ -200,8 +200,13 @@ export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev }: Ligh
       </button>
 
       {/* Counter */}
-      <div className={styles.counter}>
-        {currentIndex + 1} / {assets.length}
+      <div className={styles.counter} aria-live="polite" aria-atomic="true">
+        <span aria-hidden="true">
+          {currentIndex + 1} / {assets.length}
+        </span>
+        <span className="sr-only">
+          Photo {currentIndex + 1} of {assets.length}
+        </span>
       </div>
 
       {/* EXIF toggle */}

--- a/docs/gallery-config.md
+++ b/docs/gallery-config.md
@@ -193,26 +193,27 @@ Your bio text here. Supports full Markdown.
 
 - **Album UUIDs**: In Immich, go to Albums → click an album → the UUID is in the URL bar
 - **Asset UUIDs**: Click any photo → the UUID is in the URL bar
- 
+
 ## System & Security
- 
+
 Advanced system settings are configured via environment variables in your `.env` or `.env.local` file.
- 
+
 ### Rate Limiting
- 
+
 To protect against brute-force attacks and resource exhaustion, Immich Folio includes an in-memory rate limiter.
- 
+
 - `RATE_LIMIT_RPM`: Maximum requests per minute per IP (default: `1500` for general API, `120` for map data).
- 
+
 ### Trusted Proxies
- 
+
 If you are running Immich Folio behind a reverse proxy (like Nginx, Traefik, Caddy, or Cloudflare), you should configure trusted proxies to prevent IP spoofing.
- 
+
 - `TRUSTED_PROXIES`: A comma-separated list of IP addresses of your proxies.
- 
+
 Example:
+
 ```bash
 TRUSTED_PROXIES=127.0.0.1,172.18.0.1
 ```
- 
+
 When set, the rate limiter will only trust `X-Forwarded-For` and `X-Real-IP` headers if the request directly comes from one of these IPs. If not set, headers are trusted as a best-effort, which is less secure in public-facing environments.

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -33,12 +33,7 @@ export function getClientIp(request: NextRequest): string {
 
   // Fallback for self-hosted environments without explicit trusted proxies:
   // We have to trust headers as a best-effort, but this is vulnerable to spoofing.
-  return (
-    directIp ??
-    xRealIp ??
-    xForwardedFor?.split(',')[0].trim() ??
-    'unknown'
-  );
+  return directIp ?? xRealIp ?? xForwardedFor?.split(',')[0].trim() ?? 'unknown';
 }
 
 interface RateLimitEntry {


### PR DESCRIPTION
💡 What: Added aria-live="polite" and aria-atomic="true" to the Lightbox counter, and provided a visually hidden context-rich string ("Photo X of Y") for screen readers.
🎯 Why: Without these attributes, screen readers may not announce the counter change when navigating through images, or they might read confusing text like "1 slash 5". This provides a clear, context-rich announcement on image change.
📸 Before/After: Visuals remain unchanged, but screen reader experience is improved.
♿ Accessibility: Ensures the image position counter is announced correctly when navigating the Lightbox.

---
*PR created automatically by Jules for task [360715536701858822](https://jules.google.com/task/360715536701858822) started by @ralksta*