### PR TITLE
feat: favicon upload via admin settings, served from content/ volume

### DIFF
--- a/app/admin/admin.css
+++ b/app/admin/admin.css
@@ -3978,3 +3978,19 @@ h3 .svg-icon {
   padding: 0.75rem;
   border-top: 1px solid var(--admin-border);
 }
+
+/* ── Favicon upload (Settings › General) ─────────────────────── */
+
+.favicon-field {
+  margin-top: 1rem;
+}
+
+.favicon-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.favicon-row input[type='file'] {
+  font-size: 0.8rem;
+}

--- a/app/admin/components/SettingsEditor.tsx
+++ b/app/admin/components/SettingsEditor.tsx
@@ -134,6 +134,8 @@ export default function SettingsEditor() {
   const [saveMessage, setSaveMessage] = useState('');
   const [activeSection, setActiveSection] = useState('general');
   const [currentMode, setCurrentMode] = useState<'dark' | 'light'>('dark');
+  const [faviconUploading, setFaviconUploading] = useState(false);
+  const [faviconMessage, setFaviconMessage] = useState('');
 
   useEffect(() => {
     loadSettings();
@@ -442,6 +444,50 @@ export default function SettingsEditor() {
                     <span className="switch-slider" />
                   </div>
                 </button>
+              </div>
+
+              <div className="admin-field" style={{ marginTop: '1rem' }}>
+                <label>Favicon</label>
+                <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+                  <input
+                    type="file"
+                    accept=".svg,.png,.ico,.jpg,.jpeg"
+                    onChange={async (e) => {
+                      const file = e.target.files?.[0];
+                      if (!file) return;
+                      setFaviconMessage('');
+                      setFaviconUploading(true);
+                      const form = new FormData();
+                      form.append('file', file);
+                      try {
+                        const res = await fetch('/api/admin/favicon', { method: 'PUT', body: form });
+                        const data = await res.json();
+                        if (res.ok) {
+                          setFaviconMessage(data.message);
+                        } else {
+                          setFaviconMessage(`Error: ${data.error}`);
+                        }
+                      } catch {
+                        setFaviconMessage('Error: Upload failed');
+                      } finally {
+                        setFaviconUploading(false);
+                        e.target.value = '';
+                      }
+                    }}
+                    disabled={faviconUploading}
+                    style={{ fontSize: '0.8rem' }}
+                  />
+                  {faviconUploading && <div className="admin-spinner" />}
+                </div>
+                {faviconMessage && (
+                  <p className={`save-message ${faviconMessage.startsWith('Error') ? 'error' : 'success'}`}
+                    style={{ marginTop: '0.3rem', fontSize: '0.75rem' }}>
+                    {faviconMessage}
+                  </p>
+                )}
+                <span className="admin-field-hint" style={{ display: 'block', marginTop: '0.2rem' }}>
+                  SVG, PNG, ICO, or JPEG — max 512 kB. Stored in the content volume.
+                </span>
               </div>
             </div>
           )}

--- a/app/admin/components/SettingsEditor.tsx
+++ b/app/admin/components/SettingsEditor.tsx
@@ -446,12 +446,13 @@ export default function SettingsEditor() {
                 </button>
               </div>
 
-              <div className="admin-field" style={{ marginTop: '1rem' }}>
+              <div className="admin-field favicon-field">
                 <label>Favicon</label>
-                <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+                <div className="favicon-row">
                   <input
                     type="file"
                     accept=".svg,.png,.ico,.jpg,.jpeg"
+                    disabled={faviconUploading}
                     onChange={async (e) => {
                       const file = e.target.files?.[0];
                       if (!file) return;
@@ -462,11 +463,7 @@ export default function SettingsEditor() {
                       try {
                         const res = await fetch('/api/admin/favicon', { method: 'PUT', body: form });
                         const data = await res.json();
-                        if (res.ok) {
-                          setFaviconMessage(data.message);
-                        } else {
-                          setFaviconMessage(`Error: ${data.error}`);
-                        }
+                        setFaviconMessage(res.ok ? data.message : `Error: ${data.error}`);
                       } catch {
                         setFaviconMessage('Error: Upload failed');
                       } finally {
@@ -474,19 +471,37 @@ export default function SettingsEditor() {
                         e.target.value = '';
                       }
                     }}
-                    disabled={faviconUploading}
-                    style={{ fontSize: '0.8rem' }}
                   />
+                  <button
+                    type="button"
+                    className="admin-btn"
+                    disabled={faviconUploading}
+                    onClick={async () => {
+                      setFaviconMessage('');
+                      setFaviconUploading(true);
+                      try {
+                        const res = await fetch('/api/admin/favicon', { method: 'DELETE' });
+                        const data = await res.json();
+                        setFaviconMessage(res.ok ? data.message : `Error: ${data.error}`);
+                      } catch {
+                        setFaviconMessage('Error: Reset failed');
+                      } finally {
+                        setFaviconUploading(false);
+                      }
+                    }}
+                  >
+                    Reset
+                  </button>
                   {faviconUploading && <div className="admin-spinner" />}
                 </div>
                 {faviconMessage && (
-                  <p className={`save-message ${faviconMessage.startsWith('Error') ? 'error' : 'success'}`}
-                    style={{ marginTop: '0.3rem', fontSize: '0.75rem' }}>
+                  <p className={`save-message ${faviconMessage.startsWith('Error') ? 'error' : 'success'}`}>
                     {faviconMessage}
                   </p>
                 )}
-                <span className="admin-field-hint" style={{ display: 'block', marginTop: '0.2rem' }}>
-                  SVG, PNG, ICO, or JPEG — max 512 kB. Stored in the content volume.
+                <span className="admin-field-hint">
+                  SVG, PNG, ICO, or JPEG — max 512 kB. Stored in the content volume. Reset restores
+                  the bundled default.
                 </span>
               </div>
             </div>

--- a/app/api/admin/__tests__/admin-guards.test.ts
+++ b/app/api/admin/__tests__/admin-guards.test.ts
@@ -121,6 +121,20 @@ const ROUTES: {
     method: 'POST',
     args: () => [new Request('http://localhost/api/admin/backups', { method: 'POST', body: '{}' })],
   },
+  {
+    name: 'PUT /api/admin/favicon',
+    path: 'favicon',
+    load: () => import('../favicon/route'),
+    method: 'PUT',
+    args: () => [new Request('http://localhost/api/admin/favicon', { method: 'PUT' })],
+  },
+  {
+    name: 'DELETE /api/admin/favicon',
+    path: 'favicon',
+    load: () => import('../favicon/route'),
+    method: 'DELETE',
+    args: () => [],
+  },
 ];
 
 describe('admin route guards', () => {
@@ -165,7 +179,7 @@ describe('admin route guards', () => {
           if (entry.name === '__tests__') continue;
           walk(full);
         } else if (entry.name === 'route.ts') {
-          found.push(path.relative(adminDir, path.dirname(full)));
+          found.push(path.relative(adminDir, path.dirname(full)).replace(/\\/g, '/'));
         }
       }
     };

--- a/app/api/admin/favicon/route.ts
+++ b/app/api/admin/favicon/route.ts
@@ -8,6 +8,24 @@ const DEST = 'favicon.svg';
 
 const MAX_SIZE = 512 * 1024; // 512 kB
 
+/**
+ * Write via temp file + rename, the same pattern yaml-service uses: GET
+ * /api/favicon reads this path on every request, so a plain writeFile would
+ * let a concurrent read see a half-written icon.
+ */
+async function writeFavicon(content: Buffer | string): Promise<void> {
+  await fs.mkdir(CONTENT_DIR, { recursive: true });
+  const dest = path.join(CONTENT_DIR, DEST);
+  const tmpPath = `${dest}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    await fs.writeFile(tmpPath, content);
+    await fs.rename(tmpPath, dest);
+  } catch (err) {
+    await fs.unlink(tmpPath).catch(() => {});
+    throw err;
+  }
+}
+
 export async function PUT(request: Request) {
   if (!isAdminEnabled()) {
     return NextResponse.json({ error: 'Admin not enabled' }, { status: 403 });
@@ -23,8 +41,11 @@ export async function PUT(request: Request) {
     return NextResponse.json({ error: 'Invalid form data' }, { status: 400 });
   }
 
-  const file = body.get('file') as File | null;
-  if (!file) {
+  // A plain text field named "file" also satisfies `body.get('file')`, and the
+  // .size/.arrayBuffer() calls below would then throw a 500 on what is really
+  // a malformed request.
+  const file = body.get('file');
+  if (!(file instanceof File)) {
     return NextResponse.json({ error: 'Missing file' }, { status: 400 });
   }
 
@@ -40,8 +61,7 @@ export async function PUT(request: Request) {
     if (!text.includes('<svg')) {
       return NextResponse.json({ error: 'Invalid SVG file' }, { status: 400 });
     }
-    await fs.mkdir(CONTENT_DIR, { recursive: true });
-    await fs.writeFile(path.join(CONTENT_DIR, DEST), buf);
+    await writeFavicon(buf);
     return NextResponse.json({ success: true, message: 'Favicon updated.' });
   }
 
@@ -66,8 +86,7 @@ export async function PUT(request: Request) {
 </svg>
 `;
 
-  await fs.mkdir(CONTENT_DIR, { recursive: true });
-  await fs.writeFile(path.join(CONTENT_DIR, DEST), svg);
+  await writeFavicon(svg);
   return NextResponse.json({ success: true, message: 'Favicon updated.' });
 }
 
@@ -82,7 +101,10 @@ export async function DELETE() {
 
   try {
     await fs.unlink(path.join(CONTENT_DIR, DEST));
-    return NextResponse.json({ success: true, message: 'Custom favicon removed. Default restored.' });
+    return NextResponse.json({
+      success: true,
+      message: 'Custom favicon removed. Default restored.',
+    });
   } catch {
     return NextResponse.json({ error: 'No custom favicon to remove' }, { status: 404 });
   }

--- a/app/api/admin/favicon/route.ts
+++ b/app/api/admin/favicon/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse } from 'next/server';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { isAdminAuthenticated, isAdminEnabled } from '@/lib/admin/auth';
+
+const CONTENT_DIR = path.resolve(process.cwd(), 'content');
+const DEST = 'favicon.svg';
+
+const MAX_SIZE = 512 * 1024; // 512 kB
+
+export async function PUT(request: Request) {
+  if (!isAdminEnabled()) {
+    return NextResponse.json({ error: 'Admin not enabled' }, { status: 403 });
+  }
+  if (!(await isAdminAuthenticated())) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let body: FormData;
+  try {
+    body = await request.formData();
+  } catch {
+    return NextResponse.json({ error: 'Invalid form data' }, { status: 400 });
+  }
+
+  const file = body.get('file') as File | null;
+  if (!file) {
+    return NextResponse.json({ error: 'Missing file' }, { status: 400 });
+  }
+
+  if (file.size > MAX_SIZE) {
+    return NextResponse.json({ error: 'File must be under 512 kB' }, { status: 400 });
+  }
+
+  const buf = Buffer.from(await file.arrayBuffer());
+
+  // SVG passes through directly — CSP on the GET route protects the origin.
+  if (file.type === 'image/svg+xml') {
+    const text = buf.toString('utf-8');
+    if (!text.includes('<svg')) {
+      return NextResponse.json({ error: 'Invalid SVG file' }, { status: 400 });
+    }
+    await fs.mkdir(CONTENT_DIR, { recursive: true });
+    await fs.writeFile(path.join(CONTENT_DIR, DEST), buf);
+    return NextResponse.json({ success: true, message: 'Favicon updated.' });
+  }
+
+  // Raster formats (PNG, ICO, JPEG) — wrap in an SVG container so the favicon
+  // reference and CSP apply uniformly regardless of the uploaded format.
+  const mime = file.type || 'image/png';
+  if (
+    mime !== 'image/png' &&
+    mime !== 'image/x-icon' &&
+    mime !== 'image/vnd.microsoft.icon' &&
+    mime !== 'image/jpeg'
+  ) {
+    return NextResponse.json(
+      { error: `Unsupported file type: ${mime}. Use SVG, PNG, ICO, or JPEG.` },
+      { status: 400 },
+    );
+  }
+
+  const b64 = buf.toString('base64');
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <image href="data:${mime};base64,${b64}" width="32" height="32"/>
+</svg>
+`;
+
+  await fs.mkdir(CONTENT_DIR, { recursive: true });
+  await fs.writeFile(path.join(CONTENT_DIR, DEST), svg);
+  return NextResponse.json({ success: true, message: 'Favicon updated.' });
+}
+
+/** Clean up stale favicon files left by a previous upload of a different format. */
+export async function DELETE() {
+  if (!isAdminEnabled()) {
+    return NextResponse.json({ error: 'Admin not enabled' }, { status: 403 });
+  }
+  if (!(await isAdminAuthenticated())) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    await fs.unlink(path.join(CONTENT_DIR, DEST));
+    return NextResponse.json({ success: true, message: 'Custom favicon removed. Default restored.' });
+  } catch {
+    return NextResponse.json({ error: 'No custom favicon to remove' }, { status: 404 });
+  }
+}

--- a/app/api/favicon/route.ts
+++ b/app/api/favicon/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const PUBLIC_DIR = path.resolve(process.cwd(), 'public');
+const CONTENT_DIR = path.resolve(process.cwd(), 'content');
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  let buf: Buffer;
+  let contentType: string;
+
+  // Prefer the uploaded favicon in content/ (writable, mounted volume).
+  // Fall back to the bundled default in public/.
+  try {
+    const filePath = path.join(CONTENT_DIR, 'favicon.svg');
+    buf = await fs.readFile(filePath);
+    contentType = 'image/svg+xml';
+  } catch {
+    try {
+      const filePath = path.join(PUBLIC_DIR, 'favicon.svg');
+      buf = await fs.readFile(filePath);
+      contentType = 'image/svg+xml';
+    } catch {
+      return new NextResponse(null, { status: 404 });
+    }
+  }
+
+  return new NextResponse(new Uint8Array(buf), {
+    status: 200,
+    headers: {
+      'Content-Type': contentType,
+      'Cache-Control': 'public, max-age=86400, immutable',
+      // /api routes are excluded from the CSP nonce in proxy.ts, so the
+      // response must carry its own policy. An uploaded SVG must not be
+      // allowed to execute script on the origin.
+      'Content-Security-Policy': "default-src 'none'; sandbox",
+    },
+  });
+}

--- a/app/api/favicon/route.ts
+++ b/app/api/favicon/route.ts
@@ -7,35 +7,42 @@ const CONTENT_DIR = path.resolve(process.cwd(), 'content');
 
 export const dynamic = 'force-dynamic';
 
-export async function GET() {
-  let buf: Buffer;
-  let contentType: string;
-
+export async function GET(request: Request) {
   // Prefer the uploaded favicon in content/ (writable, mounted volume).
   // Fall back to the bundled default in public/.
+  let filePath = path.join(CONTENT_DIR, 'favicon.svg');
+  let stat;
   try {
-    const filePath = path.join(CONTENT_DIR, 'favicon.svg');
-    buf = await fs.readFile(filePath);
-    contentType = 'image/svg+xml';
+    stat = await fs.stat(filePath);
   } catch {
+    filePath = path.join(PUBLIC_DIR, 'favicon.svg');
     try {
-      const filePath = path.join(PUBLIC_DIR, 'favicon.svg');
-      buf = await fs.readFile(filePath);
-      contentType = 'image/svg+xml';
+      stat = await fs.stat(filePath);
     } catch {
       return new NextResponse(null, { status: 404 });
     }
   }
 
-  return new NextResponse(new Uint8Array(buf), {
-    status: 200,
-    headers: {
-      'Content-Type': contentType,
-      'Cache-Control': 'public, max-age=86400, immutable',
-      // /api routes are excluded from the CSP nonce in proxy.ts, so the
-      // response must carry its own policy. An uploaded SVG must not be
-      // allowed to execute script on the origin.
-      'Content-Security-Policy': "default-src 'none'; sandbox",
-    },
-  });
+  // The URL is fixed but its content is not — an upload replaces the file in
+  // place. A far-future `immutable` would hide the new icon for as long as the
+  // browser kept the old one, so revalidate every time and answer with a 304
+  // when nothing changed. The ETag is derived from the file itself, so it moves
+  // the moment the admin uploads a new one.
+  const etag = `"${stat.mtimeMs.toString(36)}-${stat.size.toString(36)}"`;
+  const headers = {
+    'Content-Type': 'image/svg+xml',
+    'Cache-Control': 'public, max-age=0, must-revalidate',
+    ETag: etag,
+    // /api routes are excluded from the CSP nonce in proxy.ts, so the
+    // response must carry its own policy. An uploaded SVG must not be
+    // allowed to execute script on the origin.
+    'Content-Security-Policy': "default-src 'none'; sandbox",
+  };
+
+  if (request.headers.get('if-none-match') === etag) {
+    return new NextResponse(null, { status: 304, headers });
+  }
+
+  const buf = await fs.readFile(filePath);
+  return new NextResponse(new Uint8Array(buf), { status: 200, headers });
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -24,7 +24,11 @@ export async function generateMetadata(): Promise<Metadata> {
   const config = getConfigOrNull();
   if (!config) {
     // Nothing to describe, and nothing that should be indexed while broken.
-    return { title: 'Setup Required', robots: { index: false, follow: false } };
+    return {
+      title: 'Setup Required',
+      robots: { index: false, follow: false },
+      icons: { icon: '/api/favicon' },
+    };
   }
 
   const siteTitle = config.seo.title;
@@ -42,6 +46,7 @@ export async function generateMetadata(): Promise<Metadata> {
     description: siteDescription,
     robots,
     icons: {
+      icon: '/api/favicon',
       apple: '/apple-touch-icon.png',
     },
     openGraph: {

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <rect width="32" height="32" rx="6" fill="#111"/>
+  <circle cx="16" cy="16" r="5" stroke="#fff" stroke-width="2"/>
+  <circle cx="16" cy="16" r="2" fill="#fff"/>
+  <path d="M8 10h3l1.5-2h7l1.5 2h3a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V12a2 2 0 0 1 2-2z" stroke="#fff" stroke-width="2" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## Summary

Adds favicon support: a bundled default SVG, an upload widget in admin settings, and a route handler that serves from the writable content/ volume.

### Design
- **Default** — public/favicon.svg with a camera icon, bundled in the image
- **Upload** — file input in admin Settings > General. SVG passes through; PNG/ICO/JPEG are wrapped in an SVG container with base64 data URI
- **Storage** — writes to content/favicon.svg (mounted Docker volume, writable at runtime not root-owned public/)
- **Serving** — GET /api/favicon reads content/favicon.svg first, falls back to public/favicon.svg. Sets Content-Security-Policy: default-src 'none'; sandbox to prevent SVG script execution
- **Metadata** — references /api/favicon (no stat on every render, unlike the previous mtime-based approach)
- **Cleanup** — DELETE /api/admin/favicon removes the custom favicon, restoring the default

### Files changed (6 files, +203 -2)
- **New:** public/favicon.svg, app/api/favicon/route.ts, app/api/admin/favicon/route.ts
- **Modified:** app/layout.tsx, app/admin/components/SettingsEditor.tsx, app/api/admin/\__tests__/admin-guards.test.ts