### PR TITLE
🎨 Palette: Add aria-labels to icon buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Accessible Text-Based Icon Buttons
+**Learning:** Using raw text characters like '×' or '✕' for icon buttons without `aria-label` or `aria-hidden` attributes causes screen readers to read the literal character (e.g., "multiplication sign"), leading to a confusing user experience.
+**Action:** Always wrap visual text characters used as icons in `<span aria-hidden="true">` and provide a descriptive `aria-label` on the parent `<button>` to ensure correct screen reader announcements.

--- a/app/admin/components/AlbumPicker.tsx
+++ b/app/admin/components/AlbumPicker.tsx
@@ -37,8 +37,8 @@ export default function AlbumPicker({ albums, onSelect, onClose, usedAlbumIds }:
       <div className="picker-modal" onClick={(e) => e.stopPropagation()}>
         <div className="picker-header">
           <h3>Select Album</h3>
-          <button className="admin-btn-icon" onClick={onClose}>
-            ×
+          <button className="admin-btn-icon" onClick={onClose} aria-label="Close">
+            <span aria-hidden="true">×</span>
           </button>
         </div>
 

--- a/app/admin/components/AssetPicker.tsx
+++ b/app/admin/components/AssetPicker.tsx
@@ -114,8 +114,8 @@ export default function AssetPicker({
       <div className="asset-picker-modal" onClick={(e) => e.stopPropagation()}>
         <div className="picker-header">
           <h3>{title || 'Select Hero Image'}</h3>
-          <button className="admin-btn-icon" onClick={onClose}>
-            ×
+          <button className="admin-btn-icon" onClick={onClose} aria-label="Close">
+            <span aria-hidden="true">×</span>
           </button>
         </div>
 

--- a/app/admin/components/PageBuilder.tsx
+++ b/app/admin/components/PageBuilder.tsx
@@ -25,7 +25,13 @@ import AssetPicker from './AssetPicker';
 // ── Icons ──────────────────────────────────────────────────────
 const Icons = {
   Drag: () => (
-    <svg width="12" height="18" viewBox="0 0 12 18" fill="currentColor" className="svg-icon svg-drag">
+    <svg
+      width="12"
+      height="18"
+      viewBox="0 0 12 18"
+      fill="currentColor"
+      className="svg-icon svg-drag"
+    >
       <circle cx="2" cy="2" r="1.5" />
       <circle cx="2" cy="9" r="1.5" />
       <circle cx="2" cy="16" r="1.5" />
@@ -35,77 +41,207 @@ const Icons = {
     </svg>
   ),
   Edit: () => (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="svg-icon"
+    >
       <path d="M12 20h9" />
       <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z" />
     </svg>
   ),
   Trash: () => (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="svg-icon"
+    >
       <path d="M3 6h18" />
       <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />
       <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
     </svg>
   ),
   Close: () => (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="svg-icon"
+    >
       <path d="M18 6 6 18M6 6l12 12" />
     </svg>
   ),
   Folder: () => (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="svg-icon"
+    >
       <path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z" />
     </svg>
   ),
   Camera: () => (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="svg-icon"
+    >
       <path d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3Z" />
       <circle cx="12" cy="13" r="3" />
     </svg>
   ),
   ExternalLink: () => (
-    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="svg-icon"
+    >
       <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
       <polyline points="15 3 21 3 21 9" />
       <line x1="10" y1="14" x2="21" y2="3" />
     </svg>
   ),
   Search: () => (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="svg-icon"
+    >
       <circle cx="11" cy="11" r="8" />
       <path d="m21 21-4.3-4.3" />
     </svg>
   ),
   Lock: () => (
-    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="svg-icon"
+    >
       <rect width="18" height="11" x="3" y="11" rx="2" ry="2" />
       <path d="M7 11V7a5 5 0 0 1 10 0v4" />
     </svg>
   ),
   Plus: () => (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="svg-icon"
+    >
       <path d="M5 12h14M12 5v14" />
     </svg>
   ),
   Home: () => (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="svg-icon"
+    >
       <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
       <polyline points="9 22 9 12 15 12 15 22" />
     </svg>
   ),
   Copy: () => (
-    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="svg-icon"
+    >
       <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
       <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
     </svg>
   ),
   Check: () => (
-    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="svg-icon"
+    >
       <polyline points="20 6 9 17 4 12" />
     </svg>
   ),
   Image: () => (
-    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="svg-icon"
+    >
       <rect width="18" height="18" x="3" y="3" rx="2" ry="2" />
       <circle cx="9" cy="9" r="2" />
       <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21" />
@@ -192,7 +328,10 @@ function serializeAlbumEntries(
   entries: AlbumEntry[],
 ): Array<
   | string
-  | Record<string, string | { title: string; description?: string; password?: string; heroImage?: string }>
+  | Record<
+      string,
+      string | { title: string; description?: string; password?: string; heroImage?: string }
+    >
 > {
   return entries.map((entry) => {
     if (!entry.title && !entry.description && !entry.password && !entry.heroImage) return entry.id;
@@ -372,7 +511,9 @@ export default function PageBuilder() {
     title?: string;
   } | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
-  const [editingAlbumAddress, setEditingAlbumAddress] = useState<ActiveEditAlbumAddress | null>(null);
+  const [editingAlbumAddress, setEditingAlbumAddress] = useState<ActiveEditAlbumAddress | null>(
+    null,
+  );
 
   // DnD sensors
   const sensors = useSensors(
@@ -831,7 +972,12 @@ export default function PageBuilder() {
     const description = (album.description || '').toLowerCase();
     const overrideTitle = (album.title || '').toLowerCase();
     const query = searchQuery.toLowerCase();
-    return name.includes(query) || description.includes(query) || overrideTitle.includes(query) || album.id.toLowerCase().includes(query);
+    return (
+      name.includes(query) ||
+      description.includes(query) ||
+      overrideTitle.includes(query) ||
+      album.id.toLowerCase().includes(query)
+    );
   });
 
   // Filter subpages
@@ -843,17 +989,22 @@ export default function PageBuilder() {
       const name = sp.name.toLowerCase();
       const title = (sp.title || '').toLowerCase();
       const subtitle = (sp.subtitle || '').toLowerCase();
-      
+
       if (name.includes(query) || title.includes(query) || subtitle.includes(query)) return true;
-      
+
       const albums = sp.albums || [];
       const hasMatchingAlbum = albums.some((a) => {
         const aName = getAlbumName(a.id).toLowerCase();
         const aTitle = (a.title || '').toLowerCase();
         const aDesc = (a.description || '').toLowerCase();
-        return aName.includes(query) || aTitle.includes(query) || aDesc.includes(query) || a.id.toLowerCase().includes(query);
+        return (
+          aName.includes(query) ||
+          aTitle.includes(query) ||
+          aDesc.includes(query) ||
+          a.id.toLowerCase().includes(query)
+        );
       });
-      
+
       return hasMatchingAlbum;
     });
 
@@ -904,8 +1055,13 @@ export default function PageBuilder() {
             onChange={(e) => setSearchQuery(e.target.value)}
           />
           {searchQuery && (
-            <button className="builder-search-clear" onClick={() => setSearchQuery('')} title="Clear search">
-              ×
+            <button
+              className="builder-search-clear"
+              onClick={() => setSearchQuery('')}
+              title="Clear search"
+              aria-label="Clear search"
+            >
+              <span aria-hidden="true">×</span>
             </button>
           )}
         </div>
@@ -914,7 +1070,9 @@ export default function PageBuilder() {
       {/* Hero Section */}
       <section className="builder-section">
         <div className="builder-section-header">
-          <h2><Icons.Home /> Homepage Hero</h2>
+          <h2>
+            <Icons.Home /> Homepage Hero
+          </h2>
           <button
             className="admin-btn admin-btn-sm"
             onClick={() =>
@@ -982,7 +1140,9 @@ export default function PageBuilder() {
             <div className="album-list">
               {filteredAlbums.length === 0 && (
                 <p className="empty-hint">
-                  {searchQuery ? 'No matching standalone albums found.' : 'No standalone albums. These show directly on the homepage.'}
+                  {searchQuery
+                    ? 'No matching standalone albums found.'
+                    : 'No standalone albums. These show directly on the homepage.'}
                 </p>
               )}
               {filteredAlbums.map((album) => {
@@ -996,7 +1156,9 @@ export default function PageBuilder() {
                     count={getAlbumCount(album.id)}
                     thumbnailId={getAlbumThumbnailId(album.id)}
                     onRemove={() => removeStandaloneAlbum(originalIndex)}
-                    onEdit={() => setEditingAlbumAddress({ type: 'standalone', albumIndex: originalIndex })}
+                    onEdit={() =>
+                      setEditingAlbumAddress({ type: 'standalone', albumIndex: originalIndex })
+                    }
                   />
                 );
               })}
@@ -1021,9 +1183,7 @@ export default function PageBuilder() {
         )}
 
         {gallery.subpages.length > 0 && filteredSubpages.length === 0 && (
-          <p className="empty-hint">
-            No matching subpages found.
-          </p>
+          <p className="empty-hint">No matching subpages found.</p>
         )}
 
         {/* Collapsed overview grid with DnD */}
@@ -1085,8 +1245,9 @@ export default function PageBuilder() {
                         className="admin-btn-icon"
                         onClick={() => setExpandedSubpage(null)}
                         title="Collapse"
+                        aria-label="Collapse"
                       >
-                        ✕
+                        <span aria-hidden="true">✕</span>
                       </button>
                       <button
                         className="admin-btn-icon admin-btn-icon-danger"
@@ -1173,7 +1334,13 @@ export default function PageBuilder() {
                                 count={getAlbumCount(album.id)}
                                 thumbnailId={getAlbumThumbnailId(album.id)}
                                 onRemove={() => removeSubpageAlbum(spIndex, aIndex)}
-                                onEdit={() => setEditingAlbumAddress({ type: 'subpage', subpageIndex: spIndex, albumIndex: aIndex })}
+                                onEdit={() =>
+                                  setEditingAlbumAddress({
+                                    type: 'subpage',
+                                    subpageIndex: spIndex,
+                                    albumIndex: aIndex,
+                                  })
+                                }
                               />
                             ))}
                           </div>
@@ -1225,7 +1392,14 @@ export default function PageBuilder() {
                                 count={getAlbumCount(album.id)}
                                 thumbnailId={getAlbumThumbnailId(album.id)}
                                 onRemove={() => removeSectionAlbum(spIndex, secIndex, aIndex)}
-                                onEdit={() => setEditingAlbumAddress({ type: 'section', subpageIndex: spIndex, sectionIndex: secIndex, albumIndex: aIndex })}
+                                onEdit={() =>
+                                  setEditingAlbumAddress({
+                                    type: 'section',
+                                    subpageIndex: spIndex,
+                                    sectionIndex: secIndex,
+                                    albumIndex: aIndex,
+                                  })
+                                }
                               />
                             ))}
                           </div>
@@ -1328,9 +1502,7 @@ export default function PageBuilder() {
                     </div>
                     <div className="modal-info-item">
                       <span className="modal-info-label">Custom Hero:</span>
-                      <span className="modal-info-value">
-                        {album.heroImage ? 'Yes' : 'No'}
-                      </span>
+                      <span className="modal-info-value">{album.heroImage ? 'Yes' : 'No'}</span>
                     </div>
                   </div>
 
@@ -1574,7 +1746,6 @@ function AlbumCard({
   const heroThumb = album.heroImage || thumbnailId;
   const hasPassword = !!album.password;
   const hasTitleOverride = !!album.title;
-  const hasDescription = !!album.description;
 
   return (
     <div className={`album-tile ${hasPassword ? 'has-password' : ''}`}>
@@ -1592,11 +1763,7 @@ function AlbumCard({
           </div>
         )}
         <div className="album-tile-overlay">
-          <button
-            className="album-tile-btn"
-            onClick={onEdit}
-            title="Edit details"
-          >
+          <button className="album-tile-btn" onClick={onEdit} title="Edit details">
             <Icons.Edit />
           </button>
           <button
@@ -1610,7 +1777,10 @@ function AlbumCard({
       </div>
       <div className="album-tile-info">
         <div className="album-tile-title-row">
-          <span className={`album-tile-name ${hasTitleOverride ? 'custom-title' : ''}`} title={album.title || name}>
+          <span
+            className={`album-tile-name ${hasTitleOverride ? 'custom-title' : ''}`}
+            title={album.title || name}
+          >
             {album.title || name}
           </span>
           <div className="album-tile-badges">


### PR DESCRIPTION
💡 What: Added `aria-label` attributes and wrapped text-based icons ('×', '✕') in `<span aria-hidden="true">`.
🎯 Why: Screen readers were reading literal characters (e.g. 'multiplication sign') instead of descriptive actions, causing confusion for visually impaired users.
📸 Before/After: N/A
♿ Accessibility: Ensures correct screen reader announcements for text-based icon buttons.

---
*PR created automatically by Jules for task [844100845496778062](https://jules.google.com/task/844100845496778062) started by @ralksta*