### PR TITLE
⚡ Bolt: Replace JSON.parse(JSON.stringify) with structuredClone

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-07-07 - Deep cloning large settings states
+**Learning:** `JSON.parse(JSON.stringify())` performs string serialization that consumes CPU cycles and increases memory overhead, particularly noticeable on frequently updated or deeply nested settings states in React.
+**Action:** Use native `structuredClone()` to perform deep copies natively in JavaScript for better performance, but ensure it is correctly cast if dynamic property assignment is required since it preserves strict typing.

--- a/app/admin/components/SettingsEditor.tsx
+++ b/app/admin/components/SettingsEditor.tsx
@@ -55,7 +55,10 @@ const PHOTO_FRAMES = ['none', 'passepartout', 'shadow'];
 const HERO_STYLES = ['split', 'fullbleed', 'minimal', 'stacked', 'typographic', 'mosaic'];
 const ASPECT_RATIOS = ['1', '3/2', '2/3', '16/9', 'auto'];
 
-const THEME_INFO: Record<string, { desc: string; label: string; accent: string; bg: string; tile: string }> = {
+const THEME_INFO: Record<
+  string,
+  { desc: string; label: string; accent: string; bg: string; tile: string }
+> = {
   studio: {
     label: 'Studio',
     desc: 'Clean, high-contrast grid with sans-serif type.',
@@ -170,7 +173,8 @@ export default function SettingsEditor() {
 
   function update(path: string, value: unknown) {
     setSettings((s) => {
-      const copy = JSON.parse(JSON.stringify(s));
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const copy = structuredClone(s) as any;
       const parts = path.split('.');
       let obj = copy;
       for (let i = 0; i < parts.length - 1; i++) {
@@ -194,7 +198,8 @@ export default function SettingsEditor() {
     setSaveMessage('');
 
     // Clean up empty objects
-    const cleaned = JSON.parse(JSON.stringify(settings));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cleaned = structuredClone(settings) as any;
     for (const key of Object.keys(cleaned)) {
       if (typeof cleaned[key] === 'object' && Object.keys(cleaned[key]).length === 0) {
         delete cleaned[key];
@@ -348,7 +353,13 @@ export default function SettingsEditor() {
                 <label>Preset</label>
                 <div className="preset-card-grid">
                   {PRESETS.map((p) => {
-                    const info = THEME_INFO[p] || { label: p, desc: '', bg: '#fff', tile: '#eee', accent: '#333' };
+                    const info = THEME_INFO[p] || {
+                      label: p,
+                      desc: '',
+                      bg: '#fff',
+                      tile: '#eee',
+                      accent: '#333',
+                    };
                     const isActive = (settings.theme?.preset || 'studio') === p;
                     return (
                       <button
@@ -360,8 +371,16 @@ export default function SettingsEditor() {
                       >
                         <div className="preset-card-preview" style={{ backgroundColor: info.bg }}>
                           <div className="mini-header">
-                            <span className="mini-dot" style={{ backgroundColor: info.accent }}></span>
-                            <span className="mini-line" style={{ backgroundColor: isActive ? info.accent : 'var(--admin-border)' }}></span>
+                            <span
+                              className="mini-dot"
+                              style={{ backgroundColor: info.accent }}
+                            ></span>
+                            <span
+                              className="mini-line"
+                              style={{
+                                backgroundColor: isActive ? info.accent : 'var(--admin-border)',
+                              }}
+                            ></span>
                           </div>
                           <div className="mini-grid">
                             <div className="mini-tile" style={{ backgroundColor: info.tile }}></div>


### PR DESCRIPTION
💡 What: Replaced two instances of `JSON.parse(JSON.stringify)` with native `structuredClone()` in `SettingsEditor.tsx`. Added `as any` and eslint disable comments to satisfy TypeScript because `structuredClone` preserves strict typing and dynamic key updates are made on the objects.
🎯 Why: `JSON.parse(JSON.stringify)` is significantly slower and less memory efficient because it serializes the object to a string before parsing it back. `structuredClone` natively performs deep cloning, avoiding string serialization overhead.
📊 Impact: Reduces memory usage and CPU overhead when modifying complex settings objects. Avoids string serialization overhead entirely.
🔬 Measurement: Verify by interacting with SettingsEditor and observing faster state updates on large settings configurations without functional regressions.

---
*PR created automatically by Jules for task [1225303077343833029](https://jules.google.com/task/1225303077343833029) started by @ralksta*