### PR TITLE
⚡ Bolt: Replace JSON.parse(JSON.stringify) with structuredClone

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,7 @@
 ## 2024-05-29 - Memoize repeated auth checks in Map API
 **Learning:** When filtering map locations, the API performs redundant `isAuthenticated` checks for albums within the same subpage slug. Since each check involves cryptographic operations (HMAC calculations), doing this repeatedly in a nested filter loop severely impacts performance for galleries with many geotagged photos.
 **Action:** Use a request-scoped `Map` to memoize the results of `isAuthenticated` calls within the route handler, preventing redundant cryptographic operations for the same subpage context.
+
+## 2024-06-27 - Replace JSON.parse(JSON.stringify) with structuredClone
+**Learning:** `structuredClone` preserves strict typing in TS, requiring casting (e.g., `as any`) if the cloned object requires dynamic string-key mutations not defined in its interface.
+**Action:** When swapping `JSON.parse(JSON.stringify)` for `structuredClone` in TypeScript where index access operations occur, ensure the clone's type is adjusted (e.g. `as any`) to prevent "Element implicitly has an 'any' type because expression of type 'string' can't be used to index" compiler errors.

--- a/app/admin/components/SettingsEditor.tsx
+++ b/app/admin/components/SettingsEditor.tsx
@@ -170,7 +170,7 @@ export default function SettingsEditor() {
 
   function update(path: string, value: unknown) {
     setSettings((s) => {
-      const copy = JSON.parse(JSON.stringify(s));
+      const copy = structuredClone(s) as any;
       const parts = path.split('.');
       let obj = copy;
       for (let i = 0; i < parts.length - 1; i++) {
@@ -194,7 +194,7 @@ export default function SettingsEditor() {
     setSaveMessage('');
 
     // Clean up empty objects
-    const cleaned = JSON.parse(JSON.stringify(settings));
+    const cleaned = structuredClone(settings) as any;
     for (const key of Object.keys(cleaned)) {
       if (typeof cleaned[key] === 'object' && Object.keys(cleaned[key]).length === 0) {
         delete cleaned[key];


### PR DESCRIPTION
* 💡 What: Replace JSON.parse(JSON.stringify) with structuredClone in app/admin/components/SettingsEditor.tsx.
* 🎯 Why: Deep cloning using JSON.parse(JSON.stringify) involves expensive serialization/deserialization.
* 📊 Impact: Reduces CPU time for copying settings during updates.
* 🔬 Measurement: Measure the time taken in the update function or handleSave function during settings mutations.

---
*PR created automatically by Jules for task [11591825732999494315](https://jules.google.com/task/11591825732999494315) started by @ralksta*