### PR TITLE
docs: document the setup wizard, fix the read-only content mount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,44 @@ Releases up to and including v0.9.2 are documented in the
 
 ## [Unreleased]
 
+### Added
+
+- **First-run setup wizard at `/install`**
+  ([#419](https://github.com/ralksta/immich-folio/pull/419)). A fresh deployment
+  can now be configured from the browser: connect to Immich, optionally pick
+  albums, name the site. Credentials are verified against the Immich server
+  before anything is written, so a typo cannot produce an "installed" site that
+  loads no photos. The wizard is gated by a one-time token printed to the server
+  log — a deployment is reachable before it has any configuration, and without
+  the gate whoever found the URL first could configure it. Credentials land in
+  `content/install.json` (mode `0600`, admin password stored as an scrypt hash);
+  environment variables continue to take precedence, so rotation still works by
+  setting a variable. Configuring everything by hand remains fully supported.
+- **Custom favicon upload** in admin Settings › General
+  ([#422](https://github.com/ralksta/immich-folio/pull/422)). SVG, PNG, ICO or
+  JPEG, stored in the writable `content/` volume and served through
+  `/api/favicon` with a policy that stops an uploaded SVG executing script. A
+  Reset button restores the bundled default.
+
+### Changed
+
+- **A gallery with no albums is now a valid, rendered state**
+  ([#421](https://github.com/ralksta/immich-folio/pull/421)) instead of an error
+  — the setup wizard can finish without picking one, and albums can be added
+  later in `/admin`.
+- **The Immich URL may end in `/api`** without breaking every request
+  ([#421](https://github.com/ralksta/immich-folio/pull/421)). The suffix was
+  appended unconditionally, producing `.../api/api`.
+
+### Documentation
+
+- **README documents the setup wizard**, what it writes, and that
+  `content/install.json` holds credentials — so a backup of `content/` is
+  understood to include your Immich API key. The Docker examples no longer mount
+  `content/` read-only: the wizard, the admin panel and the backup rotation all
+  write into it, and `:ro` silently breaks all three.
+- **Contributors are credited in the README.**
+
 ### Security
 
 - **Next.js 16.3.0** — picks up the fix for CVE-2025-13465 in Next's vendored
@@ -17,6 +55,13 @@ Releases up to and including v0.9.2 are documented in the
 ### Internal
 
 Nothing user-facing; recorded so the next release notes are complete.
+
+- **CI annotates unformatted files in a PR without blocking it**
+  ([#424](https://github.com/ralksta/immich-folio/pull/424)). Prettier is
+  configured as an eslint error but had never run in CI, so part of the tree
+  predates it. Failing on that would make a PR red for merely touching an old
+  file; reformatting the tree in one commit would bury every future diff in
+  churn. The check runs over the files a PR changes and warns.
 
 - **Dependency PRs now target `dev`**, and CI runs on pull requests to `dev` as
   well ([#411](https://github.com/ralksta/immich-folio/pull/411)). The workflow

--- a/README.md
+++ b/README.md
@@ -128,21 +128,84 @@ Full history in the [GitHub releases](https://github.com/ralksta/immich-folio/re
 ## Quick Start
 
 ```bash
-# Clone and install
 git clone https://github.com/ralksta/immich-folio.git
 cd immich-folio
 npm install
+npm run dev
+```
 
-# Configure
+Then open `http://localhost:3000/install` and let the setup wizard connect you to
+Immich — see [First-Run Setup](#first-run-setup) below. It needs a token from the
+server log, which is printed on first access.
+
+<details>
+<summary><strong>Prefer to configure by hand?</strong></summary>
+
+The wizard writes the same files you would write yourself, so the manual route
+remains fully supported:
+
+```bash
 cp .env.local.example .env.local
 # Edit .env.local with your Immich server URL and API key
 
 cp content/gallery.yaml.example content/gallery.yaml
 # Edit gallery.yaml with your album UUIDs
 
-# Run
 npm run dev
 ```
+
+</details>
+
+## First-Run Setup
+
+A deployment with no `gallery.yaml` and no Immich credentials serves a setup
+screen. The wizard at **`/install`** fills both in from the browser: it connects
+to Immich, lets you pick albums (optional — you can add them later in `/admin`),
+and names the site. Nothing is written until your credentials have been verified
+against your Immich server, so a typo cannot leave you with an "installed" site
+that loads no photos.
+
+**The wizard is gated by a one-time token** printed to the server log on first
+access, because a fresh deployment is reachable before it has any configuration —
+and without the gate, whoever finds the URL first could configure it:
+
+```
+══════════════════════════════════════════════════════
+  Immich Folio — First-run setup token
+══════════════════════════════════════════════════════
+  Token:  PTmUKFIdce2DwuqBG71RAExH7tVxceXX
+```
+
+Read it from your container logs (`docker compose logs immich-folio`) and append
+it to the URL:
+
+```
+http://your-site/install?token=PTmUKFIdce2DwuqBG71RAExH7tVxceXX
+```
+
+The token is stored in `content/.setup-token` (mode `0600`) so it survives a
+restart, and is deleted once setup completes. From then on `/install` redirects
+to the gallery and its API routes refuse to run again.
+
+### What the wizard writes
+
+| File                    | Contents                                                             |
+| ----------------------- | -------------------------------------------------------------------- |
+| `content/gallery.yaml`  | The albums you picked                                                |
+| `content/settings.yaml` | Site title, subtitle, theme — only if it does not exist yet          |
+| `content/install.json`  | Immich URL and API key, a generated site secret, admin password hash |
+
+> **`content/install.json` holds credentials.** It is written with mode `0600`,
+> and it is the reason a backup of your `content/` directory is now a backup of
+> your Immich API key as well — treat it accordingly. The admin password is
+> stored as an scrypt hash, not as you typed it; the API key and site secret have
+> to stay readable to be usable.
+
+**Environment variables always win.** `IMMICH_API_URL`, `IMMICH_API_KEY`,
+`AUTH_SECRET` and `ADMIN_PASSWORD` override anything in `install.json`, so you
+can rotate any of them by setting the variable — no need to touch the file. Set
+all of them up front and the wizard never appears, which is the usual choice for
+an infrastructure-as-code deployment.
 
 ## Configuration
 
@@ -213,7 +276,7 @@ services:
     env_file:
       - .env.local
     volumes:
-      - ./content:/app/content:ro
+      - ./content:/app/content
 ```
 
 Run with:
@@ -239,11 +302,14 @@ docker run -d \
   --restart unless-stopped \
   -p 7211:7211 \
   --env-file .env.local \
-  -v ./content:/app/content:ro \
+  -v ./content:/app/content \
   immich-folio
 ```
 
-> **Note:** The `content/` volume mount lets you update `gallery.yaml` and `about.md` without rebuilding the image.
+> **Note:** The `content/` volume mount lets you update `gallery.yaml` and
+> `about.md` without rebuilding the image. It must be **read-write**: the setup
+> wizard, the admin panel and the backup rotation all write into it. A `:ro`
+> mount leaves the wizard unable to complete and the admin panel unable to save.
 
 ### Health Check
 
@@ -285,6 +351,10 @@ A built-in visual editor at `/admin` lets you manage your gallery without editin
 ADMIN_PASSWORD=your-secure-admin-password
 ```
 
+Or set the password in the [setup wizard](#first-run-setup), which stores it as
+an scrypt hash rather than in your environment. An `ADMIN_PASSWORD` variable
+takes precedence over the stored one if both are present.
+
 Then navigate to `http://your-site/admin` and log in. The panel is protected by its
 own password, separate from any album passwords, and writes straight to
 `gallery.yaml` / `settings.yaml` with automatic backups.
@@ -307,6 +377,27 @@ own password, separate from any album passwords, and writes straight to
 - **React 19**
 - **TypeScript**
 - **Vanilla CSS** (no framework)
+
+## Contributors
+
+Immich Folio is maintained by [@ralksta](https://github.com/ralksta) and made
+better by the people below. Thank you — every one of these made the project
+easier to live with.
+
+- **[@lancetm714](https://github.com/lancetm714)** — built the setup wizard that
+  turns a fresh install into a few clicks in the browser instead of hand-written
+  config files. Also added custom favicons, so your portfolio gets its own icon
+  in the browser tab, and made a gallery with no albums yet a perfectly valid
+  starting point rather than an error.
+- **[Jules](https://jules.google.com)** — an automated reviewer that has been
+  quietly hardening the project in the background: better screen-reader support
+  in the photo grid, and a series of fixes keeping the public endpoints from
+  being overwhelmed by traffic.
+- **[Dependabot](https://github.com/dependabot)** — keeps every dependency
+  current, which is most of the reason security fixes land here quickly.
+
+Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) to get
+started. Pull requests target the `dev` branch.
 
 ## License
 


### PR DESCRIPTION
The wizard from #419 is on `dev` but appears nowhere in the README. A new deployment has no way to learn that `/install` exists — let alone that it needs a token from the server log.

### Added

- **Quick Start leads with the wizard**, with the hand-written route kept in a details block. Both are supported; only one of them is discoverable in 30 seconds.
- **A First-Run Setup section** covering the token (what it is, why it exists, where to read it), the three files the wizard writes, and that environment variables still take precedence — so rotation works by setting a variable, and setting all of them up front skips the wizard entirely.
- **Contributors section**, describing what each person's work does for someone using the project rather than reading it.

### Fixed

- **Both Docker examples mounted `./content` as `:ro`.** The wizard, the admin panel and the backup rotation all write there, so a read-only mount silently breaks all three. `docs/admin-panel.md` already warned about this — the README contradicted it. The actual `docker-compose.yml` in the repo was already correct.
- **Nothing documented that `content/install.json` holds the Immich API key.** Backing up `content/` now means backing up credentials, which is better learned from a README than by discovering it.

### Verified

Every claim checked against the code, not from memory: the `0600` mode on both files, the token deletion in `completeInstall()`, `settings.yaml` only being written when absent, env precedence in `getInstallCredentials()`, and the `isInstalled()` redirect on the page.

Docs only — no code touched.