### PR TITLE
chore(release): v0.9.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "immich-lightbox",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "immich-lightbox",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "immich-lightbox",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "license": "MIT",
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Version bump only — `package.json` and `package-lock.json` from 0.9.1 to 0.9.2, same shape as #393.

## Since v0.9.1

**Immich failure handling (#394)** — outages surface as `503` with `Retry-After` and `Cache-Control: no-store` instead of a cacheable `404`, so a transient failure can no longer pin a broken image in a visitor's browser cache for a year. Genuine 404s are still cached as missing. Requests are bounded by `IMMICH_TIMEOUT_MS` rather than hanging.

**Image proxy (#394)** — `?w=` can narrow the tier instead of being ignored, and the tier is part of the ETag so the three sizes cache separately. `IMAGE_CACHE_VERSION` added as an escape hatch for stale browser caches after Immich regenerates a thumbnail; empty by default, so generated URLs are unchanged unless you set it.

**Rate limiting (#394)** — every rate-limited response carries `Retry-After`. A warning now fires once per process when `TRUSTED_PROXY_HOPS` cannot identify a client, instead of silently lumping every visitor into one shared bucket.

**Admin panel (#394)** — a save that would produce an unloadable `gallery.yaml` is rejected before the write with the real reason, rather than reporting success and taking the public site down. `/admin` stays reachable when the config cannot be derived. Backup filenames are validated before restore; concurrent saves no longer share a temp file.

**Security (#395)** — the admin password comparison no longer leaks the password length through timing. Both sides are HMAC'd to a fixed length before the constant-time compare.

**Also** — `middleware.ts` migrated to the Next 16 `proxy` convention, themed error and not-found pages, subpage password hashing moved off the main thread, and dependency bumps: next 16.2.12, react 19.2.8, js-yaml 4.3.1, @playwright/test 1.62.1, plus three GitHub Actions majors.

## Verification

- `npm run test:unit` — 210 passing, exit 0
- `npx tsc --noEmit` — 0 errors
- `npm run build` — passes
- Smoke-tested against a live Immich 3.x instance at the merge commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)