### PR TITLE
🎨 Palette: Improve accessibility of text-based icons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -17,3 +17,6 @@
 ## 2024-06-18 - Dynamic Numeric Counters ARIA
 **Learning:** When displaying dynamic numeric text changes during navigation (like a lightbox image counter), the visual presentation (e.g., "1 / 5") does not provide sufficient context for screen reader users and might not be announced automatically.
 **Action:** Wrap the counter container with `aria-live="polite"` and `aria-atomic="true"`. Use `.sr-only` to provide a context-rich screen reader string (e.g., "Photo 1 of 5") and hide the visual short-hand using `aria-hidden="true"`.
+## 2025-02-26 - Improved accessibility of text-based icon buttons
+**Learning:** Found several buttons using bare text characters (like ×, ✕, ↗, ↑) as icons without proper `aria-label`s or `aria-hidden` spans. This pattern breaks screen reader announcements and is common even in admin interfaces.
+**Action:** Always wrap visual text icon characters in `<span aria-hidden="true">` and add descriptive `aria-label`s to the parent `<button>` or `<a>` tag to ensure proper accessibility.

--- a/app/admin/components/AlbumPicker.tsx
+++ b/app/admin/components/AlbumPicker.tsx
@@ -37,8 +37,8 @@ export default function AlbumPicker({ albums, onSelect, onClose, usedAlbumIds }:
       <div className="picker-modal" onClick={(e) => e.stopPropagation()}>
         <div className="picker-header">
           <h3>Select Album</h3>
-          <button className="admin-btn-icon" onClick={onClose}>
-            ×
+          <button className="admin-btn-icon" onClick={onClose} aria-label="Close">
+            <span aria-hidden="true">×</span>
           </button>
         </div>
 

--- a/app/admin/components/AssetPicker.tsx
+++ b/app/admin/components/AssetPicker.tsx
@@ -114,8 +114,8 @@ export default function AssetPicker({
       <div className="asset-picker-modal" onClick={(e) => e.stopPropagation()}>
         <div className="picker-header">
           <h3>{title || 'Select Hero Image'}</h3>
-          <button className="admin-btn-icon" onClick={onClose}>
-            ×
+          <button className="admin-btn-icon" onClick={onClose} aria-label="Close">
+            <span aria-hidden="true">×</span>
           </button>
         </div>
 

--- a/app/admin/components/PageBuilder.tsx
+++ b/app/admin/components/PageBuilder.tsx
@@ -904,8 +904,8 @@ export default function PageBuilder() {
             onChange={(e) => setSearchQuery(e.target.value)}
           />
           {searchQuery && (
-            <button className="builder-search-clear" onClick={() => setSearchQuery('')} title="Clear search">
-              ×
+            <button className="builder-search-clear" onClick={() => setSearchQuery('')} title="Clear search" aria-label="Clear search">
+              <span aria-hidden="true">×</span>
             </button>
           )}
         </div>
@@ -1077,16 +1077,18 @@ export default function PageBuilder() {
                         rel="noopener noreferrer"
                         className="admin-btn-icon"
                         title="Preview this page"
+                        aria-label="Preview this page"
                         onClick={(e) => e.stopPropagation()}
                       >
-                        ↗
+                        <span aria-hidden="true">↗</span>
                       </a>
                       <button
                         className="admin-btn-icon"
                         onClick={() => setExpandedSubpage(null)}
                         title="Collapse"
+                        aria-label="Collapse"
                       >
-                        ✕
+                        <span aria-hidden="true">✕</span>
                       </button>
                       <button
                         className="admin-btn-icon admin-btn-icon-danger"

--- a/components/ScrollToTop.tsx
+++ b/components/ScrollToTop.tsx
@@ -34,7 +34,7 @@ export function ScrollToTop() {
       tabIndex={visible ? 0 : -1}
       aria-hidden={!visible}
     >
-      ↑
+      <span aria-hidden="true">↑</span>
     </button>
   );
 }


### PR DESCRIPTION
💡 What: Replaced bare text characters (×, ✕, ↗, ↑) acting as icons with accessible screen-reader hidden spans, and added aria-labels to their parent interactive elements.
🎯 Why: Text characters used as icons without proper ARIA attributes are announced confusingly by screen readers (e.g. "times" instead of "Close"). Wrapping them in aria-hidden spans and labeling the buttons makes the UI much more accessible.
📸 Before/After: Visuals remain identical, but screen reader announcements are now descriptive.
♿ Accessibility: Improved keyboard navigation and screen reader support for icon-only buttons across the admin panel and public site.

---
*PR created automatically by Jules for task [17342062838490501257](https://jules.google.com/task/17342062838490501257) started by @ralksta*