### PR TITLE
⚡ Bolt: Memoize auth checks in Map API

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -18,3 +18,6 @@
 ## 2024-05-30 - [O(1) Memory Bucketing for Coordinate Aggregation]
 **Learning:** When bucketing or grouping large datasets (e.g., thousands of map coordinates into geographical clusters), array allocations (`[].push()`) followed by `reduce` operations create an O(N) memory overhead per bucket and expensive post-processing loops.
 **Action:** Replace memory-heavy array collections with running statistical accumulators (e.g., `latSum`, `lngSum`, `count`) directly on the bucket. This reduces bucket memory from O(N) to O(1).
+## 2024-05-29 - Memoize repeated auth checks in Map API
+**Learning:** When filtering map locations, the API performs redundant `isAuthenticated` checks for albums within the same subpage slug. Since each check involves cryptographic operations (HMAC calculations), doing this repeatedly in a nested filter loop severely impacts performance for galleries with many geotagged photos.
+**Action:** Use a request-scoped `Map` to memoize the results of `isAuthenticated` calls within the route handler, preventing redundant cryptographic operations for the same subpage context.

--- a/app/api/map/route.ts
+++ b/app/api/map/route.ts
@@ -44,12 +44,16 @@ export async function GET(request: NextRequest) {
   const locations = await getMapData();
 
   // Filter locations and albums based on auth
+  const authCache = new Map<string, boolean>();
   const publicLocations = locations
     .map((loc) => {
       // Only keep albums the user is allowed to see
       const allowedAlbums = loc.albums.filter((a) => {
         if (!a.subpageSlug) return true; // Standalone albums are public
-        return isAuthenticated(a.subpageSlug, getCookie);
+        if (authCache.has(a.subpageSlug)) return authCache.get(a.subpageSlug)!;
+        const result = isAuthenticated(a.subpageSlug, getCookie);
+        authCache.set(a.subpageSlug, result);
+        return result;
       });
 
       if (allowedAlbums.length === 0) return null;


### PR DESCRIPTION
**What**: Introduced a request-scoped `Map` (`authCache`) in `app/api/map/route.ts` to memoize `isAuthenticated` calls. 
**Why**: The `getMapData` loop iterates over all albums across all locations. Albums within the same subpage slug trigger repeated `isAuthenticated` checks, which execute expensive HMAC cryptographic operations, causing performance degradation for large datasets. 
**Impact**: Eliminates redundant cryptographic operations during map data fetching, reducing CPU utilization and response times for the Map API. 
**Measurement**: Verify by profiling the execution time of the `GET /api/map` endpoint, which should show a significant reduction in CPU time spent in HMAC functions.

---
*PR created automatically by Jules for task [16222880595341767265](https://jules.google.com/task/16222880595341767265) started by @ralksta*