### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix crypto.timingSafeEqual DoS and length leak vulnerabilities

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -25,3 +25,8 @@
 **Vulnerability:** Asset proxy routes (`/api/image/*`, `/api/video/*`) directly served the upstream `Content-Type` header without validation. Since these API routes are explicitly excluded from the Next.js Content Security Policy (CSP) matcher, returning types like `image/svg+xml` or `text/html` would execute scripts directly in the user's browser, leading to Stored XSS.
 **Learning:** Endpoints that serve user-controlled content and are not protected by global CSP headers require strict MIME-type validation. An attacker could upload an SVG containing malicious scripts and retrieve it via these proxy endpoints to bypass standard security controls.
 **Prevention:** Always sanitize the `Content-Type` header on proxy endpoints. First convert it to lowercase, remap required generic types (like `application/octet-stream` to `image/jpeg`), and finally enforce a strict positive allowlist (`startsWith('image/')` and `!includes('svg')`) before falling back to `application/octet-stream`.
+
+## 2024-06-28 - crypto.timingSafeEqual DoS and Length Leaks
+**Vulnerability:** `crypto.timingSafeEqual` was throwing unhandled exceptions when buffer lengths differed, causing DoS. Unconstrained input length caused memory exhaustion. Passwords were being compared dynamically which leaked length via side-channels.
+**Learning:** `crypto.timingSafeEqual` strictly requires equal-length buffers in Node.js. Variable-length comparisons must be hashed to a fixed length first to safely mitigate both length inference and DoS (via `Buffer.alloc`).
+**Prevention:** Always enforce a maximum string length on unauthenticated inputs and hash secrets to a fixed length before constant-time comparison.

--- a/lib/admin/auth.ts
+++ b/lib/admin/auth.ts
@@ -30,6 +30,8 @@ export function createAdminToken(): string {
 
 /** Verify a session token. Returns true if valid. */
 export function verifyAdminToken(token: string): boolean {
+  if (token.length > 4096) return false;
+
   const parts = token.split('.');
   if (parts.length !== 2) return false;
 
@@ -37,7 +39,15 @@ export function verifyAdminToken(token: string): boolean {
   const key = getSigningKey();
   const expectedSig = crypto.createHmac('sha256', key).update(data).digest('base64url');
 
-  if (!crypto.timingSafeEqual(Buffer.from(sig), Buffer.from(expectedSig))) {
+  const sigBuf = Buffer.from(sig);
+  const expectedBuf = Buffer.from(expectedSig);
+
+  if (sigBuf.length !== expectedBuf.length) {
+    crypto.timingSafeEqual(expectedBuf, expectedBuf); // Prevent timing attacks on length
+    return false;
+  }
+
+  if (!crypto.timingSafeEqual(sigBuf, expectedBuf)) {
     return false;
   }
 
@@ -54,17 +64,13 @@ export function verifyAdminToken(token: string): boolean {
 /** Verify admin password. */
 export function verifyAdminPassword(password: string): boolean {
   const adminPw = env.ADMIN_PASSWORD;
-  if (!adminPw) return false;
+  if (!adminPw || password.length > 4096) return false;
 
-  // Constant-time comparison
-  const pwBuf = Buffer.from(password);
-  const expectedBuf = Buffer.from(adminPw);
-  if (pwBuf.length !== expectedBuf.length) {
-    // Still do a comparison to prevent timing attacks on length
-    crypto.timingSafeEqual(pwBuf, Buffer.alloc(pwBuf.length));
-    return false;
-  }
-  return crypto.timingSafeEqual(pwBuf, expectedBuf);
+  // Hash to fixed length to prevent timing attacks on length and DoS
+  const pwHash = crypto.createHash('sha256').update(password).digest();
+  const expectedHash = crypto.createHash('sha256').update(adminPw).digest();
+
+  return crypto.timingSafeEqual(pwHash, expectedHash);
 }
 
 /** Check if the current request has a valid admin session. */


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: `crypto.timingSafeEqual` throws an exception when buffer lengths differ, causing DoS. Comparing raw variable-length passwords leaked their lengths and unconstrained buffer allocations allowed memory exhaustion.
🎯 Impact: Unauthenticated attackers could crash the application or exhaust memory by passing malformed tokens or excessively long passwords.
🔧 Fix: Added a maximum string length constraint to inputs. Handled buffer lengths gracefully and switched to hashing variable-length passwords to a fixed length before comparison.
✅ Verification: Tests pass. Tested timing safe equals behaviour locally in a JS scratchpad.

---
*PR created automatically by Jules for task [787112197341885949](https://jules.google.com/task/787112197341885949) started by @ralksta*