### PR TITLE
🎨 Palette: Improve Lightbox screen reader counter context

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-26 - Interactive Card ARIA Labels
 **Learning:** When building interactive card components that contain multiple pieces of text or badges (like titles and photo counts), screen readers may announce them in a fragmented or confusing way.
 **Action:** Always apply a comprehensive `aria-label` to the parent link/container that encompasses all meaningful visual data (e.g., titles and item counts). Use `aria-hidden="true"` on redundant text or visual child elements, and set `alt=""` on decorative images to consolidate screen reader announcements into a single, accurate interaction point.
+
+## 2024-05-27 - Screen Reader Navigation Counters
+**Learning:** Numeric counters (like '1 / 5') in navigation components such as lightboxes are often not announced correctly or lack context for screen readers. Using `aria-live="polite"` and `aria-atomic="true"` on the counter wrapper, along with a visually hidden context-rich text (e.g., 'Photo 1 of 5'), ensures correct and meaningful announcements when navigating.
+**Action:** When building pagination or slider counters, always wrap them in an `aria-live` region, hide the visual numeric layout using `aria-hidden="true"`, and provide a visually hidden span with a descriptive text format.

--- a/components/Lightbox.tsx
+++ b/components/Lightbox.tsx
@@ -200,8 +200,13 @@ export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev }: Ligh
       </button>
 
       {/* Counter */}
-      <div className={styles.counter}>
-        {currentIndex + 1} / {assets.length}
+      <div className={styles.counter} aria-live="polite" aria-atomic="true">
+        <span className="sr-only">
+          Photo {currentIndex + 1} of {assets.length}
+        </span>
+        <span aria-hidden="true">
+          {currentIndex + 1} / {assets.length}
+        </span>
       </div>
 
       {/* EXIF toggle */}


### PR DESCRIPTION
**💡 What:** Added `aria-live="polite"`, `aria-atomic="true"`, and a visually hidden `sr-only` span to the Lightbox counter in `components/Lightbox.tsx`. The visual '1 / 5' text is now hidden from screen readers.\n**🎯 Why:** The counter text '1 / 5' lacks context and might not be announced correctly or automatically when navigating through images with arrow keys or buttons. Adding an `aria-live` region ensures updates are politely announced.\n**📸 Before/After:** Screen readers previously announced 'one slash five' without context; now they announce 'Photo 1 of 5' whenever the user navigates to a new image.\n**♿ Accessibility:** Enhanced screen reader experience by making image counter changes observable and context-rich.

---
*PR created automatically by Jules for task [3788977128628565743](https://jules.google.com/task/3788977128628565743) started by @ralksta*