### PR TITLE
⚡ Bolt: Replace JSON.parse(JSON.stringify) with structuredClone

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,7 @@
 ## 2024-05-29 - Memoize repeated auth checks in Map API
 **Learning:** When filtering map locations, the API performs redundant `isAuthenticated` checks for albums within the same subpage slug. Since each check involves cryptographic operations (HMAC calculations), doing this repeatedly in a nested filter loop severely impacts performance for galleries with many geotagged photos.
 **Action:** Use a request-scoped `Map` to memoize the results of `isAuthenticated` calls within the route handler, preventing redundant cryptographic operations for the same subpage context.
+
+## 2024-06-11 - [Native structuredClone for deep copies]
+**Learning:** Using `JSON.parse(JSON.stringify())` to deep clone objects is inefficient because it requires serializing the entire object to a string and then deserializing it back into memory. This creates overhead and doesn't handle complex types like Date or Map natively.
+**Action:** Use the native `structuredClone()` function for deep cloning JavaScript objects to improve performance and preserve complex types. Cast to `any` in TypeScript if dynamic string-key mutations are required.

--- a/app/admin/components/SettingsEditor.tsx
+++ b/app/admin/components/SettingsEditor.tsx
@@ -55,7 +55,10 @@ const PHOTO_FRAMES = ['none', 'passepartout', 'shadow'];
 const HERO_STYLES = ['split', 'fullbleed', 'minimal', 'stacked', 'typographic', 'mosaic'];
 const ASPECT_RATIOS = ['1', '3/2', '2/3', '16/9', 'auto'];
 
-const THEME_INFO: Record<string, { desc: string; label: string; accent: string; bg: string; tile: string }> = {
+const THEME_INFO: Record<
+  string,
+  { desc: string; label: string; accent: string; bg: string; tile: string }
+> = {
   studio: {
     label: 'Studio',
     desc: 'Clean, high-contrast grid with sans-serif type.',
@@ -170,7 +173,7 @@ export default function SettingsEditor() {
 
   function update(path: string, value: unknown) {
     setSettings((s) => {
-      const copy = JSON.parse(JSON.stringify(s));
+      const copy = structuredClone(s) as any;
       const parts = path.split('.');
       let obj = copy;
       for (let i = 0; i < parts.length - 1; i++) {
@@ -194,7 +197,7 @@ export default function SettingsEditor() {
     setSaveMessage('');
 
     // Clean up empty objects
-    const cleaned = JSON.parse(JSON.stringify(settings));
+    const cleaned = structuredClone(settings) as any;
     for (const key of Object.keys(cleaned)) {
       if (typeof cleaned[key] === 'object' && Object.keys(cleaned[key]).length === 0) {
         delete cleaned[key];
@@ -348,7 +351,13 @@ export default function SettingsEditor() {
                 <label>Preset</label>
                 <div className="preset-card-grid">
                   {PRESETS.map((p) => {
-                    const info = THEME_INFO[p] || { label: p, desc: '', bg: '#fff', tile: '#eee', accent: '#333' };
+                    const info = THEME_INFO[p] || {
+                      label: p,
+                      desc: '',
+                      bg: '#fff',
+                      tile: '#eee',
+                      accent: '#333',
+                    };
                     const isActive = (settings.theme?.preset || 'studio') === p;
                     return (
                       <button
@@ -360,8 +369,16 @@ export default function SettingsEditor() {
                       >
                         <div className="preset-card-preview" style={{ backgroundColor: info.bg }}>
                           <div className="mini-header">
-                            <span className="mini-dot" style={{ backgroundColor: info.accent }}></span>
-                            <span className="mini-line" style={{ backgroundColor: isActive ? info.accent : 'var(--admin-border)' }}></span>
+                            <span
+                              className="mini-dot"
+                              style={{ backgroundColor: info.accent }}
+                            ></span>
+                            <span
+                              className="mini-line"
+                              style={{
+                                backgroundColor: isActive ? info.accent : 'var(--admin-border)',
+                              }}
+                            ></span>
                           </div>
                           <div className="mini-grid">
                             <div className="mini-tile" style={{ backgroundColor: info.tile }}></div>


### PR DESCRIPTION
💡 What: Replaced two instances of `JSON.parse(JSON.stringify())` with `structuredClone()` in `SettingsEditor.tsx`.\n🎯 Why: Using JSON serialization for deep cloning is computationally expensive. Native `structuredClone` is faster and handles more complex types correctly.\n📊 Impact: Improves rendering performance when updating settings, particularly for large configuration objects.\n🔬 Measurement: Verify by interacting with the Settings Editor and observing no regressions, and running `pnpm test`.

---
*PR created automatically by Jules for task [13475051900883390504](https://jules.google.com/task/13475051900883390504) started by @ralksta*