### PR TITLE
🎨 Palette: Improve accessibility for text-based close buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -17,3 +17,7 @@
 ## 2024-06-18 - Dynamic Numeric Counters ARIA
 **Learning:** When displaying dynamic numeric text changes during navigation (like a lightbox image counter), the visual presentation (e.g., "1 / 5") does not provide sufficient context for screen reader users and might not be announced automatically.
 **Action:** Wrap the counter container with `aria-live="polite"` and `aria-atomic="true"`. Use `.sr-only` to provide a context-rich screen reader string (e.g., "Photo 1 of 5") and hide the visual short-hand using `aria-hidden="true"`.
+
+## 2024-06-25 - Text-based Icon Button Accessibility
+**Learning:** Screen readers will often try to pronounce text characters used as icons (like "×" for close) in unhelpful ways (e.g. "times" or "multiply"). Using just a `title` attribute is insufficient for full accessibility, as not all screen readers will announce it reliably, and missing an `aria-label` completely provides zero context.
+**Action:** When fixing accessibility for text-based icon buttons (e.g., buttons using characters like '×' instead of SVGs), wrap the visual text character in `<span aria-hidden="true">` and add a descriptive `aria-label` to the parent `<button>` to ensure correct screen reader announcements.

--- a/app/admin/components/AlbumPicker.tsx
+++ b/app/admin/components/AlbumPicker.tsx
@@ -37,8 +37,8 @@ export default function AlbumPicker({ albums, onSelect, onClose, usedAlbumIds }:
       <div className="picker-modal" onClick={(e) => e.stopPropagation()}>
         <div className="picker-header">
           <h3>Select Album</h3>
-          <button className="admin-btn-icon" onClick={onClose}>
-            ×
+          <button className="admin-btn-icon" onClick={onClose} aria-label="Close">
+            <span aria-hidden="true">×</span>
           </button>
         </div>
 

--- a/app/admin/components/AssetPicker.tsx
+++ b/app/admin/components/AssetPicker.tsx
@@ -114,8 +114,8 @@ export default function AssetPicker({
       <div className="asset-picker-modal" onClick={(e) => e.stopPropagation()}>
         <div className="picker-header">
           <h3>{title || 'Select Hero Image'}</h3>
-          <button className="admin-btn-icon" onClick={onClose}>
-            ×
+          <button className="admin-btn-icon" onClick={onClose} aria-label="Close">
+            <span aria-hidden="true">×</span>
           </button>
         </div>
 

--- a/app/admin/components/PageBuilder.tsx
+++ b/app/admin/components/PageBuilder.tsx
@@ -904,8 +904,8 @@ export default function PageBuilder() {
             onChange={(e) => setSearchQuery(e.target.value)}
           />
           {searchQuery && (
-            <button className="builder-search-clear" onClick={() => setSearchQuery('')} title="Clear search">
-              ×
+            <button className="builder-search-clear" onClick={() => setSearchQuery('')} title="Clear search" aria-label="Clear search">
+              <span aria-hidden="true">×</span>
             </button>
           )}
         </div>


### PR DESCRIPTION
💡 What: Wrapped text-based icon characters ('×') in `<span aria-hidden="true">` and added descriptive `aria-label` attributes to their parent `<button>` elements across picker modals and search fields.
🎯 Why: Screen readers often pronounce text characters used as icons unhelpfully (e.g. "times"). Hiding the character and providing a clear `aria-label` ("Close" or "Clear search") improves context and accessibility for keyboard and screen reader users.
📸 Before/After: Visuals remain unchanged, but screen reader announcements are corrected.
♿ Accessibility: Replaced poorly announced "×" characters with clear text labels ("Close" and "Clear search") via ARIA attributes.

---
*PR created automatically by Jules for task [14591650131220881107](https://jules.google.com/task/14591650131220881107) started by @ralksta*