### PR TITLE
⚡ Bolt: Memoize authentication checks in map API route

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -18,3 +18,6 @@
 ## 2024-05-30 - [O(1) Memory Bucketing for Coordinate Aggregation]
 **Learning:** When bucketing or grouping large datasets (e.g., thousands of map coordinates into geographical clusters), array allocations (`[].push()`) followed by `reduce` operations create an O(N) memory overhead per bucket and expensive post-processing loops.
 **Action:** Replace memory-heavy array collections with running statistical accumulators (e.g., `latSum`, `lngSum`, `count`) directly on the bucket. This reduces bucket memory from O(N) to O(1).
+## 2024-05-31 - [Memoize authentication checks in loops]
+**Learning:** When processing data collections where multiple items share the same authorization context (e.g., `subpageSlug`), evaluating `isAuthenticated` on every item causes redundant and expensive operations like HMAC calculations and configuration lookups.
+**Action:** Use a request-scoped `Map` to memoize the results of `isAuthenticated` within map/filter loops to avoid repeated expensive calculations for the same context.

--- a/app/api/map/route.ts
+++ b/app/api/map/route.ts
@@ -44,12 +44,18 @@ export async function GET(request: NextRequest) {
   const locations = await getMapData();
 
   // Filter locations and albums based on auth
+  const authCache = new Map<string, boolean>();
   const publicLocations = locations
     .map((loc) => {
       // Only keep albums the user is allowed to see
       const allowedAlbums = loc.albums.filter((a) => {
         if (!a.subpageSlug) return true; // Standalone albums are public
-        return isAuthenticated(a.subpageSlug, getCookie);
+        let isAuth = authCache.get(a.subpageSlug);
+        if (isAuth === undefined) {
+          isAuth = isAuthenticated(a.subpageSlug, getCookie);
+          authCache.set(a.subpageSlug, isAuth);
+        }
+        return isAuth;
       });
 
       if (allowedAlbums.length === 0) return null;


### PR DESCRIPTION
* 💡 What: Introduced a request-scoped `Map` to memoize `isAuthenticated` results within the `locations.map` loop in `app/api/map/route.ts`.
* 🎯 Why: When fetching map locations, multiple albums can share the same `subpageSlug`. Previously, `isAuthenticated` was called redundantly for each album, causing unnecessary HMAC calculations and config lookups.
* 📊 Impact: Significantly reduces CPU overhead and latency when generating the map payload for datasets with many albums under the same subpage.
* 🔬 Measurement: Verify the map loads faster and consumes fewer CPU cycles when there are many items by hitting the `/api/map` endpoint.

---
*PR created automatically by Jules for task [12412509511944102831](https://jules.google.com/task/12412509511944102831) started by @ralksta*