### PR TITLE
🎨 Palette: Add aria-hidden to text-based icon buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-07-09 - Accessible Icon Buttons
+**Learning:** Found several text-based icon buttons in the admin and dev toolbar components (using characters like '×', '✕', '↑', '🎨') that lack screen reader accessibility. Although some have `aria-label` or `title`, the text character itself is announced by screen readers, which can be confusing (e.g., "times" or "multiplication X" instead of "close").
+**Action:** When using text characters as icons in buttons, wrap the character in a `<span aria-hidden="true">` to hide it from screen readers, and rely on the `aria-label` on the parent button for accessibility.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,25 +61,26 @@ Singleton `ImmichClient` class exported as `immich`. All Immich API calls are se
 
 ### API routes (`app/api/`)
 
-| Route | Purpose |
-|---|---|
-| `GET /api/image/[id]` | Image proxy — decodes token, rate-limits, streams from Immich |
-| `GET /api/exif/[id]` | EXIF data for lightbox panel |
-| `POST /api/auth` | Password submission → sets `HttpOnly` cookie |
-| `GET /api/og` | Dynamic OG image generation (rate-limited) |
-| `GET /api/map` | Aggregated GPS coordinates for map view |
-| `GET /api/health` | Health check |
-| `GET/POST/DELETE /api/admin/auth` | Admin login, session check, logout |
-| `GET/PUT /api/admin/gallery` | Read/write `gallery.yaml` |
-| `GET/PUT /api/admin/settings` | Read/write `settings.yaml` |
-| `GET /api/admin/albums` | Browse all shared Immich albums (admin-only) |
-| `POST /api/admin/reload` | Invalidate config + Immich cache |
+| Route                             | Purpose                                                       |
+| --------------------------------- | ------------------------------------------------------------- |
+| `GET /api/image/[id]`             | Image proxy — decodes token, rate-limits, streams from Immich |
+| `GET /api/exif/[id]`              | EXIF data for lightbox panel                                  |
+| `POST /api/auth`                  | Password submission → sets `HttpOnly` cookie                  |
+| `GET /api/og`                     | Dynamic OG image generation (rate-limited)                    |
+| `GET /api/map`                    | Aggregated GPS coordinates for map view                       |
+| `GET /api/health`                 | Health check                                                  |
+| `GET/POST/DELETE /api/admin/auth` | Admin login, session check, logout                            |
+| `GET/PUT /api/admin/gallery`      | Read/write `gallery.yaml`                                     |
+| `GET/PUT /api/admin/settings`     | Read/write `settings.yaml`                                    |
+| `GET /api/admin/albums`           | Browse all shared Immich albums (admin-only)                  |
+| `POST /api/admin/reload`          | Invalidate config + Immich cache                              |
 
 The image proxy maps requested pixel widths (`?w=`) to Immich size tiers: `≤250px→thumbnail`, `≤1440px→preview`, `>1440px→original`.
 
 ### Routing (`app/[...path]/page.tsx`)
 
 Single catch-all route handles three cases:
+
 1. `/[subpage-slug]/[album-slug]` — renders album detail with back-link to subpage
 2. `/[subpage-slug]` — if subpage has >1 album, renders `SubpageGridView`; if exactly 1 album, renders `AlbumDetailView` directly
 3. `/[album-slug]` — standalone album detail

--- a/README.md
+++ b/README.md
@@ -99,11 +99,11 @@ ADMIN_PASSWORD=your-secure-password   # enables /admin panel
 
 Create a dedicated API key in Immich under **Account Settings → API Keys**. Immich Folio only needs **read access** — it never modifies your library.
 
-| Permission | Required | Used for |
-|---|---|---|
-| `album.read` | ✅ Yes | List and fetch album metadata & photo lists |
-| `asset.read` | ✅ Yes | Fetch asset metadata, EXIF data, thumbnails, previews, and originals |
-| `asset.view` | ✅ Yes | Stream image/video files (thumbnail, preview, video playback) |
+| Permission   | Required | Used for                                                             |
+| ------------ | -------- | -------------------------------------------------------------------- |
+| `album.read` | ✅ Yes   | List and fetch album metadata & photo lists                          |
+| `asset.read` | ✅ Yes   | Fetch asset metadata, EXIF data, thumbnails, previews, and originals |
+| `asset.view` | ✅ Yes   | Stream image/video files (thumbnail, preview, video playback)        |
 
 > **No write permissions needed.** `album.create`, `asset.upload`, `asset.delete`, etc. can all be left **off**.
 

