### PR TITLE
⚡ Bolt: Memoize isAuthenticated in map API

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -18,3 +18,7 @@
 ## 2024-05-30 - [O(1) Memory Bucketing for Coordinate Aggregation]
 **Learning:** When bucketing or grouping large datasets (e.g., thousands of map coordinates into geographical clusters), array allocations (`[].push()`) followed by `reduce` operations create an O(N) memory overhead per bucket and expensive post-processing loops.
 **Action:** Replace memory-heavy array collections with running statistical accumulators (e.g., `latSum`, `lngSum`, `count`) directly on the bucket. This reduces bucket memory from O(N) to O(1).
+
+## 2024-05-31 - [Memoize expensive auth operations in loops]
+**Learning:** When processing data collections where multiple items share the same authorization context (e.g., `subpageSlug`), evaluating `isAuthenticated` inside map/filter loops executes redundant expensive operations like HMAC calculations.
+**Action:** Use a request-scoped `Map` to memoize `isAuthenticated` results and prevent redundant computations.

--- a/app/api/map/route.ts
+++ b/app/api/map/route.ts
@@ -43,13 +43,21 @@ export async function GET(request: NextRequest) {
 
   const locations = await getMapData();
 
+  // ⚡ Bolt: Memoize expensive auth checks (HMAC operations) per subpage.
+  // When a map has thousands of points sharing a handful of subpages, this prevents
+  // redundant computations and significantly reduces CPU overhead and response times.
+  const authCache = new Map<string, boolean>();
+
   // Filter locations and albums based on auth
   const publicLocations = locations
     .map((loc) => {
       // Only keep albums the user is allowed to see
       const allowedAlbums = loc.albums.filter((a) => {
         if (!a.subpageSlug) return true; // Standalone albums are public
-        return isAuthenticated(a.subpageSlug, getCookie);
+        if (authCache.has(a.subpageSlug)) return authCache.get(a.subpageSlug)!;
+        const result = isAuthenticated(a.subpageSlug, getCookie);
+        authCache.set(a.subpageSlug, result);
+        return result;
       });
 
       if (allowedAlbums.length === 0) return null;


### PR DESCRIPTION
💡 What: Added a request-scoped memoization Map for `isAuthenticated` calls in the map API route.
🎯 Why: To avoid redundant expensive operations (like HMAC calculations and configuration lookups) when filtering large datasets where many locations share the same authorization context.
📊 Impact: Significantly reduces CPU overhead and response times when generating map data with large collections of photos.
🔬 Measurement: Run `pnpm test` and verify that the map API endpoint remains functional while processing faster for repeated subpage configurations.

---
*PR created automatically by Jules for task [1718390773529852892](https://jules.google.com/task/1718390773529852892) started by @ralksta*