### PR TITLE
🎨 Palette: Improve Lightbox counter accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-26 - Interactive Card ARIA Labels
 **Learning:** When building interactive card components that contain multiple pieces of text or badges (like titles and photo counts), screen readers may announce them in a fragmented or confusing way.
 **Action:** Always apply a comprehensive `aria-label` to the parent link/container that encompasses all meaningful visual data (e.g., titles and item counts). Use `aria-hidden="true"` on redundant text or visual child elements, and set `alt=""` on decorative images to consolidate screen reader announcements into a single, accurate interaction point.
+
+## 2024-05-27 - Lightbox Counter Accessibility
+**Learning:** To ensure screen readers correctly announce numeric text changes during navigation (like '1 / 5' in a lightbox counter), wrap the counter in an element with aria-live="polite" and aria-atomic="true", and include a visually hidden span with context-rich text (e.g., 'Photo 1 of 5').
+**Action:** When adding or modifying interactive numeric counters, always ensure context is provided to screen readers and visually hidden from sighted users to improve accessibility.

--- a/components/Lightbox.tsx
+++ b/components/Lightbox.tsx
@@ -200,8 +200,13 @@ export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev }: Ligh
       </button>
 
       {/* Counter */}
-      <div className={styles.counter}>
-        {currentIndex + 1} / {assets.length}
+      <div className={styles.counter} aria-live="polite" aria-atomic="true">
+        <span className="sr-only">
+          Photo {currentIndex + 1} of {assets.length}
+        </span>
+        <span aria-hidden="true">
+          {currentIndex + 1} / {assets.length}
+        </span>
       </div>
 
       {/* EXIF toggle */}


### PR DESCRIPTION
💡 What: Added ARIA live region and context-rich hidden text to the lightbox photo counter.
🎯 Why: Screen readers were previously just announcing numbers without context, confusing users navigating through images.
📸 Before/After: Visuals remain unchanged. Screen readers now announce "Photo X of Y" instead of just "X / Y".
♿ Accessibility: Improved screen reader announcements for the lightbox counter by using aria-live, aria-atomic, and visually hidden text.

---
*PR created automatically by Jules for task [1326805202490773326](https://jules.google.com/task/1326805202490773326) started by @ralksta*