### PR TITLE
refactor(admin): drop decorative emoji from the sort select labels

### DIFF
--- a/app/admin/components/PageBuilder.tsx
+++ b/app/admin/components/PageBuilder.tsx
@@ -31,13 +31,19 @@ import {
 } from '@/lib/albumSort';
 import type { AlbumEntryObject } from '@/lib/config/schema';
 
-/** Labels for the per-album sort select. Order matches ALBUM_SORT_MODES. */
+/**
+ * Labels for the per-album sort select. Order matches ALBUM_SORT_MODES.
+ *
+ * Plain text, no emoji: an <option> cannot contain markup, so the SVG set in
+ * `Icons` below is not available here — and a decorative emoji is not a
+ * substitute for it. The badge on the album card uses a real icon instead.
+ */
 const SORT_LABELS: Record<AlbumSortMode, string> = {
-  immich: '🗓 Immich order (default)',
-  newest: '⬇ Newest first',
-  oldest: '⬆ Oldest first',
-  filename: '🔤 Filename',
-  manual: '✋ Manual',
+  immich: 'Immich order (default)',
+  newest: 'Newest first',
+  oldest: 'Oldest first',
+  filename: 'Filename',
+  manual: 'Manual',
 };
 
 // ── Icons ──────────────────────────────────────────────────────


### PR DESCRIPTION
Follow-up to #414.

The per-album sort select shipped with emoji in its `<option>` labels (`🗓 Immich order`, `🔤 Filename`, `✋ Manual`). That does not follow the admin panel's icon convention — the panel has an SVG `Icons` set, and emoji are not a substitute for it.

An `<option>` cannot contain markup, so the SVG set is genuinely unreachable there. The right answer is therefore no icon at all rather than a decorative stand-in:

```
Immich order (default) | Newest first | Oldest first | Filename | Manual
```

The album card badge is unaffected — it already renders `Icons.Drag` for `manual` and the mode name as text otherwise.

## Not in scope

The admin panel has more emoji-as-icons that predate the sort feature and are left alone here, so this stays a one-file change:

- `AssetPicker.tsx` — the `📂 This Album` / `⭐ Favorites` / `🖼️ All Photos` tabs and the favourite badge
- `PageBuilder.tsx` — the `📷 Standalone Albums` and `📂 Subpages` headings, and the layout picker options (`📷 Masonry Grid`, `⭐ Showcase`, …)

Worth a dedicated pass if the convention should hold panel-wide.

## Tests

`tsc --noEmit` clean, 317 unit tests green. No behaviour change — the stored value is unchanged, only the visible label.
