### PR TITLE
🎨 Palette: Add accessible live region to Lightbox counter

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-26 - Interactive Card ARIA Labels
 **Learning:** When building interactive card components that contain multiple pieces of text or badges (like titles and photo counts), screen readers may announce them in a fragmented or confusing way.
 **Action:** Always apply a comprehensive `aria-label` to the parent link/container that encompasses all meaningful visual data (e.g., titles and item counts). Use `aria-hidden="true"` on redundant text or visual child elements, and set `alt=""` on decorative images to consolidate screen reader announcements into a single, accurate interaction point.
+
+## 2024-05-27 - Lightbox Counter Accessibility
+**Learning:** To ensure screen readers correctly announce numeric text changes during navigation (like '1 / 5' in a lightbox counter), wrap the counter in an element with `aria-live="polite"` and `aria-atomic="true"`, and include a visually hidden span with context-rich text (e.g., 'Photo 1 of 5').
+**Action:** When adding numeric text changes during navigation (like '1 / 5' in a lightbox counter), wrap the counter in an element with `aria-live="polite"` and `aria-atomic="true"`, and include a visually hidden span with context-rich text (e.g., 'Photo 1 of 5').

--- a/components/Lightbox.tsx
+++ b/components/Lightbox.tsx
@@ -200,8 +200,13 @@ export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev }: Ligh
       </button>
 
       {/* Counter */}
-      <div className={styles.counter}>
-        {currentIndex + 1} / {assets.length}
+      <div className={styles.counter} aria-live="polite" aria-atomic="true">
+        <span className="sr-only">
+          Photo {currentIndex + 1} of {assets.length}
+        </span>
+        <span aria-hidden="true">
+          {currentIndex + 1} / {assets.length}
+        </span>
       </div>
 
       {/* EXIF toggle */}

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,14 @@
+1. **Add accessibility to the Lightbox Counter**
+   - Update `components/Lightbox.tsx` to wrap the counter in a live region for screen readers.
+   - Use `aria-live="polite"` and `aria-atomic="true"`.
+   - Include a visually hidden span (`className="sr-only"`) with context-rich text ('Photo X of Y').
+   - Hide the raw numerical text (`X / Y`) from screen readers with `aria-hidden="true"`.
+2. **Verify changes**
+   - Run `pnpm exec eslint components/Lightbox.tsx` and `pnpm test` to ensure no regressions in modified files.
+3. **Log learning**
+   - Append the learning regarding the Lightbox Counter ARIA live region to `.Jules/palette.md` using `cat << 'EOF' >> .Jules/palette.md`.
+   - Verify the learning was appended properly.
+4. **Complete pre-commit steps**
+   - Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+5. **Submit the PR**
+   - Submit the branch with "🎨 Palette: Add accessible live region to Lightbox counter" and PR details.


### PR DESCRIPTION
💡 What: Added a polite live region to the Lightbox counter.
🎯 Why: To ensure screen readers correctly announce numeric text changes during navigation (like "1 / 5" in a lightbox counter). Without it, screen reader users do not receive audio feedback that the slide changed when clicking the next/prev buttons.
📸 Before/After: The visual design remains identical (as verified by playwright testing).
♿ Accessibility: Wrapped the counter in an element with `aria-live="polite"` and `aria-atomic="true"`, and included a visually hidden span with context-rich text ("Photo X of Y"). The original raw textual fraction is marked `aria-hidden="true"`.

---
*PR created automatically by Jules for task [889867928910414015](https://jules.google.com/task/889867928910414015) started by @ralksta*