### PR TITLE
⚡ Bolt: Memoize authentication checks in map API

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -18,3 +18,7 @@
 ## 2024-05-30 - [O(1) Memory Bucketing for Coordinate Aggregation]
 **Learning:** When bucketing or grouping large datasets (e.g., thousands of map coordinates into geographical clusters), array allocations (`[].push()`) followed by `reduce` operations create an O(N) memory overhead per bucket and expensive post-processing loops.
 **Action:** Replace memory-heavy array collections with running statistical accumulators (e.g., `latSum`, `lngSum`, `count`) directly on the bucket. This reduces bucket memory from O(N) to O(1).
+
+## 2024-05-26 - Memoize Authentication Checks in Data Processing Loops
+**Learning:** The `isAuthenticated` function involves computing an HMAC-SHA256 token and performing a `timingSafeEqual` comparison. Calling this repeatedly inside `.map()` or `.filter()` loops on large collections with duplicate contexts (like `subpageSlug`) creates a significant CPU bottleneck.
+**Action:** Use request-scoped memoization (e.g., a `Map`) when iterating over collections that require authorization checks on repeated parent scopes to avoid redundant expensive cryptography and config lookups.

--- a/app/api/map/route.ts
+++ b/app/api/map/route.ts
@@ -43,13 +43,24 @@ export async function GET(request: NextRequest) {
 
   const locations = await getMapData();
 
+  // ⚡ Bolt: Memoize expensive authentication checks per request
+  // Avoids redundant HMAC calculations and config lookups for the same subpage
+  const authCache = new Map<string, boolean>();
+
   // Filter locations and albums based on auth
   const publicLocations = locations
     .map((loc) => {
       // Only keep albums the user is allowed to see
       const allowedAlbums = loc.albums.filter((a) => {
         if (!a.subpageSlug) return true; // Standalone albums are public
-        return isAuthenticated(a.subpageSlug, getCookie);
+
+        if (authCache.has(a.subpageSlug)) {
+          return authCache.get(a.subpageSlug)!;
+        }
+
+        const isAuth = isAuthenticated(a.subpageSlug, getCookie);
+        authCache.set(a.subpageSlug, isAuth);
+        return isAuth;
       });
 
       if (allowedAlbums.length === 0) return null;


### PR DESCRIPTION
💡 What: Added request-scoped memoization using a `Map` to cache `isAuthenticated` results for subpage slugs within the map data API route.
🎯 Why: The `isAuthenticated` function performs expensive HMAC-SHA256 calculations and constant-time buffer comparisons. Executing it repeatedly for every album across all locations with the same `subpageSlug` caused a significant CPU bottleneck.
📊 Impact: Eliminates redundant HMAC computations, changing the time complexity for authorization from O(N) where N is the total number of albums to O(S) where S is the number of unique subpages. Should significantly reduce response times for users with many location albums grouped under the same subpage.
🔬 Measurement: Profile the map API endpoint response time locally or examine CPU flame graphs. CPU time spent in `crypto.createHmac` should drop to near zero for subsequent identical slugs.

---
*PR created automatically by Jules for task [18398850363715956872](https://jules.google.com/task/18398850363715956872) started by @ralksta*