### PR TITLE
⚡ Bolt: Replace JSON serialization with structuredClone for deep cloning

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,7 @@
 ## 2024-05-29 - Memoize repeated auth checks in Map API
 **Learning:** When filtering map locations, the API performs redundant `isAuthenticated` checks for albums within the same subpage slug. Since each check involves cryptographic operations (HMAC calculations), doing this repeatedly in a nested filter loop severely impacts performance for galleries with many geotagged photos.
 **Action:** Use a request-scoped `Map` to memoize the results of `isAuthenticated` calls within the route handler, preventing redundant cryptographic operations for the same subpage context.
+
+## 2025-01-24 - [Avoid JSON serialization for deep cloning]
+**Learning:** For deep cloning JavaScript objects, use the native `structuredClone()` instead of `JSON.parse(JSON.stringify())` to avoid expensive serialization/deserialization, especially in high-frequency event handlers like React `onChange` functions. This reduces synchronous blocking time and CPU cycles.
+**Action:** Always prefer `structuredClone()` when deep cloning objects, and proactively look for `JSON.parse(JSON.stringify())` patterns to replace.

--- a/app/admin/components/SettingsEditor.tsx
+++ b/app/admin/components/SettingsEditor.tsx
@@ -170,7 +170,7 @@ export default function SettingsEditor() {
 
   function update(path: string, value: unknown) {
     setSettings((s) => {
-      const copy = JSON.parse(JSON.stringify(s));
+      const copy = structuredClone(s);
       const parts = path.split('.');
       let obj = copy;
       for (let i = 0; i < parts.length - 1; i++) {
@@ -194,7 +194,7 @@ export default function SettingsEditor() {
     setSaveMessage('');
 
     // Clean up empty objects
-    const cleaned = JSON.parse(JSON.stringify(settings));
+    const cleaned = structuredClone(settings);
     for (const key of Object.keys(cleaned)) {
       if (typeof cleaned[key] === 'object' && Object.keys(cleaned[key]).length === 0) {
         delete cleaned[key];

--- a/app/admin/components/SettingsEditor.tsx
+++ b/app/admin/components/SettingsEditor.tsx
@@ -172,7 +172,8 @@ export default function SettingsEditor() {
     setSettings((s) => {
       const copy = structuredClone(s);
       const parts = path.split('.');
-      let obj = copy;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let obj: any = copy;
       for (let i = 0; i < parts.length - 1; i++) {
         if (!obj[parts[i]]) obj[parts[i]] = {};
         obj = obj[parts[i]];
@@ -196,8 +197,10 @@ export default function SettingsEditor() {
     // Clean up empty objects
     const cleaned = structuredClone(settings);
     for (const key of Object.keys(cleaned)) {
-      if (typeof cleaned[key] === 'object' && Object.keys(cleaned[key]).length === 0) {
-        delete cleaned[key];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      if (typeof (cleaned as any)[key] === 'object' && Object.keys((cleaned as any)[key]).length === 0) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        delete (cleaned as any)[key];
       }
     }
 


### PR DESCRIPTION
💡 What: Replaced `JSON.parse(JSON.stringify())` with `structuredClone()` for deep cloning the settings object in SettingsEditor.tsx.
🎯 Why: `JSON.parse(JSON.stringify())` incurs unnecessary overhead from string serialization and deserialization, blocking the main thread during high-frequency events like input `onChange`.
📊 Impact: Reduces synchronous execution time for deep cloning, resulting in a smoother UI when typing or interacting with settings.
🔬 Measurement: Can be verified by profiling the JavaScript execution time during rapid input changes in the settings editor.

---
*PR created automatically by Jules for task [17882156231522413047](https://jules.google.com/task/17882156231522413047) started by @ralksta*