### PR TITLE
⚡ Bolt: Memoize repetitive auth checks in map route

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -18,3 +18,7 @@
 ## 2024-05-30 - [O(1) Memory Bucketing for Coordinate Aggregation]
 **Learning:** When bucketing or grouping large datasets (e.g., thousands of map coordinates into geographical clusters), array allocations (`[].push()`) followed by `reduce` operations create an O(N) memory overhead per bucket and expensive post-processing loops.
 **Action:** Replace memory-heavy array collections with running statistical accumulators (e.g., `latSum`, `lngSum`, `count`) directly on the bucket. This reduces bucket memory from O(N) to O(1).
+
+## 2024-05-24 - [Memoize repetitive auth checks]
+**Learning:** When processing data collections where multiple items share the same authorization context (e.g., `subpageSlug`), repeated `isAuthenticated` checks perform redundant expensive operations like HMAC calculations and configuration lookups.
+**Action:** Use a request-scoped `Map` to memoize `isAuthenticated` results and avoid redundant expensive operations within map/filter loops.

--- a/app/api/map/route.ts
+++ b/app/api/map/route.ts
@@ -44,12 +44,16 @@ export async function GET(request: NextRequest) {
   const locations = await getMapData();
 
   // Filter locations and albums based on auth
+  const authCache = new Map<string, boolean>();
   const publicLocations = locations
     .map((loc) => {
       // Only keep albums the user is allowed to see
       const allowedAlbums = loc.albums.filter((a) => {
         if (!a.subpageSlug) return true; // Standalone albums are public
-        return isAuthenticated(a.subpageSlug, getCookie);
+        if (authCache.has(a.subpageSlug)) return authCache.get(a.subpageSlug);
+        const isAuthed = isAuthenticated(a.subpageSlug, getCookie);
+        authCache.set(a.subpageSlug, isAuthed);
+        return isAuthed;
       });
 
       if (allowedAlbums.length === 0) return null;


### PR DESCRIPTION
What: Introduced a request-scoped Map to memoize `isAuthenticated` calls for subpage slugs in `app/api/map/route.ts`.
Why: When building public map markers, the API iterates over all configured albums for every map location. By memoizing the `isAuthenticated` calls per `subpageSlug`, we avoid redundant and expensive HMAC calculations and configuration lookups within the filter loop.
Impact: Reduces the number of times `isAuthenticated` runs from O(N) where N is the total number of albums, to O(M) where M is the number of unique subpages, improving map data generation time for large libraries.
Measurement: Ensure map data still correctly filters protected and non-protected locations. Performance improvements are most pronounced on setups with large galleries containing many albums in protected subpages.

---
*PR created automatically by Jules for task [10040384677081335300](https://jules.google.com/task/10040384677081335300) started by @ralksta*