### PR TITLE
fix(screenshots): make the sharp typings work on 0.34 and 0.35

### DIFF
--- a/scripts/screenshots.ts
+++ b/scripts/screenshots.ts
@@ -266,9 +266,16 @@ async function main() {
  * dependency here, so a missing install just skips this step.
  */
 async function optimizePngs(): Promise<void> {
-  let sharp: typeof import('sharp');
+  // sharp 0.35 switched from `export =` to ESM: the module namespace stopped
+  // being callable and the factory moved to `.default`. Resolve whichever
+  // shape the installed version has, so this type-checks and runs on both.
+  type SharpFactory = typeof import('sharp') extends { default: infer Factory }
+    ? Factory
+    : typeof import('sharp');
+  let sharp: SharpFactory;
   try {
-    sharp = (await import('sharp')).default;
+    const mod = (await import('sharp')) as unknown as { default?: SharpFactory };
+    sharp = mod.default ?? (mod as unknown as SharpFactory);
   } catch {
     console.log('\n⏭  sharp not available — screenshots left as captured.');
     return;


### PR DESCRIPTION
The Next bump in #402 pulls `sharp` from 0.34.5 to 0.35.3 as a transitive dependency, and `npx tsc --noEmit` fails on it:

```
scripts/screenshots.ts(271,5): error TS2739: Type 'SharpConstructor' is missing the following properties from type 'typeof import("sharp/dist/index")': sharp, sharp
scripts/screenshots.ts(283,29): error TS2349: This expression is not callable.
```

sharp 0.35 moved from `export =` to ESM: the module namespace is no longer callable and the factory sits on `.default`. `scripts/screenshots.ts` had the 0.34 shape written into the type annotation.

sharp is not a declared dependency here — it arrives through Next — so the script has to tolerate either shape. The type is now derived from whatever is installed, and the runtime side picks `.default` when present.

Verified both ways: `npx tsc --noEmit` is clean with 0.34.5 (current lockfile) and with 0.35.3 installed on top.

This unblocks #402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)