### PR TITLE
fix(ci): Trivy action reference does not exist — no image was published for v0.10.0

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -59,7 +59,10 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Scan image for vulnerabilities
-        uses: aquasecurity/trivy-action@0.29.0
+        # Pinned to a commit SHA, not a tag: the action's tags carry a leading
+        # "v" (v0.36.0), so the previous "@0.29.0" resolved to nothing and the
+        # job failed at action setup — before the image was ever built.
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
           format: sarif


### PR DESCRIPTION
`aquasecurity/trivy-action@0.29.0` does not resolve: that repository's tags carry a leading `v` (`v0.29.0`). The publish job introduced in #399 therefore fails during action setup, after seven seconds, before the image is built — so **no image was pushed to ghcr.io for v0.10.0** ([run](https://github.com/ralksta/immich-folio/actions/runs/31367938097)):

```
Unable to resolve action `aquasecurity/trivy-action@0.29.0`, unable to find version `0.29.0`
```

Pinned to the commit SHA of v0.36.0 rather than a tag — tags on a third-party action are mutable, and this job runs with `security-events: write`.

After this lands, the v0.10.0 release needs to be re-published (draft → publish) to fire `release: published` again; a `workflow_dispatch` run would not produce the semver and `latest` tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)