### PR TITLE
refactor(admin): fold PageBuilder's local icons into the shared Icons module

### DIFF
--- a/app/admin/admin.css
+++ b/app/admin/admin.css
@@ -1782,8 +1782,10 @@
     color 0.15s ease;
 }
 
+/* Drag handles use IconGripVertical's square 24x24 viewBox, so keep the box
+   square too — a 12x18 box would letterbox the glyph down to 12x12. */
 .svg-drag {
-  width: 12px;
+  width: 18px;
   height: 18px;
 }
 

--- a/app/admin/components/Icons.tsx
+++ b/app/admin/components/Icons.tsx
@@ -279,6 +279,50 @@ export function IconGripVertical({ size = 16, className = 'svg-icon', strokeWidt
   );
 }
 
+export function IconX({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+      <path d="M18 6 6 18M6 6l12 12" />
+    </svg>
+  );
+}
+
+export function IconPlus({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+      <path d="M5 12h14M12 5v14" />
+    </svg>
+  );
+}
+
+export function IconHome({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+      <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+      <polyline points="9 22 9 12 15 12 15 22" />
+    </svg>
+  );
+}
+
+export function IconCopy({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+      <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
+      <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+    </svg>
+  );
+}
+
+export function IconImage({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+      <rect width="18" height="18" x="3" y="3" rx="2" ry="2" />
+      <circle cx="9" cy="9" r="2" />
+      <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21" />
+    </svg>
+  );
+}
+
 export function IconQuote({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>

--- a/app/admin/components/Icons.tsx
+++ b/app/admin/components/Icons.tsx
@@ -332,16 +332,6 @@ export function IconCopy({ size = 16, className = 'svg-icon', strokeWidth = 2, .
   );
 }
 
-export function IconImage({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
-      <rect width="18" height="18" x="3" y="3" rx="2" ry="2" />
-      <circle cx="9" cy="9" r="2" />
-      <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21" />
-    </svg>
-  );
-}
-
 export function IconQuote({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>

--- a/app/admin/components/PageBuilder.tsx
+++ b/app/admin/components/PageBuilder.tsx
@@ -30,6 +30,20 @@ import {
   type AlbumSortMode,
 } from '@/lib/albumSort';
 import type { AlbumEntryObject } from '@/lib/config/schema';
+import {
+  IconCamera,
+  IconCopy,
+  IconFolder,
+  IconGripVertical,
+  IconHome,
+  IconImage,
+  IconLock,
+  IconPencil,
+  IconPlus,
+  IconSearch,
+  IconTrash,
+  IconX,
+} from './Icons';
 
 /** Labels for the per-album sort select. Order matches ALBUM_SORT_MODES. */
 const SORT_LABELS: Record<AlbumSortMode, string> = {
@@ -38,97 +52,6 @@ const SORT_LABELS: Record<AlbumSortMode, string> = {
   oldest: '⬆ Oldest first',
   filename: '🔤 Filename',
   manual: '✋ Manual',
-};
-
-// ── Icons ──────────────────────────────────────────────────────
-const Icons = {
-  Drag: () => (
-    <svg width="12" height="18" viewBox="0 0 12 18" fill="currentColor" className="svg-icon svg-drag">
-      <circle cx="2" cy="2" r="1.5" />
-      <circle cx="2" cy="9" r="1.5" />
-      <circle cx="2" cy="16" r="1.5" />
-      <circle cx="10" cy="2" r="1.5" />
-      <circle cx="10" cy="9" r="1.5" />
-      <circle cx="10" cy="16" r="1.5" />
-    </svg>
-  ),
-  Edit: () => (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
-      <path d="M12 20h9" />
-      <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z" />
-    </svg>
-  ),
-  Trash: () => (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
-      <path d="M3 6h18" />
-      <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />
-      <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
-    </svg>
-  ),
-  Close: () => (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
-      <path d="M18 6 6 18M6 6l12 12" />
-    </svg>
-  ),
-  Folder: () => (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
-      <path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z" />
-    </svg>
-  ),
-  Camera: () => (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
-      <path d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3Z" />
-      <circle cx="12" cy="13" r="3" />
-    </svg>
-  ),
-  ExternalLink: () => (
-    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
-      <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
-      <polyline points="15 3 21 3 21 9" />
-      <line x1="10" y1="14" x2="21" y2="3" />
-    </svg>
-  ),
-  Search: () => (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
-      <circle cx="11" cy="11" r="8" />
-      <path d="m21 21-4.3-4.3" />
-    </svg>
-  ),
-  Lock: () => (
-    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
-      <rect width="18" height="11" x="3" y="11" rx="2" ry="2" />
-      <path d="M7 11V7a5 5 0 0 1 10 0v4" />
-    </svg>
-  ),
-  Plus: () => (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
-      <path d="M5 12h14M12 5v14" />
-    </svg>
-  ),
-  Home: () => (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
-      <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
-      <polyline points="9 22 9 12 15 12 15 22" />
-    </svg>
-  ),
-  Copy: () => (
-    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
-      <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
-      <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
-    </svg>
-  ),
-  Check: () => (
-    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
-      <polyline points="20 6 9 17 4 12" />
-    </svg>
-  ),
-  Image: () => (
-    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="svg-icon">
-      <rect width="18" height="18" x="3" y="3" rx="2" ry="2" />
-      <circle cx="9" cy="9" r="2" />
-      <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21" />
-    </svg>
-  ),
 };
 
 // ── Types ──────────────────────────────────────────────────────
@@ -270,11 +193,11 @@ function SortableHeroTile({
   return (
     <div ref={setNodeRef} style={style} className="hero-tile" {...attributes}>
       <div className="hero-tile-drag" {...listeners} title="Drag to reorder">
-        <Icons.Drag />
+        <IconGripVertical size={18} className="svg-icon svg-drag" />
       </div>
       <img src={`/api/admin/thumbnail/${id}`} alt="" loading="lazy" />
       <button className="hero-tile-remove" onClick={onRemove} title="Remove">
-        <Icons.Close />
+        <IconX size={14} />
       </button>
       <span className="hero-tile-index">{index + 1}</span>
     </div>
@@ -366,7 +289,7 @@ function SortableSubpageTile({
       {...attributes}
     >
       <div className="subpage-tile-drag" {...listeners} title="Drag to reorder">
-        <Icons.Drag />
+        <IconGripVertical size={18} className="svg-icon svg-drag" />
       </div>
 
       {sp.enabled === false && (
@@ -377,7 +300,7 @@ function SortableSubpageTile({
 
       {sp.password && (
         <span className="subpage-badge-protected" title="Password protected">
-          <Icons.Lock /> Password
+          <IconLock size={12} /> Password
         </span>
       )}
 
@@ -386,11 +309,11 @@ function SortableSubpageTile({
           <img src={`/api/admin/thumbnail/${firstThumb}`} alt="" loading="lazy" />
         ) : (
           <div className="subpage-tile-placeholder">
-            <Icons.Folder />
+            <IconFolder />
           </div>
         )}
         <div className="subpage-hover-overlay">
-          <span className="hover-action-btn"><Icons.Edit /> Edit Page</span>
+          <span className="hover-action-btn"><IconPencil size={14} /> Edit Page</span>
         </div>
       </div>
       <div className="subpage-tile-info">
@@ -399,7 +322,7 @@ function SortableSubpageTile({
           <span className="subpage-tile-slug">/{slug}</span>
         </div>
         <span className="subpage-tile-meta">
-          <Icons.Folder /> {totalAlbums} album{totalAlbums !== 1 ? 's' : ''}
+          <IconFolder /> {totalAlbums} album{totalAlbums !== 1 ? 's' : ''}
         </span>
       </div>
     </div>
@@ -967,7 +890,7 @@ export default function PageBuilder() {
       {/* Search Bar */}
       <div className="builder-search-container">
         <div className="builder-search-wrapper">
-          <span className="builder-search-icon"><Icons.Search /></span>
+          <span className="builder-search-icon"><IconSearch size={14} /></span>
           <input
             type="text"
             className="builder-search-input"
@@ -986,7 +909,7 @@ export default function PageBuilder() {
       {/* Hero Section */}
       <section className="builder-section">
         <div className="builder-section-header">
-          <h2><Icons.Home /> Homepage Hero</h2>
+          <h2><IconHome /> Homepage Hero</h2>
           <button
             className="admin-btn admin-btn-sm"
             onClick={() =>
@@ -997,7 +920,7 @@ export default function PageBuilder() {
               })
             }
           >
-            <Icons.Plus /> Add Hero
+            <IconPlus size={14} /> Add Hero
           </button>
         </div>
         <DndContext
@@ -1145,7 +1068,7 @@ export default function PageBuilder() {
                             onClick={() => setDrawerMode('edit')}
                             style={{ padding: '0.2rem 0.6rem', fontSize: '0.75rem' }}
                           >
-                            <Icons.Edit /> Edit
+                            <IconPencil size={14} /> Edit
                           </button>
                           <button
                             type="button"
@@ -1153,7 +1076,7 @@ export default function PageBuilder() {
                             onClick={() => setDrawerMode('preview')}
                             style={{ padding: '0.2rem 0.6rem', fontSize: '0.75rem' }}
                           >
-                            <Icons.Search /> Live Preview
+                            <IconSearch size={14} /> Live Preview
                           </button>
                         </div>
 
@@ -1200,7 +1123,7 @@ export default function PageBuilder() {
                                           {thumb ? (
                                             <img src={`/api/admin/thumbnail/${thumb}`} alt="" />
                                           ) : (
-                                            <div className="subpage-tile-placeholder"><Icons.Folder /></div>
+                                            <div className="subpage-tile-placeholder"><IconFolder /></div>
                                           )}
                                         </div>
                                         <span className="preview-album-title">
@@ -1224,7 +1147,7 @@ export default function PageBuilder() {
                                       {thumb ? (
                                         <img src={`/api/admin/thumbnail/${thumb}`} alt="" />
                                       ) : (
-                                        <div className="subpage-tile-placeholder"><Icons.Folder /></div>
+                                        <div className="subpage-tile-placeholder"><IconFolder /></div>
                                       )}
                                     </div>
                                     <span className="preview-album-title">
@@ -1280,7 +1203,7 @@ export default function PageBuilder() {
                         <div className="admin-field">
                           <label>Password Protection (optional)</label>
                           <div className="password-input-wrapper">
-                            <span className="password-icon"><Icons.Lock /></span>
+                            <span className="password-icon"><IconLock size={12} /></span>
                             <input
                               type="password"
                               value={sp.password || ''}
@@ -1433,7 +1356,7 @@ export default function PageBuilder() {
                                   onClick={() => removeSection(spIndex, secIndex)}
                                   title="Remove section"
                                 >
-                                  <Icons.Close />
+                                  <IconX size={14} />
                                 </button>
                               </div>
                               <div className="admin-field">
@@ -1503,7 +1426,7 @@ export default function PageBuilder() {
                           setExpandedSubpage(null);
                         }}
                       >
-                        <Icons.Trash /> Delete Subpage
+                        <IconTrash size={14} /> Delete Subpage
                       </button>
                       <button
                         className="admin-btn admin-btn-primary admin-btn-sm"
@@ -1543,14 +1466,14 @@ export default function PageBuilder() {
             <div className="album-drawer" onClick={(e) => e.stopPropagation()}>
               <div className="album-drawer-header">
                 <h3>
-                  <Icons.Camera /> Edit Album Details
+                  <IconCamera /> Edit Album Details
                 </h3>
                 <button
                   className="admin-btn-icon"
                   onClick={() => setEditingAlbumAddress(null)}
                   title="Close details"
                 >
-                  <Icons.Close />
+                  <IconX size={14} />
                 </button>
               </div>
               <div className="album-drawer-body">
@@ -1561,7 +1484,7 @@ export default function PageBuilder() {
                       <img src={`/api/admin/thumbnail/${heroThumb}`} alt="" loading="lazy" />
                     ) : (
                       <div className="modal-cover-placeholder">
-                        <Icons.Camera />
+                        <IconCamera />
                       </div>
                     )}
                   </div>
@@ -1600,7 +1523,7 @@ export default function PageBuilder() {
                         }}
                         title="Copy UUID"
                       >
-                        <Icons.Copy />
+                        <IconCopy size={12} />
                       </button>
                     </div>
                   </div>
@@ -1651,7 +1574,7 @@ export default function PageBuilder() {
                             onClick={() => onUpdate({ heroImage: undefined })}
                             title="Remove custom hero image"
                           >
-                            <Icons.Close />
+                            <IconX size={14} />
                           </button>
                         </div>
                       ) : (
@@ -1671,7 +1594,7 @@ export default function PageBuilder() {
                           })
                         }
                       >
-                        <Icons.Image /> {album.heroImage ? 'Change Image' : 'Pick Hero Image'}
+                        <IconImage size={12} /> {album.heroImage ? 'Change Image' : 'Pick Hero Image'}
                       </button>
                     </div>
                   </div>
@@ -1721,7 +1644,7 @@ export default function PageBuilder() {
                             })
                           }
                         >
-                          <Icons.Drag />{' '}
+                          <IconGripVertical size={18} className="svg-icon svg-drag" />{' '}
                           {album.assetOrder?.length
                             ? `Reorder photos (${album.assetOrder.length} pinned)`
                             : 'Reorder photos'}
@@ -1737,7 +1660,7 @@ export default function PageBuilder() {
                   onClick={onRemove}
                   style={{ maxWidth: '160px' }}
                 >
-                  <Icons.Trash /> Remove Album
+                  <IconTrash size={14} /> Remove Album
                 </button>
                 <button
                   className="admin-btn admin-btn-primary"
@@ -1900,14 +1823,14 @@ function AlbumCard({
       <div className="album-tile-cover">
         {dragListeners && (
           <div className="album-tile-drag" {...dragListeners} title="Drag to reorder">
-            <Icons.Drag />
+            <IconGripVertical size={18} className="svg-icon svg-drag" />
           </div>
         )}
         {heroThumb ? (
           <img src={`/api/admin/thumbnail/${heroThumb}`} alt="" loading="lazy" />
         ) : (
           <div className="album-tile-placeholder">
-            <Icons.Camera />
+            <IconCamera />
           </div>
         )}
         <div className="album-tile-overlay">
@@ -1916,14 +1839,14 @@ function AlbumCard({
             onClick={onEdit}
             title="Edit details"
           >
-            <Icons.Edit />
+            <IconPencil size={14} />
           </button>
           <button
             className="album-tile-btn album-tile-btn-danger"
             onClick={onRemove}
             title="Remove album"
           >
-            <Icons.Trash />
+            <IconTrash size={14} />
           </button>
         </div>
       </div>
@@ -1935,17 +1858,17 @@ function AlbumCard({
           <div className="album-tile-badges">
             {hasPassword && (
               <span className="badge badge-password" title="Password protected">
-                <Icons.Lock />
+                <IconLock size={12} />
               </span>
             )}
             {album.heroImage && (
               <span className="badge badge-hero" title="Custom Hero Image set">
-                <Icons.Image />
+                <IconImage size={12} />
               </span>
             )}
             {album.sort && album.sort !== DEFAULT_ALBUM_SORT && (
               <span className="badge badge-sort" title={`Photo order: ${SORT_LABELS[album.sort]}`}>
-                {album.sort === 'manual' ? <Icons.Drag /> : album.sort}
+                {album.sort === 'manual' ? <IconGripVertical size={18} className="svg-icon svg-drag" /> : album.sort}
               </span>
             )}
           </div>

--- a/app/admin/components/PageBuilder.tsx
+++ b/app/admin/components/PageBuilder.tsx
@@ -48,9 +48,9 @@ import {
 /**
  * Labels for the per-album sort select. Order matches ALBUM_SORT_MODES.
  *
- * Plain text, no emoji: an <option> cannot contain markup, so the SVG set in
- * `Icons` below is not available here — and a decorative emoji is not a
- * substitute for it. The badge on the album card uses a real icon instead.
+ * Plain text, no emoji: an <option> cannot contain markup, so the SVG set from
+ * `./Icons` is not available here — and a decorative emoji is not a substitute
+ * for it. The badge on the album card uses a real icon instead.
  */
 const SORT_LABELS: Record<AlbumSortMode, string> = {
   immich: 'Immich order (default)',
@@ -961,7 +961,7 @@ export default function PageBuilder() {
       <section className="builder-section">
         <div className="builder-section-header">
           <h2>
-            <Icons.Camera />
+            <IconCamera />
             Standalone Albums
           </h2>
           <button
@@ -1013,7 +1013,7 @@ export default function PageBuilder() {
       <section className="builder-section">
         <div className="builder-section-header">
           <h2>
-            <Icons.Folder />
+            <IconFolder />
             Subpages
           </h2>
           <button className="admin-btn admin-btn-sm" onClick={addSubpage}>


### PR DESCRIPTION
## Summary

The admin panel had two parallel SVG icon sets: the shared `app/admin/components/Icons.tsx` module, and a local `Icons` object at the top of `PageBuilder.tsx` that duplicated most of the same glyphs with hardcoded sizes. This folds the local object into the shared module and migrates all 32 call sites.

Does not close an issue. Related: #417, which covers the emoji labels in the sort dropdown — deliberately left out of this PR, see below.

**Added to `Icons.tsx`** — five glyphs that had no counterpart, ported 1:1 from the local paths so nothing changes visually: `IconX`, `IconPlus`, `IconHome`, `IconCopy`, `IconImage`.

**Dropped** — the local `ExternalLink` and `Check` are not ported. Both had zero call sites; they were dead code.

**Sizes** — call sites pass `size={12}` / `size={14}` where the local version used a non-16 box. The 16px ones rely on the default. In practice `.svg-icon` forces `width/height: 1em`, so `size` is mostly a fallback.

## Two deliberate visual changes

Worth a reviewer's eye, since consolidating means picking one glyph over the other:

1. **Camera** — the local path closed the body with `h-3Z`; the shared `IconCamera` has `l-2.5-3z`, i.e. the small viewfinder bump on top. PageBuilder now gets that bump, matching the rest of the admin panel.

2. **Drag handle** — `.svg-drag` goes from `12px × 18px` to `18px × 18px` in `admin.css`. The local `Drag` icon had `viewBox="0 0 12 18"`, so its dots filled the box edge to edge. `IconGripVertical` uses the module's square `24 × 24` viewBox; inside a 12×18 box `preserveAspectRatio` would letterbox it to a centred 12×12 and visibly shrink the handle. Squaring the CSS box keeps the rendered handle about the same size. There is a comment in `admin.css` explaining this so it does not get "fixed" back later.

## Not in scope

The five colour emoji in `SORT_LABELS` (🗓 ⬇ ⬆ 🔤 ✋) are still emoji. They cannot be swapped for SVG here: they are consumed inside a native `<option>` and inside a `title` attribute, both of which take plain text only. Fixing them properly means replacing the native `<select>` with an accessible custom listbox, which is tracked separately in #417.

## Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🎨 Style / visual
- [x] ♻️ Refactor
- [ ] 🔒 Security fix
- [ ] 📝 Documentation
- [ ] 🛠️ Build / CI

## Checklist

- [x] Targets the `dev` branch (see [CONTRIBUTING.md](../CONTRIBUTING.md#branches))
- [x] `npm run build` passes locally
- [x] `npx tsc --noEmit` passes (0 type errors)
- [x] `npx vitest run` passes (ran as `npm run test:unit` — 317 tests across 27 files, all green)
- [x] No secrets / API keys in diff
- [x] Documentation updated if needed — no docs describe the icon internals
- [ ] Screenshots attached if there are visual changes — see below

`npm run lint` also went from 652 problems on `dev` to 649, so no new violations. The remaining Prettier errors in both files are pre-existing; `npm run format` was deliberately not run, since CLAUDE.md warns it pollutes the diff repo-wide.

## Screenshots (if applicable)

None attached, and I want to be upfront about why rather than leave the box quietly unticked. This checkout has no `.env.local`, only the example, so there is no `ADMIN_PASSWORD` and no reachable Immich instance — `/admin` does not render and a dev server would not have proven anything.

The drag handle is the one place where the rendered result actually changes, so that is the spot to eyeball on a live instance before merging.
