### PR TITLE
refactor(admin): replace emoji icons with the shared SVG icon set

### DIFF
--- a/app/admin/admin.css
+++ b/app/admin/admin.css
@@ -1510,6 +1510,10 @@
 
 .asset-picker-tab {
   flex: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
   padding: 0.7rem 1rem;
   background: none;
   border: none;
@@ -1607,8 +1611,11 @@
   position: absolute;
   top: 4px;
   left: 4px;
-  font-size: 0.7rem;
-  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.6);
+  display: flex;
+  font-size: 0.85rem;
+  color: var(--admin-accent);
+  /* drop-shadow, not text-shadow: the badge is an inline SVG, not a glyph. */
+  filter: drop-shadow(0 1px 3px rgba(0, 0, 0, 0.6));
 }
 
 .asset-picker-uuid-section {

--- a/app/admin/components/AssetPicker.tsx
+++ b/app/admin/components/AssetPicker.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback, useRef } from 'react';
+import { IconFolder, IconImage, IconStar } from './Icons';
 
 interface AssetInfo {
   id: string;
@@ -126,20 +127,23 @@ export default function AssetPicker({
               className={`asset-picker-tab ${tab === 'album' ? 'active' : ''}`}
               onClick={() => setTab('album')}
             >
-              📂 This Album
+              <IconFolder size={14} />
+              This Album
             </button>
           )}
           <button
             className={`asset-picker-tab ${tab === 'favorites' ? 'active' : ''}`}
             onClick={() => setTab('favorites')}
           >
-            ⭐ Favorites
+            <IconStar size={14} />
+            Favorites
           </button>
           <button
             className={`asset-picker-tab ${tab === 'all' ? 'active' : ''}`}
             onClick={() => setTab('all')}
           >
-            🖼️ All Photos
+            <IconImage size={14} />
+            All Photos
           </button>
         </div>
 
@@ -173,7 +177,9 @@ export default function AssetPicker({
                     />
                     {isUsed && <div className="asset-picker-used-badge">✓</div>}
                     {asset.isFavorite && !isUsed && (
-                      <div className="asset-picker-fav-badge">⭐</div>
+                      <div className="asset-picker-fav-badge" title="Favorite in Immich">
+                        <IconStar size={14} />
+                      </div>
                     )}
                   </div>
                 );

--- a/app/admin/components/Icons.tsx
+++ b/app/admin/components/Icons.tsx
@@ -256,6 +256,25 @@ export function IconHeart({ size = 16, className = 'svg-icon', strokeWidth = 2, 
   );
 }
 
+/** Filled by default — it marks a state (favourite), not an action. */
+export function IconStar({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+      <path d="m12 2 3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14l-5-4.87 6.91-1.01Z" />
+    </svg>
+  );
+}
+
+export function IconImage({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+      <rect width="18" height="18" x="3" y="3" rx="2" ry="2" />
+      <circle cx="9" cy="9" r="2" />
+      <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21" />
+    </svg>
+  );
+}
+
 export function IconBarChart({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>

--- a/app/admin/components/PageBuilder.tsx
+++ b/app/admin/components/PageBuilder.tsx
@@ -1031,7 +1031,10 @@ export default function PageBuilder() {
       {/* Standalone Albums */}
       <section className="builder-section">
         <div className="builder-section-header">
-          <h2>📷 Standalone Albums</h2>
+          <h2>
+            <Icons.Camera />
+            Standalone Albums
+          </h2>
           <button
             className="admin-btn admin-btn-sm"
             onClick={() => setPickerTarget({ type: 'standalone' })}
@@ -1080,7 +1083,10 @@ export default function PageBuilder() {
       {/* Subpages */}
       <section className="builder-section">
         <div className="builder-section-header">
-          <h2>📂 Subpages</h2>
+          <h2>
+            <Icons.Folder />
+            Subpages
+          </h2>
           <button className="admin-btn admin-btn-sm" onClick={addSubpage}>
             + New Subpage
           </button>
@@ -1327,12 +1333,17 @@ export default function PageBuilder() {
                             }}
                             style={{ padding: '8px 12px', borderRadius: '6px', width: '100%', fontSize: '0.9rem' }}
                           >
-                            <option value="masonry">📷 Masonry Grid (Dynamic Height)</option>
-                            <option value="uniform">🔲 Uniform Grid (Square Tiles)</option>
-                            <option value="showcase">⭐ Showcase (Featured First Asset)</option>
-                            <option value="filmstrip">🎞️ Filmstrip (Horizontal Scroll)</option>
-                            <option value="editorial-flow">📰 Editorial Flow</option>
-                            <option value="essay">📖 Photo Essay Mode (Storytelling Editor)</option>
+                            {/*
+                              Plain text, no emoji: an <option> cannot contain markup, so the
+                              SVG icon set is not available here — and a decorative emoji is
+                              not a substitute for it.
+                            */}
+                            <option value="masonry">Masonry Grid (Dynamic Height)</option>
+                            <option value="uniform">Uniform Grid (Square Tiles)</option>
+                            <option value="showcase">Showcase (Featured First Asset)</option>
+                            <option value="filmstrip">Filmstrip (Horizontal Scroll)</option>
+                            <option value="editorial-flow">Editorial Flow</option>
+                            <option value="essay">Photo Essay Mode (Storytelling Editor)</option>
                           </select>
                         </div>
                       </div>


### PR DESCRIPTION
## Summary

The admin panel mixed two icon conventions: inline SVGs from `app/admin/components/Icons.tsx` in most components, and decorative emoji in the asset picker and a few PageBuilder labels. This replaces the emoji so the panel follows a single convention.

Emoji render differently per platform/font, ignore `--admin-accent`, and can't inherit the `.svg-icon` sizing rules the rest of the panel uses.

**Changes**

- **`Icons.tsx`** — adds `IconStar` (filled, since it marks a state rather than an action) and `IconImage`, matching the module's existing `IconProps` signature and style.
- **`AssetPicker.tsx`** — the three tab labels (`📂 This Album`, `⭐ Favorites`, `🖼️ All Photos`) and the `⭐` favourite badge on a tile now use `IconFolder` / `IconStar` / `IconImage`. The badge also gains a `title="Favorite in Immich"`, which the bare emoji never had.
- **`PageBuilder.tsx`** — the `📷 Standalone Albums` and `📂 Subpages` headings use the icon set.
- **`PageBuilder.tsx`** — the layout picker `<option>` labels drop their emoji for plain text. An HTML `<option>` cannot contain markup, so an SVG is impossible there and a decorative glyph is not a substitute; a code comment records why. Same reasoning as #415 for the sort select.
- **`admin.css`** — `.asset-picker-tab` becomes `inline-flex` with a gap so icon and label align; `.asset-picker-fav-badge` swaps `text-shadow` for `filter: drop-shadow(...)`, since `text-shadow` does nothing to an inline SVG, and takes the accent colour.

**Notes for the reviewer**

- The original plan was to extract the `Icons` object out of `PageBuilder.tsx` into its own module. That turned out to be unnecessary: a shared `Icons.tsx` already exists and is already the dominant convention (imported by `AdminDashboard`, `SettingsEditor`, `AnalyticsView`, `BackupManagerModal`, `EssayBlockEditor`). `AssetPicker` now imports from it too.
- `PageBuilder` still carries its own local `Icons` object — a near-duplicate of the shared module used at ~32 call sites. The two headings here use that local set so the file stays internally consistent; deduping it is a separate refactor and is deliberately out of scope for this PR.
- `SORT_LABELS` still has its emoji: that is #415's change, left alone here to avoid conflicting.
- Lint: the two new functions in `Icons.tsx` add 4 `prettier/prettier` errors, because they match that file's existing single-line style rather than mixing formatted and unformatted functions in one file. `Icons.tsx` already has 65 such errors on `dev` (the repo has 515 in total); `npm run format` on that file would clear all of them at once. No new lint errors in `PageBuilder.tsx` or `AssetPicker.tsx`.

## Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🎨 Style / visual
- [ ] ♻️ Refactor
- [ ] 🔒 Security fix
- [ ] 📝 Documentation
- [ ] 🛠️ Build / CI

## Checklist

- [x] Targets the `dev` branch (see [CONTRIBUTING.md](../CONTRIBUTING.md#branches))
- [x] `npm run build` passes locally
- [x] `npx tsc --noEmit` passes (0 type errors)
- [x] `npx vitest run` passes (317 tests, 27 files, all green)
- [x] No secrets / API keys in diff
- [ ] Documentation updated if needed (`docs/`, `README.md`) — no docs cover these labels
- [ ] Screenshots attached if there are visual changes — see below

## Screenshots (if applicable)

Not attached. The admin panel needs `ADMIN_PASSWORD` plus live Immich credentials, and there is no `.env.local` in the environment this was built in, so the panel could not be rendered to capture before/after. The changes are visual and worth a manual look on a configured instance — specifically the asset picker tabs, the favourite badge over a thumbnail, and the two section headings.
