### PR TITLE
⚡ Bolt: shared IntersectionObserver in FadeIn

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-10 - Singleton IntersectionObserver Pattern
+**Learning:** Creating O(n) IntersectionObserver instances (one per element) in large lists or masonry photo grids causes significant memory and initialization overhead.
+**Action:** Implement a singleton shared IntersectionObserver pattern with a WeakMap to register per-element callbacks, rather than instantiating a new observer for every component.

--- a/components/FadeIn.tsx
+++ b/components/FadeIn.tsx
@@ -20,6 +20,34 @@ interface FadeInProps {
   className?: string;
 }
 
+type RevealCallback = () => void;
+// Shared WeakMap to track per-element callbacks, preventing memory leaks when elements are removed
+const callbackMap = new WeakMap<Element, RevealCallback>();
+// Singleton IntersectionObserver to reduce instantiation overhead for large lists/grids
+let sharedObserver: IntersectionObserver | null = null;
+
+function getSharedObserver() {
+  if (typeof window === 'undefined') return null;
+  if (!sharedObserver) {
+    sharedObserver = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            const callback = callbackMap.get(entry.target);
+            if (callback) {
+              callback();
+              sharedObserver?.unobserve(entry.target);
+              callbackMap.delete(entry.target);
+            }
+          }
+        });
+      },
+      { threshold: 0.1 },
+    );
+  }
+  return sharedObserver;
+}
+
 export function FadeIn({ children, delay = 0, direction = 'up', className }: FadeInProps) {
   const ref = useRef<HTMLDivElement>(null);
 
@@ -37,18 +65,18 @@ export function FadeIn({ children, delay = 0, direction = 'up', className }: Fad
       return;
     }
 
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          reveal();
-          observer.unobserve(el);
-        }
-      },
-      { threshold: 0.1 },
-    );
+    const observer = getSharedObserver();
+    if (observer) {
+      callbackMap.set(el, reveal);
+      observer.observe(el);
+    }
 
-    observer.observe(el);
-    return () => observer.disconnect();
+    return () => {
+      if (observer) {
+        observer.unobserve(el);
+        callbackMap.delete(el);
+      }
+    };
   }, [reveal]);
 
   return (


### PR DESCRIPTION
💡 What: Refactored the FadeIn component to use a singleton IntersectionObserver pattern with a WeakMap.
🎯 Why: Creating an IntersectionObserver instance per element in large photo grids causes significant memory and initialization overhead.
📊 Impact: Reduces memory usage and initialization overhead by replacing O(n) observers with a single shared observer.
🔬 Measurement: Check memory profiling and DOM node allocation in DevTools when viewing a large photo grid.

---
*PR created automatically by Jules for task [2244253356756683110](https://jules.google.com/task/2244253356756683110) started by @ralksta*