### PR TITLE
⚡ Bolt: Memoize isAuthenticated in map data API

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -18,3 +18,6 @@
 ## 2024-05-30 - [O(1) Memory Bucketing for Coordinate Aggregation]
 **Learning:** When bucketing or grouping large datasets (e.g., thousands of map coordinates into geographical clusters), array allocations (`[].push()`) followed by `reduce` operations create an O(N) memory overhead per bucket and expensive post-processing loops.
 **Action:** Replace memory-heavy array collections with running statistical accumulators (e.g., `latSum`, `lngSum`, `count`) directly on the bucket. This reduces bucket memory from O(N) to O(1).
+## 2024-05-27 - Memoize expensive operations in loops
+**Learning:** Checking `isAuthenticated` involves an expensive HMAC SHA256 calculation. Calling it inside a `.filter` or `.map` loop for a list of items that share the same authorization context (like map locations with albums from the same subpage) causes redundant, expensive cryptographic overhead that slows down the API endpoint.
+**Action:** When processing data collections where multiple items share the same authorization context (e.g. subpageSlug), use a request-scoped `Map` to memoize `isAuthenticated` results.

--- a/app/api/map/route.ts
+++ b/app/api/map/route.ts
@@ -43,13 +43,19 @@ export async function GET(request: NextRequest) {
 
   const locations = await getMapData();
 
+  // Memoize authentication checks to prevent redundant HMAC calculations
+  const authMemo = new Map<string, boolean>();
+
   // Filter locations and albums based on auth
   const publicLocations = locations
     .map((loc) => {
       // Only keep albums the user is allowed to see
       const allowedAlbums = loc.albums.filter((a) => {
         if (!a.subpageSlug) return true; // Standalone albums are public
-        return isAuthenticated(a.subpageSlug, getCookie);
+        if (authMemo.has(a.subpageSlug)) return authMemo.get(a.subpageSlug);
+        const authed = isAuthenticated(a.subpageSlug, getCookie);
+        authMemo.set(a.subpageSlug, authed);
+        return authed;
       });
 
       if (allowedAlbums.length === 0) return null;

--- a/docs/gallery-config.md
+++ b/docs/gallery-config.md
@@ -193,26 +193,27 @@ Your bio text here. Supports full Markdown.
 
 - **Album UUIDs**: In Immich, go to Albums → click an album → the UUID is in the URL bar
 - **Asset UUIDs**: Click any photo → the UUID is in the URL bar
- 
+
 ## System & Security
- 
+
 Advanced system settings are configured via environment variables in your `.env` or `.env.local` file.
- 
+
 ### Rate Limiting
- 
+
 To protect against brute-force attacks and resource exhaustion, Immich Folio includes an in-memory rate limiter.
- 
+
 - `RATE_LIMIT_RPM`: Maximum requests per minute per IP (default: `1500` for general API, `120` for map data).
- 
+
 ### Trusted Proxies
- 
+
 If you are running Immich Folio behind a reverse proxy (like Nginx, Traefik, Caddy, or Cloudflare), you should configure trusted proxies to prevent IP spoofing.
- 
+
 - `TRUSTED_PROXIES`: A comma-separated list of IP addresses of your proxies.
- 
+
 Example:
+
 ```bash
 TRUSTED_PROXIES=127.0.0.1,172.18.0.1
 ```
- 
+
 When set, the rate limiter will only trust `X-Forwarded-For` and `X-Real-IP` headers if the request directly comes from one of these IPs. If not set, headers are trusted as a best-effort, which is less secure in public-facing environments.

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -33,12 +33,7 @@ export function getClientIp(request: NextRequest): string {
 
   // Fallback for self-hosted environments without explicit trusted proxies:
   // We have to trust headers as a best-effort, but this is vulnerable to spoofing.
-  return (
-    directIp ??
-    xRealIp ??
-    xForwardedFor?.split(',')[0].trim() ??
-    'unknown'
-  );
+  return directIp ?? xRealIp ?? xForwardedFor?.split(',')[0].trim() ?? 'unknown';
 }
 
 interface RateLimitEntry {


### PR DESCRIPTION
- **What**: Memoized the result of `isAuthenticated` within the `app/api/map/route.ts` endpoint using a request-scoped `Map`.
- **Why**: `isAuthenticated` performs an expensive HMAC-SHA256 calculation and timing-safe comparison. When rendering the map, locations frequently contain albums belonging to the same subpage, causing `isAuthenticated` to be evaluated redundantly inside the filter loop.
- **Impact**: Reduces O(N) expensive cryptographic validations (where N is the total number of albums across map locations) to O(U) (where U is the number of unique subpages), significantly lowering CPU load on the main thread and improving API response time.
- **Measurement**: Measure the response time of `/api/map` on an instance with hundreds of albums grouped under a few protected subpages before and after the change.

---
*PR created automatically by Jules for task [17464825820870853583](https://jules.google.com/task/17464825820870853583) started by @ralksta*