### PR TITLE
🎨 Palette: [a11y] Screen reader announcements for lightbox counter

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-26 - Interactive Card ARIA Labels
 **Learning:** When building interactive card components that contain multiple pieces of text or badges (like titles and photo counts), screen readers may announce them in a fragmented or confusing way.
 **Action:** Always apply a comprehensive `aria-label` to the parent link/container that encompasses all meaningful visual data (e.g., titles and item counts). Use `aria-hidden="true"` on redundant text or visual child elements, and set `alt=""` on decorative images to consolidate screen reader announcements into a single, accurate interaction point.
+
+## 2024-11-20 - Lightbox counter screen reader announcements
+**Learning:** Raw numeric text changes (like "1 / 5") in a lightbox counter are announced poorly by screen readers during navigation.
+**Action:** Wrap the counter in `aria-live="polite"` and `aria-atomic="true"`, and include a visually hidden span with context-rich text (e.g., 'Photo 1 of 5') while hiding the visual counter from screen readers.

--- a/components/Lightbox.tsx
+++ b/components/Lightbox.tsx
@@ -200,8 +200,13 @@ export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev }: Ligh
       </button>
 
       {/* Counter */}
-      <div className={styles.counter}>
-        {currentIndex + 1} / {assets.length}
+      <div className={styles.counter} aria-live="polite" aria-atomic="true">
+        <span className="sr-only">
+          Photo {currentIndex + 1} of {assets.length}
+        </span>
+        <span aria-hidden="true">
+          {currentIndex + 1} / {assets.length}
+        </span>
       </div>
 
       {/* EXIF toggle */}


### PR DESCRIPTION
💡 What: Wrapped the lightbox counter in `aria-live="polite"` and added a visually hidden screen reader span.
🎯 Why: Raw numeric text changes (like "1 / 5") in a lightbox counter are announced poorly by screen readers during navigation, providing no context.
📸 Before/After: N/A (visuals unchanged)
♿ Accessibility: Screen readers will now announce "Photo X of Y" when navigating the lightbox instead of just reading raw numbers, improving context for visually impaired users.

---
*PR created automatically by Jules for task [12566841435187990338](https://jules.google.com/task/12566841435187990338) started by @ralksta*