### PR TITLE
fix: keep /admin reachable while setup is required

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@
  */
 
 import type { Metadata } from 'next';
+import { headers } from 'next/headers';
 import Link from 'next/link';
 import './globals.css';
 import { SubpageNav } from '@/components/SubpageNav';
@@ -13,6 +14,7 @@ import { ScrollToTop } from '@/components/ScrollToTop';
 import { Footer } from '@/components/Footer';
 import { SetupScreen } from '@/components/SetupScreen';
 import { getConfig, getGoogleFontsUrl, AppConfig } from '@/lib/config';
+import { isAdminPath } from '@/lib/admin/paths';
 // DevToolbarLoader is a Client Component (ssr: false is only allowed there)
 import { DevToolbarLoader } from '@/components/DevToolbarLoader';
 
@@ -47,7 +49,7 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const config = getConfig();
   const { theme } = config;
   const fontsUrl = getGoogleFontsUrl(theme);
@@ -63,7 +65,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     '--radius-lg': `${theme.radius * 2}px`,
   };
 
-  if ((config as AppConfig & { needsSetup?: boolean }).needsSetup) {
+  // /admin stays reachable during setup — it is the tool that completes the
+  // setup, so the setup screen must not lock it out (#326).
+  const pathname = (await headers()).get('x-pathname');
+  if ((config as AppConfig & { needsSetup?: boolean }).needsSetup && !isAdminPath(pathname)) {
     return (
       <html lang="en" suppressHydrationWarning>
         <body>

--- a/lib/__tests__/admin-paths.test.ts
+++ b/lib/__tests__/admin-paths.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { isAdminPath } from '@/lib/admin/paths';
+
+// The root layout must keep /admin reachable while the app is in setup mode
+// (missing gallery.yaml or Immich credentials) — the admin panel is the tool
+// that fixes exactly that state (#326).
+describe('isAdminPath', () => {
+  it('matches /admin exactly', () => {
+    expect(isAdminPath('/admin')).toBe(true);
+  });
+
+  it('matches nested admin paths', () => {
+    expect(isAdminPath('/admin/settings')).toBe(true);
+  });
+
+  it('does not match the homepage', () => {
+    expect(isAdminPath('/')).toBe(false);
+  });
+
+  it('does not match sibling paths that merely start with "admin"', () => {
+    expect(isAdminPath('/administration')).toBe(false);
+  });
+
+  it('treats a missing pathname header as non-admin', () => {
+    expect(isAdminPath(null)).toBe(false);
+  });
+});

--- a/lib/admin/paths.ts
+++ b/lib/admin/paths.ts
@@ -1,0 +1,12 @@
+/**
+ * Whether a request pathname belongs to the admin panel.
+ *
+ * Used by the root layout to keep /admin reachable while the app is in
+ * setup mode: the setup screen must not lock out the very tool that fixes
+ * an incomplete configuration (#326). A null pathname (header missing,
+ * e.g. a route not covered by the middleware matcher) counts as non-admin
+ * so the setup screen remains the safe default.
+ */
+export function isAdminPath(pathname: string | null): boolean {
+  return pathname === '/admin' || pathname?.startsWith('/admin/') === true;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -23,6 +23,9 @@ export function middleware(request: NextRequest) {
 
   const requestHeaders = new Headers(request.headers);
   requestHeaders.set('x-nonce', nonce);
+  // Layouts cannot read the request URL; the root layout needs the pathname
+  // to keep /admin reachable while the app is in setup mode.
+  requestHeaders.set('x-pathname', request.nextUrl.pathname);
   requestHeaders.set('Content-Security-Policy', cspDirectives);
 
   const response = NextResponse.next({


### PR DESCRIPTION
## Problem (#326)

The root layout replaces the entire app with the "Setup Required" screen whenever the config is incomplete (missing `gallery.yaml` or missing/invalid Immich credentials) — including `/admin`, since the admin pages nest under the same root layout. That's a chicken-and-egg lockout: the admin panel is unreachable exactly when you'd need it to finish the setup.

## Fix

- `middleware.ts` forwards the request pathname as an `x-pathname` header (alongside the existing `x-nonce`).
- The root layout skips the setup-screen replacement for admin paths (`isAdminPath()` helper in `lib/admin/paths.ts`, exact `/admin` or `/admin/…` — `/administration` etc. don't match, and a missing header safely falls back to the setup screen).
- All other routes keep showing the setup instructions unchanged.

## Verification

- 5 new unit tests for `isAdminPath()` (written first, watched fail), 96 unit tests pass overall
- `npx tsc --noEmit` — 0 errors; no lint findings in touched files; `npm run build` passes
- Behavioral check with a dev server forced into setup mode (`IMMICH_API_URL="" IMMICH_API_KEY="" ADMIN_PASSWORD=…`):
  - `/` renders the Setup Required screen as before
  - `/admin` renders the admin login form (verified in the browser after hydration)

Fixes #326