### PR TITLE
chore(ci): run CI on dev and point Dependabot there

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
   # npm dependencies
   - package-ecosystem: 'npm'
     directory: '/'
+    # Dependency PRs open against dev, not the default branch: main only ever
+    # advances through a release. Dependabot also resets a PR's base to this
+    # value whenever it rebases, so retargeting a single PR by hand does not
+    # survive — the target has to be configured here.
+    target-branch: 'dev'
     schedule:
       interval: 'weekly'
       day: 'monday'
@@ -32,6 +37,7 @@ updates:
   # GitHub Actions
   - package-ecosystem: 'github-actions'
     directory: '/'
+    target-branch: 'dev'
     schedule:
       interval: 'weekly'
       day: 'monday'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,12 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    # dev is included because dependency and feature PRs target it — without
+    # it those PRs would carry no checks at all, and main would only find out
+    # at release time.
+    branches: [main, dev]
 
 # Cancel in-progress runs for the same PR / branch
 concurrency:


### PR DESCRIPTION
`main` only ever advances through a release, so dependency bumps should not land there one at a time.

Retargeting an individual PR does not achieve that: Dependabot resets a PR's base to the configured target branch whenever it rebases. #403, #404 and #406 were retargeted to `dev` by hand, got rebased, and merged into `main` anyway. `target-branch: dev` for both ecosystems makes it stick, and it has to live on the default branch to take effect — hence this PR against `main`.

Second commit: CI triggered on `main` only, for both `push` and `pull_request`. With PRs pointed at `dev`, they would carry no checks at all and a breakage would surface first at release time. #410 is already in that state — opened against `dev`, no checks reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)