### PR TITLE
⚡ Bolt: Use structuredClone for deep copy

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-07-17 - Deep Cloning Optimization
+**Learning:** `JSON.parse(JSON.stringify())` was used for deep cloning settings objects during state updates and saves in `SettingsEditor.tsx`.
+**Action:** Replaced with native `structuredClone()` which avoids string serialization overhead and supports a wider range of types, casting it as `any` where needed to allow arbitrary nested assignments required by the generic updates logic.

--- a/app/admin/components/SettingsEditor.tsx
+++ b/app/admin/components/SettingsEditor.tsx
@@ -55,7 +55,10 @@ const PHOTO_FRAMES = ['none', 'passepartout', 'shadow'];
 const HERO_STYLES = ['split', 'fullbleed', 'minimal', 'stacked', 'typographic', 'mosaic'];
 const ASPECT_RATIOS = ['1', '3/2', '2/3', '16/9', 'auto'];
 
-const THEME_INFO: Record<string, { desc: string; label: string; accent: string; bg: string; tile: string }> = {
+const THEME_INFO: Record<
+  string,
+  { desc: string; label: string; accent: string; bg: string; tile: string }
+> = {
   studio: {
     label: 'Studio',
     desc: 'Clean, high-contrast grid with sans-serif type.',
@@ -170,7 +173,9 @@ export default function SettingsEditor() {
 
   function update(path: string, value: unknown) {
     setSettings((s) => {
-      const copy = JSON.parse(JSON.stringify(s));
+      // Performance: avoids string serialization overhead for deep cloning
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const copy = structuredClone(s) as any;
       const parts = path.split('.');
       let obj = copy;
       for (let i = 0; i < parts.length - 1; i++) {
@@ -194,7 +199,9 @@ export default function SettingsEditor() {
     setSaveMessage('');
 
     // Clean up empty objects
-    const cleaned = JSON.parse(JSON.stringify(settings));
+    // Performance: avoids string serialization overhead for deep cloning
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cleaned = structuredClone(settings) as any;
     for (const key of Object.keys(cleaned)) {
       if (typeof cleaned[key] === 'object' && Object.keys(cleaned[key]).length === 0) {
         delete cleaned[key];
@@ -348,7 +355,13 @@ export default function SettingsEditor() {
                 <label>Preset</label>
                 <div className="preset-card-grid">
                   {PRESETS.map((p) => {
-                    const info = THEME_INFO[p] || { label: p, desc: '', bg: '#fff', tile: '#eee', accent: '#333' };
+                    const info = THEME_INFO[p] || {
+                      label: p,
+                      desc: '',
+                      bg: '#fff',
+                      tile: '#eee',
+                      accent: '#333',
+                    };
                     const isActive = (settings.theme?.preset || 'studio') === p;
                     return (
                       <button
@@ -360,8 +373,16 @@ export default function SettingsEditor() {
                       >
                         <div className="preset-card-preview" style={{ backgroundColor: info.bg }}>
                           <div className="mini-header">
-                            <span className="mini-dot" style={{ backgroundColor: info.accent }}></span>
-                            <span className="mini-line" style={{ backgroundColor: isActive ? info.accent : 'var(--admin-border)' }}></span>
+                            <span
+                              className="mini-dot"
+                              style={{ backgroundColor: info.accent }}
+                            ></span>
+                            <span
+                              className="mini-line"
+                              style={{
+                                backgroundColor: isActive ? info.accent : 'var(--admin-border)',
+                              }}
+                            ></span>
                           </div>
                           <div className="mini-grid">
                             <div className="mini-tile" style={{ backgroundColor: info.tile }}></div>


### PR DESCRIPTION
💡 What: Replaced `JSON.parse(JSON.stringify())` with native `structuredClone()` in `SettingsEditor.tsx`.

🎯 Why: Deep cloning settings using JSON serialization is slow and unnecessary when the native structured cloning algorithm is available.

📊 Impact: Avoids string serialization overhead for deep cloning, reducing memory allocations and improving CPU time on state updates and saves.

🔬 Measurement: Measure CPU time in performance profiler when updating deep settings objects before and after.

---
*PR created automatically by Jules for task [7792467073401101816](https://jules.google.com/task/7792467073401101816) started by @ralksta*