### PR TITLE
⚡ Bolt: Use shared IntersectionObserver for FadeIn

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Shared IntersectionObserver
+**Learning:** Creating O(n) intersection observers for grid items can lead to memory allocation and initialization overhead, negatively impacting performance on pages with many items.
+**Action:** Use a shared global `IntersectionObserver` and a callback registry (e.g., using `WeakMap` or `Map`) to observe multiple elements efficiently.

--- a/components/FadeIn.tsx
+++ b/components/FadeIn.tsx
@@ -20,6 +20,32 @@ interface FadeInProps {
   className?: string;
 }
 
+const callbacks = new WeakMap<Element, () => void>();
+
+let sharedObserver: IntersectionObserver | null = null;
+
+function getObserver() {
+  if (typeof window === 'undefined') return null;
+
+  if (!sharedObserver) {
+    sharedObserver = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            const callback = callbacks.get(entry.target);
+            if (callback) {
+              callback();
+              sharedObserver?.unobserve(entry.target);
+            }
+          }
+        }
+      },
+      { threshold: 0.1 },
+    );
+  }
+  return sharedObserver;
+}
+
 export function FadeIn({ children, delay = 0, direction = 'up', className }: FadeInProps) {
   const ref = useRef<HTMLDivElement>(null);
 
@@ -37,18 +63,18 @@ export function FadeIn({ children, delay = 0, direction = 'up', className }: Fad
       return;
     }
 
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          reveal();
-          observer.unobserve(el);
-        }
-      },
-      { threshold: 0.1 },
-    );
+    const observer = getObserver();
+    if (observer) {
+      callbacks.set(el, reveal);
+      observer.observe(el);
+    }
 
-    observer.observe(el);
-    return () => observer.disconnect();
+    return () => {
+      if (observer) {
+        observer.unobserve(el);
+        callbacks.delete(el);
+      }
+    };
   }, [reveal]);
 
   return (


### PR DESCRIPTION
💡 What: Implement a shared global IntersectionObserver in FadeIn.tsx instead of instantiating a new observer for each grid item.

🎯 Why: Creating O(n) IntersectionObservers for a large number of grid items consumes unnecessary memory and causes initialization overhead, degrading performance on pages with large photo grids.

📊 Impact: Reduces memory allocation and initial render overhead, resulting in faster load times and smoother scrolling on pages with many images.

🔬 Measurement: Profile the page load and scroll performance using Chrome DevTools (Performance tab) before and after the change; observe a reduction in memory heap usage and faster IntersectionObserver callback execution.

---
*PR created automatically by Jules for task [3444055653693998725](https://jules.google.com/task/3444055653693998725) started by @ralksta*