### PR TITLE
🎨 Palette: Improve text-based icon accessibility for Scroll to Top

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -17,3 +17,7 @@
 ## 2024-06-18 - Dynamic Numeric Counters ARIA
 **Learning:** When displaying dynamic numeric text changes during navigation (like a lightbox image counter), the visual presentation (e.g., "1 / 5") does not provide sufficient context for screen reader users and might not be announced automatically.
 **Action:** Wrap the counter container with `aria-live="polite"` and `aria-atomic="true"`. Use `.sr-only` to provide a context-rich screen reader string (e.g., "Photo 1 of 5") and hide the visual short-hand using `aria-hidden="true"`.
+
+## 2024-06-22 - Text-Based Icon Buttons Accessibility
+**Learning:** When using text characters (like '↑' or '×') as icons inside buttons that already have a descriptive `aria-label`, screen readers may announce both the label and a literal description of the character (e.g. "Upwards arrow"), causing confusion.
+**Action:** Always wrap visual text-based icon characters in a `<span aria-hidden="true">` element so that screen readers ignore the character and only read the parent's `aria-label`.

--- a/components/ScrollToTop.tsx
+++ b/components/ScrollToTop.tsx
@@ -34,7 +34,7 @@ export function ScrollToTop() {
       tabIndex={visible ? 0 : -1}
       aria-hidden={!visible}
     >
-      ↑
+      <span aria-hidden="true">↑</span>
     </button>
   );
 }


### PR DESCRIPTION
💡 What: Wrapped the visual '↑' character in the `ScrollToTop` component within a `<span aria-hidden="true">`.
🎯 Why: Text-based characters used as icons can confuse screen readers by being read aloud in addition to the button's `aria-label` (e.g. 'Upwards arrow, Scroll to top').
📸 Before/After: Visual appearance remains identical.
♿ Accessibility: Ensures that screen readers correctly ignore the visual character and only announce the descriptive 'Scroll to top' `aria-label`.

---
*PR created automatically by Jules for task [1053810582524834218](https://jules.google.com/task/1053810582524834218) started by @ralksta*