--- a/app/[...path]/AlbumDetailView.tsx
+++ b/app/[...path]/AlbumDetailView.tsx
@@ -40,7 +40,9 @@ export function AlbumDetailView({
             priority
             sizes="100vw"
             style={{ objectFit: 'cover' }}
-            {...(heroBlurDataURL ? { placeholder: 'blur' as const, blurDataURL: heroBlurDataURL } : {})}
+            {...(heroBlurDataURL
+              ? { placeholder: 'blur' as const, blurDataURL: heroBlurDataURL }
+              : {})}
           />
           <div className="album-hero__overlay" />
         </div>

--- a/app/admin/admin.css
+++ b/app/admin/admin.css
@@ -539,7 +539,9 @@
   border: 1px solid var(--admin-border);
   border-radius: 10px;
   overflow: hidden;
-  transition: border-color 0.15s, box-shadow 0.15s;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
 }
 
 .album-tile:hover {
@@ -705,7 +707,10 @@
   border-radius: 10px;
   overflow: hidden;
   cursor: pointer;
-  transition: border-color 0.15s, box-shadow 0.15s, transform 0.1s;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s,
+    transform 0.1s;
 }
 
 .subpage-tile:hover {
@@ -769,8 +774,14 @@
 }
 
 @keyframes slideDown {
-  from { opacity: 0; transform: translateY(-4px); }
-  to { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .subpage-detail-header {
@@ -1116,8 +1127,11 @@
   cursor: pointer;
   padding: 0;
   text-align: left;
-  transition: transform 0.2s cubic-bezier(0.16, 1, 0.3, 1), border-color 0.2s, box-shadow 0.2s;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  transition:
+    transform 0.2s cubic-bezier(0.16, 1, 0.3, 1),
+    border-color 0.2s,
+    box-shadow 0.2s;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
 }
 
 .preset-card:hover {
@@ -1397,15 +1411,27 @@
 
 /* Keyframes */
 @keyframes pulse-green {
-  0% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.4); }
-  70% { box-shadow: 0 0 0 6px rgba(16, 185, 129, 0); }
-  100% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0); }
+  0% {
+    box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.4);
+  }
+  70% {
+    box-shadow: 0 0 0 6px rgba(16, 185, 129, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(16, 185, 129, 0);
+  }
 }
 
 @keyframes pulse-red {
-  0% { box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.4); }
-  70% { box-shadow: 0 0 0 6px rgba(239, 68, 68, 0); }
-  100% { box-shadow: 0 0 0 0 rgba(239, 68, 68, 0); }
+  0% {
+    box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.4);
+  }
+  70% {
+    box-shadow: 0 0 0 6px rgba(239, 68, 68, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(239, 68, 68, 0);
+  }
 }
 
 /* Color Field */
@@ -1528,7 +1554,9 @@
   cursor: pointer;
   background: var(--admin-bg-elevated);
   border: 2px solid transparent;
