### PR TITLE
🛡️ Sentinel: [HIGH] Fix timing side-channel attack on admin password comparison

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-28 - Fix timing side-channel and DoS risk on admin password
+**Vulnerability:** The admin password comparison leaked the length of the secret because `crypto.timingSafeEqual` was used on raw strings converted to variable-length buffers. A mismatch in length triggered an early return, and even the "dummy" check used `Buffer.alloc(pwBuf.length)` which allocates memory proportional to the attacker's input, causing a DoS risk if the input length was massive.
+**Learning:** `crypto.timingSafeEqual` must strictly receive buffers of identical length. Using `Buffer.alloc` with an unconstrained attacker-controlled length creates an immediate out-of-memory DoS vector.
+**Prevention:** Always enforce a maximum string length check on inputs *before* authentication logic. Hash variable-length secrets to a fixed length (e.g., using HMAC-SHA256) before using `crypto.timingSafeEqual` to prevent side-channel timing attacks that leak length information.

--- a/app/api/admin/auth/route.ts
+++ b/app/api/admin/auth/route.ts
@@ -34,8 +34,8 @@ export async function POST(request: NextRequest) {
   }
 
   const body = await request.json().catch(() => null);
-  if (!body?.password || typeof body.password !== 'string') {
-    return NextResponse.json({ error: 'Password is required' }, { status: 400 });
+  if (!body?.password || typeof body.password !== 'string' || body.password.length > 100) {
+    return NextResponse.json({ error: 'Invalid password format or length' }, { status: 400 });
   }
 
   if (!verifyAdminPassword(body.password)) {

--- a/lib/admin/auth.ts
+++ b/lib/admin/auth.ts
@@ -67,15 +67,12 @@ export function verifyAdminPassword(password: string): boolean {
   const adminPw = env.ADMIN_PASSWORD;
   if (!adminPw) return false;
 
-  // Constant-time comparison
-  const pwBuf = Buffer.from(password);
-  const expectedBuf = Buffer.from(adminPw);
-  if (pwBuf.length !== expectedBuf.length) {
-    // Still do a comparison to prevent timing attacks on length
-    crypto.timingSafeEqual(pwBuf, Buffer.alloc(pwBuf.length));
-    return false;
-  }
-  return crypto.timingSafeEqual(pwBuf, expectedBuf);
+  // Hash both to a fixed length before constant-time comparison to prevent timing and length attacks
+  const secret = resolveAuthSecret();
+  const attemptHash = crypto.createHmac('sha256', secret).update(password).digest();
+  const expectedHash = crypto.createHmac('sha256', secret).update(adminPw).digest();
+
+  return crypto.timingSafeEqual(attemptHash, expectedHash);
 }
 
 /** Check if the current request has a valid admin session. */


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Admin password comparison leaked password length via early returns on length mismatch. Also lacked maximum length validation, allowing large payloads to trigger massive memory allocation (DoS).
🎯 Impact: Attackers could determine the admin password length and cause out-of-memory errors by sending massive payloads.
🔧 Fix: Added a strict 100-character length limit. Hashed both passwords using HMAC-SHA256 with `authSecret` to a fixed length before constant-time comparison via `crypto.timingSafeEqual`.
✅ Verification: Ensure `pnpm test` and `pnpm lint` pass.

---
*PR created automatically by Jules for task [2934577197332280367](https://jules.google.com/task/2934577197332280367) started by @ralksta*