### PR TITLE
fix: allow empty gallery, guard against double /api suffix

### DIFF
--- a/lib/__tests__/config-safe.test.ts
+++ b/lib/__tests__/config-safe.test.ts
@@ -39,10 +39,11 @@ function withGallery(gallery: unknown) {
 /**
  * The admin page builder can write each of these, and the root layout renders
  * /admin inside itself — so a throw here would take down the site together with
- * the only tool that can undo the save.
+ * the only tool that can undo the save. An empty gallery is deliberately NOT in
+ * this list: the install wizard can finish without selecting an album, so an
+ * empty gallery is now a valid, rendered state (see derive-gallery.test.ts).
  */
 const UNDERIVABLE = {
-  'a gallery with neither albums nor subpages': { albums: [] },
   'a subpage with no name': { albums: [ALBUM_ID], subpages: [{ albums: [ALBUM_ID] }] },
   'a subpage with neither albums nor sections': {
     albums: [ALBUM_ID],
@@ -61,6 +62,17 @@ describe('getConfig() rejects an underivable gallery.yaml', () => {
       expect(() => getConfig()).toThrow();
     });
   }
+
+  it('accepts an empty gallery — a valid post-install state', () => {
+    // The install wizard may finish without selecting an album, so an empty
+    // gallery must render (title-only homepage) rather than take down the site.
+    withGallery({ albums: [] });
+    const config = getConfig();
+    expect(config.albums).toEqual([]);
+    expect(config.standaloneAlbums).toEqual([]);
+    expect(config.subpages).toEqual([]);
+    expect(config.needsSetup).toBe(false);
+  });
 });
 
 describe('getConfigOrNull()', () => {
@@ -81,7 +93,9 @@ describe('getConfigOrNull()', () => {
   }
 
   it('logs the underlying error so the cause is diagnosable from the server log', () => {
-    withGallery({ albums: [] });
+    // A nameless subpage is still underivable — an empty gallery is not (the
+    // install wizard can finish without an album, so that shape is now valid).
+    withGallery({ albums: [ALBUM_ID], subpages: [{ albums: [ALBUM_ID] }] });
     getConfigOrNull();
 
     expect(error).toHaveBeenCalled();
@@ -89,7 +103,7 @@ describe('getConfigOrNull()', () => {
   });
 
   it('points at the backup directory, since that is the recovery path', () => {
-    withGallery({ albums: [] });
+    withGallery({ albums: [ALBUM_ID], subpages: [{ albums: [ALBUM_ID] }] });
     getConfigOrNull();
     expect(String(error.mock.calls[0][0])).toContain('content/.backups/');
   });

--- a/lib/__tests__/derive-gallery.test.ts
+++ b/lib/__tests__/derive-gallery.test.ts
@@ -31,10 +31,6 @@ const B = '22222222-2222-2222-2222-222222222222';
  * shapes the page builder can produce.
  */
 describe('deriveGallery rejects what the site cannot load', () => {
-  it('rejects a gallery with neither albums nor subpages', () => {
-    expect(() => deriveGallery({ albums: [] } as GalleryYaml)).toThrow(/at least one album/i);
-  });
-
   it('rejects a subpage with no name', () => {
     expect(() =>
       deriveGallery({ albums: [A], subpages: [{ albums: [A] }] } as unknown as GalleryYaml),
@@ -67,6 +63,15 @@ describe('deriveGallery rejects what the site cannot load', () => {
 });
 
 describe('deriveGallery accepts valid structures', () => {
+  it('derives an empty gallery (no albums or subpages)', () => {
+    // The install wizard can finish without selecting an album, so an empty
+    // gallery must be a valid, rendered state rather than an error.
+    const result = deriveGallery({ albums: [] } as GalleryYaml);
+    expect(result.albums).toEqual([]);
+    expect(result.standaloneAlbums).toEqual([]);
+    expect(result.subpages).toEqual([]);
+  });
+
   it('derives standalone albums', () => {
     const result = deriveGallery({ albums: [A, B] } as GalleryYaml);
     expect(result.albums).toEqual([A, B]);
@@ -102,77 +107,6 @@ describe('deriveGallery accepts valid structures', () => {
     expect(result.albumOverrides[A]).toBe('Renamed');
     expect(result.albumDescriptions[A]).toBe('A note');
     expect(result.albumHeroImages[A]).toBe(B);
-  });
-
-  it('collects the per-album sort mode', () => {
-    const result = deriveGallery({
-      albums: [{ [A]: { title: 'Series', sort: 'filename' } }, B],
-    } as unknown as GalleryYaml);
-
-    expect(result.albumSortModes[A]).toBe('filename');
-    // Absent means the default; an explicit entry would make `immich` and
-    // "never configured" indistinguishable downstream.
-    expect(result.albumSortModes[B]).toBeUndefined();
-  });
-
-  // A typo would otherwise be invisible: the album would keep rendering in
-  // Immich order and nothing would say why. Throwing is also what gives the
-  // admin PUT its 400, via the deriveGallery dry-run.
-  it('rejects an unknown sort mode, naming the album and the valid values', () => {
-    expect(() =>
-      deriveGallery({ albums: [{ [A]: { sort: 'alphabetical' } }] } as unknown as GalleryYaml),
-    ).toThrow(/alphabetical/);
-
-    expect(() =>
-      deriveGallery({ albums: [{ [A]: { sort: 'alphabetical' } }] } as unknown as GalleryYaml),
-    ).toThrow(new RegExp(A));
-
-    expect(() =>
-      deriveGallery({ albums: [{ [A]: { sort: 'alphabetical' } }] } as unknown as GalleryYaml),
-    ).toThrow(/filename/);
-  });
-
-  it('collects the manual asset order, preserving its order', () => {
-    const result = deriveGallery({
-      albums: [{ [A]: { sort: 'manual', assetOrder: [B, A] } }],
-    } as unknown as GalleryYaml);
-
-    expect(result.albumManualOrders[A]).toEqual([B, A]);
-  });
-
-  // Kept regardless of the mode, so toggling manual → newest → manual in the
-  // admin panel does not silently destroy a hand-curated order.
-  it('keeps the asset order even when the mode is not manual', () => {
-    const result = deriveGallery({
-      albums: [{ [A]: { sort: 'newest', assetOrder: [B] } }],
-    } as unknown as GalleryYaml);
-
-    expect(result.albumSortModes[A]).toBe('newest');
-    expect(result.albumManualOrders[A]).toEqual([B]);
-  });
-
-  it('ignores an empty asset order rather than storing one', () => {
-    const result = deriveGallery({
-      albums: [{ [A]: { sort: 'manual', assetOrder: [] } }],
-    } as unknown as GalleryYaml);
-
-    expect(result.albumManualOrders[A]).toBeUndefined();
-  });
-
-  // processAlbumEntry is reached from four places; only the array-subpage path
-  // was covered before, so a regression in the others would go unnoticed.
-  it('applies the sort mode to section and map-style subpage albums too', () => {
-    const sectioned = deriveGallery({
-      subpages: [
-        { name: 'Work', sections: [{ title: 'Recent', albums: [{ [A]: { sort: 'oldest' } }] }] },
-      ],
-    } as unknown as GalleryYaml);
-    expect(sectioned.albumSortModes[A]).toBe('oldest');
-
-    const mapStyle = deriveGallery({
-      subpages: { Trips: { albums: [{ [B]: { sort: 'filename' } }] } },
-    } as unknown as GalleryYaml);
-    expect(mapStyle.albumSortModes[B]).toBe('filename');
   });
 
   it('parses enabled property on subpages correctly', () => {

--- a/lib/__tests__/derive-gallery.test.ts
+++ b/lib/__tests__/derive-gallery.test.ts
@@ -109,6 +109,77 @@ describe('deriveGallery accepts valid structures', () => {
     expect(result.albumHeroImages[A]).toBe(B);
   });
 
+  it('collects the per-album sort mode', () => {
+    const result = deriveGallery({
+      albums: [{ [A]: { title: 'Series', sort: 'filename' } }, B],
+    } as unknown as GalleryYaml);
+
+    expect(result.albumSortModes[A]).toBe('filename');
+    // Absent means the default; an explicit entry would make `immich` and
+    // "never configured" indistinguishable downstream.
+    expect(result.albumSortModes[B]).toBeUndefined();
+  });
+
+  // A typo would otherwise be invisible: the album would keep rendering in
+  // Immich order and nothing would say why. Throwing is also what gives the
+  // admin PUT its 400, via the deriveGallery dry-run.
+  it('rejects an unknown sort mode, naming the album and the valid values', () => {
+    expect(() =>
+      deriveGallery({ albums: [{ [A]: { sort: 'alphabetical' } }] } as unknown as GalleryYaml),
+    ).toThrow(/alphabetical/);
+
+    expect(() =>
+      deriveGallery({ albums: [{ [A]: { sort: 'alphabetical' } }] } as unknown as GalleryYaml),
+    ).toThrow(new RegExp(A));
+
+    expect(() =>
+      deriveGallery({ albums: [{ [A]: { sort: 'alphabetical' } }] } as unknown as GalleryYaml),
+    ).toThrow(/filename/);
+  });
+
+  it('collects the manual asset order, preserving its order', () => {
+    const result = deriveGallery({
+      albums: [{ [A]: { sort: 'manual', assetOrder: [B, A] } }],
+    } as unknown as GalleryYaml);
+
+    expect(result.albumManualOrders[A]).toEqual([B, A]);
+  });
+
+  // Kept regardless of the mode, so toggling manual → newest → manual in the
+  // admin panel does not silently destroy a hand-curated order.
+  it('keeps the asset order even when the mode is not manual', () => {
+    const result = deriveGallery({
+      albums: [{ [A]: { sort: 'newest', assetOrder: [B] } }],
+    } as unknown as GalleryYaml);
+
+    expect(result.albumSortModes[A]).toBe('newest');
+    expect(result.albumManualOrders[A]).toEqual([B]);
+  });
+
+  it('ignores an empty asset order rather than storing one', () => {
+    const result = deriveGallery({
+      albums: [{ [A]: { sort: 'manual', assetOrder: [] } }],
+    } as unknown as GalleryYaml);
+
+    expect(result.albumManualOrders[A]).toBeUndefined();
+  });
+
+  // processAlbumEntry is reached from four places; only the array-subpage path
+  // was covered before, so a regression in the others would go unnoticed.
+  it('applies the sort mode to section and map-style subpage albums too', () => {
+    const sectioned = deriveGallery({
+      subpages: [
+        { name: 'Work', sections: [{ title: 'Recent', albums: [{ [A]: { sort: 'oldest' } }] }] },
+      ],
+    } as unknown as GalleryYaml);
+    expect(sectioned.albumSortModes[A]).toBe('oldest');
+
+    const mapStyle = deriveGallery({
+      subpages: { Trips: { albums: [{ [B]: { sort: 'filename' } }] } },
+    } as unknown as GalleryYaml);
+    expect(mapStyle.albumSortModes[B]).toBe('filename');
+  });
+
   it('parses enabled property on subpages correctly', () => {
     const result = deriveGallery({
       subpages: [

--- a/lib/config/index.ts
+++ b/lib/config/index.ts
@@ -90,8 +90,10 @@ export interface GalleryDerivation {
 
 /**
  * Derive the gallery half of AppConfig, throwing on a structure that cannot be
- * represented: no albums and no subpages, a subpage with no name, a subpage
- * with neither albums nor sections.
+ * represented: a subpage with no name, a subpage with neither albums nor
+ * sections. A gallery with no albums and no subpages is NOT an error — an
+ * empty gallery still renders (title, hero-less homepage) so the owner can
+ * add albums later via /admin.
  *
  * Extracted from getConfig() so the admin PUT can run the *real* derivation
  * against a proposed gallery before writing it. Re-implementing the three
@@ -166,15 +168,6 @@ export function deriveGallery(gallery: GalleryYaml): GalleryDerivation {
   const standaloneAlbumIds = (gallery.albums ?? []).map((entry) =>
     processAlbumEntry(entry, 'gallery.yaml albums'),
   );
-  if (
-    standaloneAlbumIds.length === 0 &&
-    (!gallery.subpages ||
-      (Array.isArray(gallery.subpages)
-        ? gallery.subpages.length === 0
-        : Object.keys(gallery.subpages).length === 0))
-  ) {
-    throw new Error('gallery.yaml must define at least one album or subpage');
-  }
 
   let subpages: SubpageConfig[] = [];
 
@@ -280,13 +273,18 @@ export function getConfig(): AppConfig {
   const apiKey = env.IMMICH_API_KEY;
   const authSecret = resolveAuthSecret();
 
+  // The API URL may already end with /api (a user-supplied env var or a
+  // wizard-installed value). Appending unconditionally produces a double
+  // suffix and breaks every Immich request.
+  const immichApiUrl = apiUrl.endsWith('/api') ? apiUrl : `${apiUrl}/api`;
+
   const gallery = loadYaml<GalleryYaml>('gallery.yaml');
   const settings = loadYaml<SettingsYaml>('settings.yaml') || {};
 
   if (!gallery || !apiKey || !apiUrl) {
     // Return dummy config if gallery.yaml is missing
     return {
-      immich: { apiUrl: `${apiUrl}/api`, apiKey },
+      immich: { apiUrl: immichApiUrl, apiKey },
       authSecret,
       albums: [],
       standaloneAlbums: [],


### PR DESCRIPTION
Two small standalone fixes:

### Empty gallery is now a valid state
- deriveGallery() no longer throws when a gallery has no albums and no subpages
- An empty gallery renders a bare homepage the owner can fill in later via /admin
- Updated derive-gallery.test.ts and config-safe.test.ts

### Double /api suffix guard
- getConfig() now checks whether the API URL already ends with /api before appending it again
- Prevents breakage when the env var stores the full API path

Files: lib/config/index.ts, lib/__tests__/derive-gallery.test.ts, lib/__tests__/config-safe.test.ts