-  transition: border-color 0.15s, transform 0.1s;
+  transition:
+    border-color 0.15s,
+    transform 0.1s;
 }
 
 .asset-picker-tile:hover:not(.used) {
@@ -1737,7 +1765,9 @@
   width: 1em;
   height: 1em;
   stroke-width: 2px;
-  transition: transform 0.2s ease, color 0.15s ease;
+  transition:
+    transform 0.2s ease,
+    color 0.15s ease;
 }
 
 .svg-drag {
@@ -2145,7 +2175,9 @@ h3 .svg-icon {
   padding: 1.25rem;
   margin-bottom: 1.25rem;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
-  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
 }
 
 .section-card:hover {

--- a/app/admin/components/AdminDashboard.tsx
+++ b/app/admin/components/AdminDashboard.tsx
@@ -89,18 +89,22 @@ export default function AdminDashboard({ onLogout }: Props) {
             >
               <span className="status-dot"></span>
               <span className="status-text">
-                {statusLoading ? 'Checking...' : status?.immich?.status === 'connected' ? 'System OK' : 'System Degraded'}
+                {statusLoading
+                  ? 'Checking...'
+                  : status?.immich?.status === 'connected'
+                    ? 'System OK'
+                    : 'System Degraded'}
               </span>
             </button>
-            
+
             {showStatus && (
               <>
                 <div className="status-dropdown-backdrop" onClick={() => setShowStatus(false)} />
                 <div className="status-dropdown">
                   <div className="status-dropdown-header">
                     <h4>System Diagnostics</h4>
-                    <button 
-                      className="status-refresh-btn" 
+                    <button
+                      className="status-refresh-btn"
                       onClick={fetchStatus}
                       disabled={statusLoading}
                       title="Refresh diagnostics"
@@ -111,13 +115,17 @@ export default function AdminDashboard({ onLogout }: Props) {
                   <div className="status-dropdown-body">
                     <div className="status-item">
                       <span className="status-label">Immich Connection</span>
-                      <span className={`status-val ${status?.immich?.status === 'connected' ? 'ok' : 'error'}`}>
+                      <span
+                        className={`status-val ${status?.immich?.status === 'connected' ? 'ok' : 'error'}`}
+                      >
                         {status?.immich?.status === 'connected' ? 'Connected' : 'Disconnected'}
                       </span>
                     </div>
                     <div className="status-item">
                       <span className="status-label">Config Integrity</span>
-                      <span className={`status-val ${status?.config?.status === 'valid' ? 'ok' : 'error'}`}>
+                      <span
+                        className={`status-val ${status?.config?.status === 'valid' ? 'ok' : 'error'}`}
+                      >
                         {status?.config?.status === 'valid' ? 'Valid' : 'Degraded'}
                       </span>
                     </div>
@@ -128,7 +136,9 @@ export default function AdminDashboard({ onLogout }: Props) {
                     <div className="status-item">
                       <span className="status-label">Latest Backup</span>
                       <span className="status-val" title={status?.backups?.lastBackup || 'None'}>
-                        {status?.backups?.lastBackup ? new Date(status.backups.lastBackup).toLocaleDateString() : 'None'}
+                        {status?.backups?.lastBackup
+                          ? new Date(status.backups.lastBackup).toLocaleDateString()
+                          : 'None'}
                       </span>
                     </div>
                     <div className="status-item">

--- a/app/admin/components/AlbumPicker.tsx
+++ b/app/admin/components/AlbumPicker.tsx
@@ -38,7 +38,7 @@ export default function AlbumPicker({ albums, onSelect, onClose, usedAlbumIds }:
         <div className="picker-header">
           <h3>Select Album</h3>
           <button className="admin-btn-icon" onClick={onClose}>
-            ×
+            <span aria-hidden="true">×</span>
           </button>
         </div>
 

--- a/app/admin/components/AssetPicker.tsx
+++ b/app/admin/components/AssetPicker.tsx
@@ -115,7 +115,7 @@ export default function AssetPicker({
         <div className="picker-header">
           <h3>{title || 'Select Hero Image'}</h3>
           <button className="admin-btn-icon" onClick={onClose}>
-            ×
+            <span aria-hidden="true">×</span>
           </button>
         </div>
 

--- a/app/admin/components/PageBuilder.tsx
+++ b/app/admin/components/PageBuilder.tsx
@@ -25,7 +25,13 @@ import AssetPicker from './AssetPicker';
 // ── Icons ──────────────────────────────────────────────────────
 const Icons = {
   Drag: () => (
-    <svg width="12" height="18" viewBox="0 0 12 18" fill="currentColor" className="svg-icon svg-drag">
+    <svg
+      width="12"
+      height="18"
+      viewBox="0 0 12 18"
+      fill="currentColor"
+      className="svg-icon svg-drag"
+    >
       <circle cx="2" cy="2" r="1.5" />
       <circle cx="2" cy="9" r="1.5" />
       <circle cx="2" cy="16" r="1.5" />
@@ -35,77 +41,207 @@ const Icons = {
     </svg>
   ),
   Edit: () => (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="svg-icon"
+    >
       <path d="M12 20h9" />
       <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z" />
     </svg>
   ),
   Trash: () => (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="svg-icon"
+    >
       <path d="M3 6h18" />
       <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />
       <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
     </svg>
   ),
   Close: () => (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="svg-icon"
+    >
       <path d="M18 6 6 18M6 6l12 12" />
     </svg>
   ),
   Folder: () => (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="svg-icon"
+    >
       <path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z" />
     </svg>
   ),
   Camera: () => (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="svg-icon"
+    >
       <path d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3Z" />
       <circle cx="12" cy="13" r="3" />
     </svg>
   ),
   ExternalLink: () => (
-    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="svg-icon"
+    >
       <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
       <polyline points="15 3 21 3 21 9" />
       <line x1="10" y1="14" x2="21" y2="3" />
     </svg>
   ),
   Search: () => (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="svg-icon"
+    >
       <circle cx="11" cy="11" r="8" />
       <path d="m21 21-4.3-4.3" />
     </svg>
   ),
   Lock: () => (
-    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="svg-icon"
+    >
       <rect width="18" height="11" x="3" y="11" rx="2" ry="2" />
       <path d="M7 11V7a5 5 0 0 1 10 0v4" />
     </svg>
   ),
   Plus: () => (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="svg-icon"
+    >
       <path d="M5 12h14M12 5v14" />
     </svg>
   ),
   Home: () => (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="svg-icon"
+    >
       <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
       <polyline points="9 22 9 12 15 12 15 22" />
     </svg>
   ),
   Copy: () => (
-    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="svg-icon"
+    >
       <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
       <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
     </svg>
   ),
   Check: () => (
-    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="svg-icon"
+    >
       <polyline points="20 6 9 17 4 12" />
     </svg>
   ),
   Image: () => (
-    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="svg-icon"
+    >
       <rect width="18" height="18" x="3" y="3" rx="2" ry="2" />
       <circle cx="9" cy="9" r="2" />
       <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21" />
@@ -192,7 +328,10 @@ function serializeAlbumEntries(
   entries: AlbumEntry[],
 ): Array<
   | string
-  | Record<string, string | { title: string; description?: string; password?: string; heroImage?: string }>
+  | Record<
+      string,
+      string | { title: string; description?: string; password?: string; heroImage?: string }
+    >
 > {
   return entries.map((entry) => {
     if (!entry.title && !entry.description && !entry.password && !entry.heroImage) return entry.id;
@@ -372,7 +511,9 @@ export default function PageBuilder() {
     title?: string;
   } | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
-  const [editingAlbumAddress, setEditingAlbumAddress] = useState<ActiveEditAlbumAddress | null>(null);
+  const [editingAlbumAddress, setEditingAlbumAddress] = useState<ActiveEditAlbumAddress | null>(
+    null,
+  );
 
   // DnD sensors
   const sensors = useSensors(
@@ -831,7 +972,12 @@ export default function PageBuilder() {
     const description = (album.description || '').toLowerCase();
     const overrideTitle = (album.title || '').toLowerCase();
     const query = searchQuery.toLowerCase();
-    return name.includes(query) || description.includes(query) || overrideTitle.includes(query) || album.id.toLowerCase().includes(query);
+    return (
+      name.includes(query) ||
+      description.includes(query) ||
+      overrideTitle.includes(query) ||
+      album.id.toLowerCase().includes(query)
+    );
   });
 
   // Filter subpages
@@ -843,17 +989,22 @@ export default function PageBuilder() {
       const name = sp.name.toLowerCase();
       const title = (sp.title || '').toLowerCase();
       const subtitle = (sp.subtitle || '').toLowerCase();
-      
+
       if (name.includes(query) || title.includes(query) || subtitle.includes(query)) return true;
-      
+
       const albums = sp.albums || [];
       const hasMatchingAlbum = albums.some((a) => {
         const aName = getAlbumName(a.id).toLowerCase();
         const aTitle = (a.title || '').toLowerCase();
         const aDesc = (a.description || '').toLowerCase();
-        return aName.includes(query) || aTitle.includes(query) || aDesc.includes(query) || a.id.toLowerCase().includes(query);
+        return (
+          aName.includes(query) ||
+          aTitle.includes(query) ||
+          aDesc.includes(query) ||
+          a.id.toLowerCase().includes(query)
+        );
       });
-      
+
       return hasMatchingAlbum;
     });
 
@@ -904,8 +1055,12 @@ export default function PageBuilder() {
             onChange={(e) => setSearchQuery(e.target.value)}
           />
           {searchQuery && (
-            <button className="builder-search-clear" onClick={() => setSearchQuery('')} title="Clear search">
-              ×
+            <button
+              className="builder-search-clear"
+              onClick={() => setSearchQuery('')}
+              title="Clear search"
+            >
+              <span aria-hidden="true">×</span>
             </button>
           )}
         </div>
@@ -914,7 +1069,9 @@ export default function PageBuilder() {
       {/* Hero Section */}
       <section className="builder-section">
         <div className="builder-section-header">
-          <h2><Icons.Home /> Homepage Hero</h2>
+          <h2>
+            <Icons.Home /> Homepage Hero
+          </h2>
           <button
             className="admin-btn admin-btn-sm"
             onClick={() =>
@@ -982,7 +1139,9 @@ export default function PageBuilder() {
             <div className="album-list">
               {filteredAlbums.length === 0 && (
                 <p className="empty-hint">
-                  {searchQuery ? 'No matching standalone albums found.' : 'No standalone albums. These show directly on the homepage.'}
+                  {searchQuery
+                    ? 'No matching standalone albums found.'
+                    : 'No standalone albums. These show directly on the homepage.'}
                 </p>
               )}
               {filteredAlbums.map((album) => {
@@ -996,7 +1155,9 @@ export default function PageBuilder() {
                     count={getAlbumCount(album.id)}
                     thumbnailId={getAlbumThumbnailId(album.id)}
                     onRemove={() => removeStandaloneAlbum(originalIndex)}
-                    onEdit={() => setEditingAlbumAddress({ type: 'standalone', albumIndex: originalIndex })}
+                    onEdit={() =>
+                      setEditingAlbumAddress({ type: 'standalone', albumIndex: originalIndex })
+                    }
                   />
                 );
               })}
@@ -1021,9 +1182,7 @@ export default function PageBuilder() {
         )}
 
         {gallery.subpages.length > 0 && filteredSubpages.length === 0 && (
-          <p className="empty-hint">
-            No matching subpages found.
-          </p>
+          <p className="empty-hint">No matching subpages found.</p>
         )}
 
         {/* Collapsed overview grid with DnD */}
@@ -1086,7 +1245,7 @@ export default function PageBuilder() {
                         onClick={() => setExpandedSubpage(null)}
                         title="Collapse"
                       >
-                        ✕
+                        <span aria-hidden="true">✕</span>
                       </button>
                       <button
                         className="admin-btn-icon admin-btn-icon-danger"
@@ -1173,7 +1332,13 @@ export default function PageBuilder() {
                                 count={getAlbumCount(album.id)}
                                 thumbnailId={getAlbumThumbnailId(album.id)}
                                 onRemove={() => removeSubpageAlbum(spIndex, aIndex)}
-                                onEdit={() => setEditingAlbumAddress({ type: 'subpage', subpageIndex: spIndex, albumIndex: aIndex })}
+                                onEdit={() =>
+                                  setEditingAlbumAddress({
+                                    type: 'subpage',
+                                    subpageIndex: spIndex,
+                                    albumIndex: aIndex,
+                                  })
+                                }
                               />
                             ))}
                           </div>
@@ -1225,7 +1390,14 @@ export default function PageBuilder() {
                                 count={getAlbumCount(album.id)}
                                 thumbnailId={getAlbumThumbnailId(album.id)}
                                 onRemove={() => removeSectionAlbum(spIndex, secIndex, aIndex)}
-                                onEdit={() => setEditingAlbumAddress({ type: 'section', subpageIndex: spIndex, sectionIndex: secIndex, albumIndex: aIndex })}
+                                onEdit={() =>
+                                  setEditingAlbumAddress({
+                                    type: 'section',
+                                    subpageIndex: spIndex,
+                                    sectionIndex: secIndex,
+                                    albumIndex: aIndex,
+                                  })
+                                }
                               />
                             ))}
                           </div>
@@ -1328,9 +1500,7 @@ export default function PageBuilder() {
                     </div>
                     <div className="modal-info-item">
                       <span className="modal-info-label">Custom Hero:</span>
-                      <span className="modal-info-value">
-                        {album.heroImage ? 'Yes' : 'No'}
-                      </span>
+                      <span className="modal-info-value">{album.heroImage ? 'Yes' : 'No'}</span>
                     </div>
                   </div>
 
@@ -1592,11 +1762,7 @@ function AlbumCard({
           </div>
         )}
         <div className="album-tile-overlay">
-          <button
-            className="album-tile-btn"
-            onClick={onEdit}
-            title="Edit details"
-          >
+          <button className="album-tile-btn" onClick={onEdit} title="Edit details">
             <Icons.Edit />
           </button>
           <button
@@ -1610,7 +1776,10 @@ function AlbumCard({
       </div>
       <div className="album-tile-info">
         <div className="album-tile-title-row">
-          <span className={`album-tile-name ${hasTitleOverride ? 'custom-title' : ''}`} title={album.title || name}>
+          <span
+            className={`album-tile-name ${hasTitleOverride ? 'custom-title' : ''}`}
+            title={album.title || name}
+          >
             {album.title || name}
           </span>
           <div className="album-tile-badges">

--- a/app/admin/components/SettingsEditor.tsx
+++ b/app/admin/components/SettingsEditor.tsx
@@ -55,7 +55,10 @@ const PHOTO_FRAMES = ['none', 'passepartout', 'shadow'];
 const HERO_STYLES = ['split', 'fullbleed', 'minimal', 'stacked', 'typographic', 'mosaic'];
 const ASPECT_RATIOS = ['1', '3/2', '2/3', '16/9', 'auto'];
 
-const THEME_INFO: Record<string, { desc: string; label: string; accent: string; bg: string; tile: string }> = {
+const THEME_INFO: Record<
+  string,
+  { desc: string; label: string; accent: string; bg: string; tile: string }
+> = {
   studio: {
     label: 'Studio',
     desc: 'Clean, high-contrast grid with sans-serif type.',
@@ -348,7 +351,13 @@ export default function SettingsEditor() {
                 <label>Preset</label>
                 <div className="preset-card-grid">
                   {PRESETS.map((p) => {
-                    const info = THEME_INFO[p] || { label: p, desc: '', bg: '#fff', tile: '#eee', accent: '#333' };
+                    const info = THEME_INFO[p] || {
+                      label: p,
+                      desc: '',
+                      bg: '#fff',
+                      tile: '#eee',
+                      accent: '#333',
+                    };
                     const isActive = (settings.theme?.preset || 'studio') === p;
                     return (
                       <button
@@ -360,8 +369,16 @@ export default function SettingsEditor() {
                       >
                         <div className="preset-card-preview" style={{ backgroundColor: info.bg }}>
                           <div className="mini-header">
-                            <span className="mini-dot" style={{ backgroundColor: info.accent }}></span>
-                            <span className="mini-line" style={{ backgroundColor: isActive ? info.accent : 'var(--admin-border)' }}></span>
+                            <span
+                              className="mini-dot"
+                              style={{ backgroundColor: info.accent }}
+                            ></span>
+                            <span
+                              className="mini-line"
+                              style={{
+                                backgroundColor: isActive ? info.accent : 'var(--admin-border)',
+                              }}
+                            ></span>
                           </div>
                           <div className="mini-grid">
                             <div className="mini-tile" style={{ backgroundColor: info.tile }}></div>

--- a/app/api/admin/gallery/route.ts
+++ b/app/api/admin/gallery/route.ts
@@ -45,7 +45,10 @@ export async function PUT(request: Request) {
     immich.invalidateAll();
     // Revalidate all pages so the homepage picks up new hero images immediately
     revalidatePath('/', 'layout');
-    return NextResponse.json({ success: true, message: 'Saved successfully. Backup of previous version created.' });
+    return NextResponse.json({
+      success: true,
+      message: 'Saved successfully. Backup of previous version created.',
+    });
   } catch (err) {
     console.error('[Admin] Failed to write gallery.yaml:', err);
     return NextResponse.json({ error: 'Failed to save gallery config' }, { status: 500 });

--- a/app/api/admin/settings/route.ts
+++ b/app/api/admin/settings/route.ts
@@ -40,7 +40,10 @@ export async function PUT(request: Request) {
     invalidateConfigCache();
     immich.invalidateAll();
     revalidatePath('/', 'layout');
-    return NextResponse.json({ success: true, message: 'Saved successfully. Backup of previous version created.' });
+    return NextResponse.json({
+      success: true,
+      message: 'Saved successfully. Backup of previous version created.',
+    });
   } catch (err) {
     console.error('[Admin] Failed to write settings.yaml:', err);
     return NextResponse.json({ error: 'Failed to save settings' }, { status: 500 });

--- a/app/api/admin/status/route.ts
+++ b/app/api/admin/status/route.ts
@@ -41,7 +41,7 @@ export async function GET() {
   const galleryBackups = await listBackups('gallery.yaml');
   const settingsBackups = await listBackups('settings.yaml');
   const backupCount = galleryBackups.length + settingsBackups.length;
-  
+
   // Find timestamp of the latest backup
   let lastBackup: string | null = null;
   const allBackups = [...galleryBackups, ...settingsBackups].sort().reverse();
@@ -60,7 +60,7 @@ export async function GET() {
       status: immichOk ? 'connected' : 'disconnected',
     },
     config: {
-      status: (galleryValid && settingsValid) ? 'valid' : 'invalid',
+      status: galleryValid && settingsValid ? 'valid' : 'invalid',
       gallery: galleryValid ? 'valid' : 'invalid',
       settings: settingsValid ? 'valid' : 'invalid',
     },

--- a/app/api/admin/thumbnail/[id]/route.ts
+++ b/app/api/admin/thumbnail/[id]/route.ts
@@ -7,10 +7,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { isAdminAuthenticated, isAdminEnabled } from '@/lib/admin/auth';
 import { getConfig } from '@/lib/config';
 
-export async function GET(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
-) {
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   if (!isAdminEnabled()) {
     return NextResponse.json({ error: 'Admin not enabled' }, { status: 403 });
   }
@@ -32,15 +29,12 @@ export async function GET(
   }
 
   try {
-    const res = await fetch(
-      `${config.immich.apiUrl}/assets/${assetId}/thumbnail?size=thumbnail`,
-      {
-        headers: {
-          'x-api-key': config.immich.apiKey,
-          Accept: 'application/octet-stream',
-        },
+    const res = await fetch(`${config.immich.apiUrl}/assets/${assetId}/thumbnail?size=thumbnail`, {
+      headers: {
+        'x-api-key': config.immich.apiKey,
+        Accept: 'application/octet-stream',
       },
-    );
+    });
 
     if (!res.ok) {
       return NextResponse.json({ error: 'Asset not found' }, { status: 404 });

--- a/components/DevToolbar.tsx
+++ b/components/DevToolbar.tsx
@@ -224,7 +224,7 @@ exifOnHover: ${exifOnHover}`;
           boxShadow: '0 4px 24px rgba(0,0,0,0.4)',
         }}
       >
-        {open ? '✕' : '🎨'}
+        {open ? <span aria-hidden="true">✕</span> : <span aria-hidden="true">🎨</span>}
       </button>
 
       {/* ── Panel — anchored bottom-left ────────── */}

--- a/components/ScrollToTop.tsx
+++ b/components/ScrollToTop.tsx
@@ -34,7 +34,7 @@ export function ScrollToTop() {
       tabIndex={visible ? 0 : -1}
       aria-hidden={!visible}
     >
-      ↑
+      <span aria-hidden="true">↑</span>
     </button>
   );
 }

--- a/docs/admin-panel.md
+++ b/docs/admin-panel.md
@@ -38,6 +38,7 @@ Add Immich asset UUIDs for the homepage hero carousel. Supports single or multip
 Albums displayed directly on the homepage. Click **+ Add Album** to open the Album Picker and select from your Immich library.
 
 Each album card supports:
+
 - **Title override** — display a custom name instead of the Immich album name
 - **Description** — shown below the album title on the subpage
 - **Password** — protect individual albums with a password
@@ -47,6 +48,7 @@ Each album card supports:
 Group albums under custom URL paths (e.g., `/japan`, `/wedding-smith`).
 
 Each subpage has:
+
 - **Name** — used for navigation and URL generation (auto-slugified)
 - **Title** — optional display title (defaults to name)
 - **Subtitle** — optional text shown below the page heading
@@ -64,14 +66,14 @@ Use the **↑/↓** buttons on subpages to change their display order. The order
 
 The **Settings** tab lets you configure global site behavior:
 
-| Section   | Controls                                                         |
-| --------- | ---------------------------------------------------------------- |
-| General   | Site title, subtitle, language, EXIF on hover, map, transitions  |
-| Theme     | Preset, accent color, photo frame, hero style, grain, header dot |
-| Grid      | Layout mode, columns, gap, aspect ratio                          |
-| Footer    | Name, Instagram, email, website                                  |
-| Legal     | Impressum toggle and all legal fields                            |
-| SEO       | Meta title, description, noindex, nofollow                       |
+| Section | Controls                                                         |
+| ------- | ---------------------------------------------------------------- |
+| General | Site title, subtitle, language, EXIF on hover, map, transitions  |
+| Theme   | Preset, accent color, photo frame, hero style, grain, header dot |
+| Grid    | Layout mode, columns, gap, aspect ratio                          |
+| Footer  | Name, Instagram, email, website                                  |
+| Legal   | Impressum toggle and all legal fields                            |
+| SEO     | Meta title, description, noindex, nofollow                       |
 
 Changes are applied immediately after saving — no server restart required.
 
@@ -86,14 +88,14 @@ When adding albums, a modal overlay shows **all shared albums** from your Immich
 
 ## Security
 
-| Aspect         | Implementation                                              |
-| -------------- | ----------------------------------------------------------- |
-| Authentication | HMAC-signed session token in an `HttpOnly` cookie           |
-| Session expiry | 24 hours (automatic logout)                                 |
-| Password check | Constant-time comparison to prevent timing attacks          |
-| Cookie flags   | `HttpOnly`, `Secure` (in production), `SameSite=Strict`    |
-| Rate limiting  | Admin endpoints share the global rate limiter               |
-| Robots         | `/admin` is marked `noindex, nofollow` in metadata          |
+| Aspect         | Implementation                                          |
+| -------------- | ------------------------------------------------------- |
+| Authentication | HMAC-signed session token in an `HttpOnly` cookie       |
+| Session expiry | 24 hours (automatic logout)                             |
+| Password check | Constant-time comparison to prevent timing attacks      |
+| Cookie flags   | `HttpOnly`, `Secure` (in production), `SameSite=Strict` |
+| Rate limiting  | Admin endpoints share the global rate limiter           |
+| Robots         | `/admin` is marked `noindex, nofollow` in metadata      |
 
 > [!NOTE]
 > The admin panel uses its own session management, completely separate from album password protection. Admin sessions use `AUTH_SECRET` for token signing.
@@ -125,7 +127,7 @@ services:
     environment:
       - ADMIN_PASSWORD=your-secure-password
     volumes:
-      - ./content:/app/content  # Must be writable for admin panel
+      - ./content:/app/content # Must be writable for admin panel
 ```
 
 > [!IMPORTANT]
@@ -134,6 +136,7 @@ services:
 ### Reload Button
 
 The admin header includes a **↻ Reload** button that:
+
 1. Invalidates the in-memory config cache
 2. Clears the Immich album/asset cache
 3. Forces the next request to re-read all YAML files

--- a/docs/brainstorm.md
+++ b/docs/brainstorm.md
@@ -6,23 +6,23 @@ _Stand: 2026-05-29 — generiert aus Projekt-Review + ideas.md_
 
 ## ✅ Bereits implementiert
 
-| Feature | Datum | Notizen |
-|---|---|---|
-| **Album-Beschreibungen** | 2026-05-29 | `description:` in `gallery.yaml` (pro Album), eigenes `<p>` unter dem Titel in `AlbumDetailView` |
+| Feature                         | Datum      | Notizen                                                                                                      |
+| ------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------ |
+| **Album-Beschreibungen**        | 2026-05-29 | `description:` in `gallery.yaml` (pro Album), eigenes `<p>` unter dem Titel in `AlbumDetailView`             |
 | **Webhook Cache-Invalidierung** | 2026-05-29 | `POST /api/webhook`, HMAC-SHA256, `WEBHOOK_SECRET` in `.env`, gezielte oder vollständige Cache-Invalidierung |
-| **Video-Support** | 2026-05-29 | Proxy `GET /api/video/[token]` mit Range-Support, Play-Button im Grid, `<video controls>` in Lightbox |
+| **Video-Support**               | 2026-05-29 | Proxy `GET /api/video/[token]` mit Range-Support, Play-Button im Grid, `<video controls>` in Lightbox        |
 
 ---
 
 ## ⚡ Quick Wins (offen)
 
-| Idee | Effort | Warum interessant |
-|---|---|---|
-| **Sequentielle Album-Navigation** | XS | „← Vorheriges / Nächstes Album →" am Ende einer Detailseite |
-| **Alt-Text aus Immich-Description** | XS | Immich-Assets haben ein `description`-Feld → als `alt`-Text → bessere Accessibility & SEO |
-| **RSS/Atom Feed** | S | `/feed.xml` mit neuen Alben — Follower können „neue Arbeit" abonnieren |
-| **Globaler Passwortschutz** | S | Eine einzige `site_password` für die gesamte Site (jetzt: nur per Subpage/Album) |
-| **Privacy-Analytics-Integration** | S | Plausible / Umami / GoatCounter via Script-Tag in `settings.yaml` konfigurieren (kein Tracking-Framework nötig) |
+| Idee                                | Effort | Warum interessant                                                                                               |
+| ----------------------------------- | ------ | --------------------------------------------------------------------------------------------------------------- |
+| **Sequentielle Album-Navigation**   | XS     | „← Vorheriges / Nächstes Album →" am Ende einer Detailseite                                                     |
+| **Alt-Text aus Immich-Description** | XS     | Immich-Assets haben ein `description`-Feld → als `alt`-Text → bessere Accessibility & SEO                       |
+| **RSS/Atom Feed**                   | S      | `/feed.xml` mit neuen Alben — Follower können „neue Arbeit" abonnieren                                          |
+| **Globaler Passwortschutz**         | S      | Eine einzige `site_password` für die gesamte Site (jetzt: nur per Subpage/Album)                                |
+| **Privacy-Analytics-Integration**   | S      | Plausible / Umami / GoatCounter via Script-Tag in `settings.yaml` konfigurieren (kein Tracking-Framework nötig) |
 
 ---
 

--- a/docs/gallery-config.md
+++ b/docs/gallery-config.md
@@ -196,26 +196,27 @@ Your bio text here. Supports full Markdown.
 
 - **Album UUIDs**: In Immich, go to Albums → click an album → the UUID is in the URL bar
 - **Asset UUIDs**: Click any photo → the UUID is in the URL bar
- 
+
 ## System & Security
- 
+
 Advanced system settings are configured via environment variables in your `.env` or `.env.local` file.
- 
+
 ### Rate Limiting
- 
+
 To protect against brute-force attacks and resource exhaustion, Immich Folio includes an in-memory rate limiter.
- 
+
 - `RATE_LIMIT_RPM`: Maximum requests per minute per IP (default: `1500` for general API, `120` for map data).
- 
+
 ### Trusted Proxies
- 
+
 If you are running Immich Folio behind a reverse proxy (like Nginx, Traefik, Caddy, or Cloudflare), you should configure trusted proxies to prevent IP spoofing.
- 
+
 - `TRUSTED_PROXIES`: A comma-separated list of IP addresses of your proxies.
- 
+
 Example:
+
 ```bash
 TRUSTED_PROXIES=127.0.0.1,172.18.0.1
 ```
- 
+
 When set, the rate limiter will only trust `X-Forwarded-For` and `X-Real-IP` headers if the request directly comes from one of these IPs. If not set, headers are trusted as a best-effort, which is less secure in public-facing environments.

--- a/lib/config/index.ts
+++ b/lib/config/index.ts
@@ -125,7 +125,10 @@ export function getConfig(): AppConfig {
   function processAlbumEntry(
     entry:
       | string
-      | Record<string, string | { title: string; description?: string; password?: string; heroImage?: string }>,
+      | Record<
+          string,
+          string | { title: string; description?: string; password?: string; heroImage?: string }
+        >,
     context: string,
   ): string {
     if (typeof entry === 'string') {


### PR DESCRIPTION
💡 What: Wrapped text characters used as icons ('×', '✕', '↑', '🎨') in `<span aria-hidden="true">`.
🎯 Why: Text characters used as icons are announced by screen readers (e.g. 'multiplication X' instead of 'close'), causing confusing accessibility experiences. Wrapping them hides them from screen readers while preserving the visual element, allowing the `aria-label` or `title` on the button to handle the announcement correctly.
♿ Accessibility: Improved screen reader announcements for text-based icon buttons by avoiding reading literal punctuation or emoji characters.

---
*PR created automatically by Jules for task [13618767846687994480](https://jules.google.com/task/13618767846687994480) started by @ralksta*