### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Denial of Service in Admin Auth Verification

### DIFF
--- a/lib/admin/auth.ts
+++ b/lib/admin/auth.ts
@@ -30,6 +30,8 @@ export function createAdminToken(): string {
 
 /** Verify a session token. Returns true if valid. */
 export function verifyAdminToken(token: string): boolean {
+  if (token.length > 500) return false;
+
   const parts = token.split('.');
   if (parts.length !== 2) return false;
 
@@ -37,7 +39,14 @@ export function verifyAdminToken(token: string): boolean {
   const key = getSigningKey();
   const expectedSig = crypto.createHmac('sha256', key).update(data).digest('base64url');
 
-  if (!crypto.timingSafeEqual(Buffer.from(sig), Buffer.from(expectedSig))) {
+  const sigBuf = Buffer.from(sig);
+  const expectedBuf = Buffer.from(expectedSig);
+
+  if (sigBuf.length !== expectedBuf.length) {
+    return false;
+  }
+
+  if (!crypto.timingSafeEqual(sigBuf, expectedBuf)) {
     return false;
   }
 
@@ -53,18 +62,16 @@ export function verifyAdminToken(token: string): boolean {
 
 /** Verify admin password. */
 export function verifyAdminPassword(password: string): boolean {
+  if (password.length > 1000) return false;
+
   const adminPw = env.ADMIN_PASSWORD;
   if (!adminPw) return false;
 
-  // Constant-time comparison
-  const pwBuf = Buffer.from(password);
-  const expectedBuf = Buffer.from(adminPw);
-  if (pwBuf.length !== expectedBuf.length) {
-    // Still do a comparison to prevent timing attacks on length
-    crypto.timingSafeEqual(pwBuf, Buffer.alloc(pwBuf.length));
-    return false;
-  }
-  return crypto.timingSafeEqual(pwBuf, expectedBuf);
+  // Hash both to a fixed length before constant-time comparison to prevent timing and length attacks
+  const pwHash = crypto.createHash('sha256').update(password).digest();
+  const expectedHash = crypto.createHash('sha256').update(adminPw).digest();
+
+  return crypto.timingSafeEqual(pwHash, expectedHash);
 }
 
 /** Check if the current request has a valid admin session. */


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: `verifyAdminToken` passes potentially mis-sized signature buffers directly to `crypto.timingSafeEqual`, throwing an unhandled exception that crashes the Node.js server. `verifyAdminPassword` is also vulnerable to DoS via unconstrained input length.
🎯 Impact: Attackers can crash the server (Denial of Service) by supplying a malformed admin session token with an incorrect signature length, or by sending massive password strings to memory exhaust the server.
🔧 Fix: Verified buffer lengths match before `timingSafeEqual` in token verification. Added strict maximum input limits to tokens and passwords. Switched password comparison to hash inputs to a fixed length before comparison, preventing both length-based timing attacks and buffer size mismatch crashes.
✅ Verification: Ran unit tests and manually tested `timingSafeEqual` exception handling in node repl. Tested token invalidation and password verification.

---
*PR created automatically by Jules for task [8311344904964034975](https://jules.google.com/task/8311344904964034975) started by @ralksta*