### PR TITLE
🎨 Palette: [UX improvement] Improve Lightbox counter accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,6 @@
 ## 2024-05-26 - Interactive Card ARIA Labels
 **Learning:** When building interactive card components that contain multiple pieces of text or badges (like titles and photo counts), screen readers may announce them in a fragmented or confusing way.
 **Action:** Always apply a comprehensive `aria-label` to the parent link/container that encompasses all meaningful visual data (e.g., titles and item counts). Use `aria-hidden="true"` on redundant text or visual child elements, and set `alt=""` on decorative images to consolidate screen reader announcements into a single, accurate interaction point.
+## 2024-05-25 - Improved Lightbox Counter Accessibility
+**Learning:** Numeric text changes during navigation (like '1 / 5' in a lightbox counter) are not correctly announced by screen readers. Wrapping the counter in an element with `aria-live="polite"` and `aria-atomic="true"`, and including a visually hidden span with context-rich text (e.g., 'Photo 1 of 5'), significantly improves the screen reader experience.
+**Action:** When implementing numeric counters that change dynamically without page reloads, use `aria-live="polite"` and visually hidden context-rich text to ensure proper announcement.

--- a/components/Lightbox.tsx
+++ b/components/Lightbox.tsx
@@ -200,8 +200,13 @@ export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev }: Ligh
       </button>
 
       {/* Counter */}
-      <div className={styles.counter}>
-        {currentIndex + 1} / {assets.length}
+      <div className={styles.counter} aria-live="polite" aria-atomic="true">
+        <span className="sr-only">
+          Photo {currentIndex + 1} of {assets.length}
+        </span>
+        <span aria-hidden="true">
+          {currentIndex + 1} / {assets.length}
+        </span>
       </div>
 
       {/* EXIF toggle */}


### PR DESCRIPTION
💡 What: Improved the accessibility of the Lightbox counter by adding `aria-live="polite"` and a visually hidden context-rich text for screen readers.
🎯 Why: Numeric text changes like "1 / 5" during navigation are often not correctly announced by screen readers without additional ARIA context. This change ensures visually impaired users are properly informed of their position within the gallery.
📸 Before/After: The visual appearance remains unchanged.
♿ Accessibility: Added `aria-live="polite"` and `aria-atomic="true"` to the counter wrapper, and a visually hidden span with the text `Photo {currentIndex + 1} of {assets.length}` for screen readers. The visual text `1 / 5` is hidden from screen readers using `aria-hidden="true"`.

---
*PR created automatically by Jules for task [7112048386647901436](https://jules.google.com/task/7112048386647901436) started by @ralksta*