### PR TITLE
🛡️ Sentinel: [HIGH] Add rate limiting to admin login

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -25,3 +25,7 @@
 **Vulnerability:** Asset proxy routes (`/api/image/*`, `/api/video/*`) directly served the upstream `Content-Type` header without validation. Since these API routes are explicitly excluded from the Next.js Content Security Policy (CSP) matcher, returning types like `image/svg+xml` or `text/html` would execute scripts directly in the user's browser, leading to Stored XSS.
 **Learning:** Endpoints that serve user-controlled content and are not protected by global CSP headers require strict MIME-type validation. An attacker could upload an SVG containing malicious scripts and retrieve it via these proxy endpoints to bypass standard security controls.
 **Prevention:** Always sanitize the `Content-Type` header on proxy endpoints. First convert it to lowercase, remap required generic types (like `application/octet-stream` to `image/jpeg`), and finally enforce a strict positive allowlist (`startsWith('image/')` and `!includes('svg')`) before falling back to `application/octet-stream`.
+## 2024-06-25 - Missing Rate Limiting on Admin Auth
+**Vulnerability:** The admin authentication endpoint (`/api/admin/auth`) lacked rate limiting, allowing unlimited brute-force attempts.
+**Learning:** Even internal or admin-only endpoints are susceptible to brute-force attacks and must be protected like public auth endpoints.
+**Prevention:** Ensure all authentication endpoints, including admin ones, implement rate limiting.

--- a/app/api/admin/auth/route.ts
+++ b/app/api/admin/auth/route.ts
@@ -7,9 +7,31 @@ import {
   COOKIE_NAME,
   SESSION_DURATION_MS,
 } from '@/lib/admin/auth';
+import { checkRateLimit, getClientIp } from '@/lib/rate-limit';
+
+/** Tight limit for auth attempts — 10 per minute per IP. */
+const AUTH_RPM = 10;
 
 /** POST: Login with admin password. */
 export async function POST(request: NextRequest) {
+  // ── Rate limiting (brute-force protection) ──────────
+  const ip = getClientIp(request);
+  const { success, remaining, resetAt } = checkRateLimit(`admin-auth:${ip}`, AUTH_RPM);
+
+  if (!success) {
+    return NextResponse.json(
+      { error: 'Too many attempts, try again later' },
+      {
+        status: 429,
+        headers: {
+          'Retry-After': String(Math.ceil((resetAt - Date.now()) / 1000)),
+          'X-RateLimit-Limit': String(AUTH_RPM),
+          'X-RateLimit-Remaining': String(remaining),
+        },
+      },
+    );
+  }
+
   if (!isAdminEnabled()) {
     return NextResponse.json(
       { error: 'Admin panel is not enabled. Set ADMIN_PASSWORD in your environment.' },


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The admin authentication endpoint lacked rate limiting, making it vulnerable to brute-force and dictionary attacks on the admin password.
🎯 Impact: Attackers could submit unlimited password guesses against the admin panel, potentially gaining unauthorized administrative access to the application.
🔧 Fix: Implemented the existing rate limiting mechanism on the admin auth POST route, restricting attempts to 10 per minute per IP address.
✅ Verification: Tested locally by sending multiple requests to verify 429 Too Many Requests response is correctly triggered after 10 attempts.

---
*PR created automatically by Jules for task [14959099301829145666](https://jules.google.com/task/14959099301829145666) started by @ralksta*