### PR TITLE
feat(admin): floating save bar pinned to the bottom of the viewport

### DIFF
--- a/app/admin/admin.css
+++ b/app/admin/admin.css
@@ -379,29 +379,14 @@
 
 .admin-main {
   flex: 1;
-  padding: 1.5rem;
+  /* Extra bottom padding so the floating save bar never covers page content. */
+  padding: 1.5rem 1.5rem 6rem;
   max-width: 1120px;
   margin: 0 auto;
   width: 100%;
 }
 
 /* ── Save Bar ──────────────────────────────────────────────── */
-
-.save-bar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0.75rem 1rem;
-  margin-bottom: 1.5rem;
-  border-radius: 8px;
-  background: var(--admin-bg-raised);
-  border: 1px solid var(--admin-border);
-  transition: border-color 0.2s;
-}
-
-.save-bar.dirty {
-  border-color: var(--admin-accent);
-}
 
 .save-bar-left {
   display: flex;
@@ -410,6 +395,8 @@
 }
 
 .unsaved-badge {
+  display: inline-flex;
+  align-items: center;
   font-size: 0.75rem;
   color: var(--admin-accent);
   font-weight: 500;
@@ -1066,6 +1053,12 @@
 }
 
 /* ── Settings Editor ──────────────────────────────────────── */
+
+.settings-live-sync-note {
+  margin: 0 0 1.25rem;
+  font-size: 0.75rem;
+  color: var(--admin-text-muted);
+}
 
 .settings-layout {
   display: grid;
@@ -1728,11 +1721,6 @@
   text-decoration: none;
 }
 
-.save-hint {
-  font-size: 0.7rem;
-  color: var(--admin-text-muted);
-}
-
 /* ── Danger icon button ───────────────────────────────────────── */
 
 .admin-btn-icon-danger:hover {
@@ -1743,7 +1731,14 @@
 
 @media (max-width: 768px) {
   .admin-main {
-    padding: 1rem;
+    padding: 1rem 1rem 6rem;
+  }
+
+  .floating-save-bar {
+    bottom: 1rem;
+    width: calc(100% - 2rem);
+    padding: 0.625rem 0.875rem;
+    gap: 0.5rem;
   }
 
   .admin-header {
@@ -3351,9 +3346,28 @@ h3 .svg-icon {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
   width: calc(100% - 3rem);
   max-width: 800px;
-  transition: all 0.25s ease;
+  transition: border-color 0.2s ease;
+  animation: save-bar-in 0.2s ease-out;
+}
+
+.floating-save-bar.dirty {
+  border-color: var(--admin-accent);
+}
+
+/* Keyframes must carry the translateX(-50%) or the bar jumps horizontally. */
+@keyframes save-bar-in {
+  from {
+    opacity: 0;
+    transform: translate(-50%, 1rem);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
 }
 
 .badge-pulse-dot {
@@ -3378,6 +3392,15 @@ h3 .svg-icon {
   100% {
     transform: scale(0.95);
     box-shadow: 0 0 0 0 rgba(255, 152, 0, 0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .floating-save-bar {
+    animation: none;
+  }
+  .badge-pulse-dot {
+    animation: none;
   }
 }
 

--- a/app/admin/components/AdminDashboard.tsx
+++ b/app/admin/components/AdminDashboard.tsx
@@ -196,11 +196,11 @@ export default function AdminDashboard({ onLogout }: Props) {
           </div>
 
           <a
-            href="/"
+            href="/?fresh=1"
             target="_blank"
             rel="noopener noreferrer"
             className="admin-btn admin-btn-ghost"
-            title="Open site in new tab"
+            title="Open site in new tab (bypassing cache)"
           >
             <Icons.IconLink size={14} /> Site
           </a>

--- a/app/admin/components/PageBuilder.tsx
+++ b/app/admin/components/PageBuilder.tsx
@@ -23,6 +23,7 @@ import AlbumPicker from './AlbumPicker';
 import AssetPicker from './AssetPicker';
 import AssetOrderEditor from './AssetOrderEditor';
 import { EssayBlockEditor } from './EssayBlockEditor';
+import SaveBar from './SaveBar';
 import {
   ALBUM_SORT_MODES,
   DEFAULT_ALBUM_SORT,
@@ -860,38 +861,14 @@ export default function PageBuilder() {
 
   return (
     <div className="page-builder">
-      {/* Save Bar */}
-      <div className={`save-bar ${dirty ? 'dirty' : ''}`}>
-        <div className="save-bar-left">
-          {dirty && <span className="unsaved-badge">Unsaved changes</span>}
-          {saveMessage && (
-            <span
-              className={`save-message ${saveMessage.startsWith('Error') ? 'error' : 'success'}`}
-            >
-              {saveMessage}
-            </span>
-          )}
-          {!dirty && !saveMessage && <span className="save-hint">⌘S to save</span>}
-        </div>
-        <div className="save-bar-right">
-          <a
-            href="/?fresh=1"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="admin-btn admin-btn-ghost admin-btn-preview"
-            title="Open site in new tab (bypassing cache)"
-          >
-            ↗ Preview Site
-          </a>
-          <button
-            className="admin-btn admin-btn-primary"
-            onClick={handleSave}
-            disabled={!dirty || saving}
-          >
-            {saving ? 'Saving...' : 'Save Changes'}
-          </button>
-        </div>
-      </div>
+      <SaveBar
+        dirty={dirty}
+        saving={saving}
+        saveMessage={saveMessage}
+        onSave={handleSave}
+        label="Save Changes"
+        showPreview
+      />
 
       {/* Search Bar */}
       <div className="builder-search-container">

--- a/app/admin/components/SaveBar.tsx
+++ b/app/admin/components/SaveBar.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+interface SaveBarProps {
+  dirty: boolean;
+  saving: boolean;
+  saveMessage: string;
+  onSave: () => void;
+  label: string;
+  /** Show the cache-bypassing preview link (page builder only). */
+  showPreview?: boolean;
+}
+
+/**
+ * Floating save bar pinned to the bottom of the viewport.
+ *
+ * It only mounts while there is something to act on (unsaved changes, an
+ * in-flight save, or a result message) so it never covers content otherwise.
+ * The success message is cleared by the caller after a few seconds, which
+ * makes the bar disappear on its own.
+ */
+export default function SaveBar({
+  dirty,
+  saving,
+  saveMessage,
+  onSave,
+  label,
+  showPreview = false,
+}: SaveBarProps) {
+  if (!dirty && !saving && !saveMessage) return null;
+
+  return (
+    <div className={`floating-save-bar ${dirty ? 'dirty' : ''}`} role="status">
+      <div className="save-bar-left">
+        {saveMessage ? (
+          <span className={`save-message ${saveMessage.startsWith('Error') ? 'error' : 'success'}`}>
+            {saveMessage}
+          </span>
+        ) : (
+          <span className="unsaved-badge">
+            <span className="badge-pulse-dot" aria-hidden="true" />
+            Unsaved changes
+          </span>
+        )}
+      </div>
+      <div className="save-bar-right">
+        {showPreview && (
+          <a
+            href="/?fresh=1"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="admin-btn admin-btn-ghost admin-btn-preview"
+            title="Open site in new tab (bypassing cache)"
+          >
+            ↗ Preview Site
+          </a>
+        )}
+        <button
+          className="admin-btn admin-btn-primary"
+          onClick={onSave}
+          disabled={!dirty || saving}
+          title="⌘S / Ctrl+S"
+        >
+          {saving ? 'Saving...' : label}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/admin/components/SettingsEditor.tsx
+++ b/app/admin/components/SettingsEditor.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import * as Icons from './Icons';
+import SaveBar from './SaveBar';
 
 interface Settings {
   title?: string;
@@ -289,30 +290,15 @@ export default function SettingsEditor() {
 
   return (
     <div className="settings-editor">
-      {/* Save Bar */}
-      <div className={`save-bar ${dirty ? 'dirty' : ''}`}>
-        <div className="save-bar-left">
-          {dirty && <span className="unsaved-badge">Unsaved changes</span>}
-          {saveMessage ? (
-            <span
-              className={`save-message ${saveMessage.startsWith('Error') ? 'error' : 'success'}`}
-            >
-              {saveMessage}
-            </span>
-          ) : (
-            <span style={{ fontSize: '0.75rem', color: 'var(--admin-text-muted)', display: 'inline-flex', alignItems: 'center', gap: '0.25rem' }}>
-              ⚡ Live Sync (No Docker restart required)
-            </span>
-          )}
-        </div>
-        <button
-          className="admin-btn admin-btn-primary"
-          onClick={handleSave}
-          disabled={!dirty || saving}
-        >
-          {saving ? 'Saving...' : 'Save Settings'}
-        </button>
-      </div>
+      <SaveBar
+        dirty={dirty}
+        saving={saving}
+        saveMessage={saveMessage}
+        onSave={handleSave}
+        label="Save Settings"
+      />
+
+      <p className="settings-live-sync-note">⚡ Live Sync (No Docker restart required)</p>
 
       <div className="settings-layout">
         {/* Sidebar */}


### PR DESCRIPTION
## Problem

The save bar (`Unsaved changes` · `↗ Preview Site` · `Save Changes`) was the first, static element inside `.admin-main`. Since the document itself scrolls, it left the viewport as soon as you scrolled down: editing a subpage section or a settings block far below gave no visible dirty hint and no reachable save button — so it was easy to miss that there were unsaved changes at all.

## Solution

Replace it with a **bottom-pinned floating bar** shared by both editors. It only appears **while there is something to act on** (unsaved changes, an in-flight save, a result message) and covers nothing while idle. The success message is cleared after 5s, which hides the bar again on its own.

- New component `app/admin/components/SaveBar.tsx` replaces the duplicated markup in `PageBuilder` and `SettingsEditor`
- Adopts the `.floating-save-bar` CSS that was already in the stylesheet but unused, and extends it: slide-in keyframes (carrying `translateX(-50%)` so the bar does not jump horizontally), dirty border, wrap/gap, mobile variant, `prefers-reduced-motion` opt-out. `z-index: 900` keeps it below modals and drawers (999/1000)
- `.admin-main` gains bottom padding so the bar never covers content at the end of the page
- Idle hints that would have no home without a visible bar move elsewhere: `⌘S to save` becomes the save button's `title`, the "⚡ Live Sync" note becomes a static line above the settings layout
- The header "Site" link now points at `/?fresh=1`, so the cache-bypassing preview stays reachable while the bar is hidden

The old `.save-bar` rules are removed; `.unsaved-badge` / `.save-message*` stay, since the floating bar reuses them.

## Verification

- `npx tsc --noEmit` — 0 errors
- `npm run build` — succeeds
- `npm run test:unit` — 343 tests passing
- New and edited regions are prettier-clean (`PageBuilder.tsx` and `SettingsEditor.tsx` were already unformatted before this change and were deliberately left alone to keep the diff readable)

Not covered here: the visual behaviour in a running dev server (slide-in while scrolling, mobile wrapping, modal overlay) — that needs a manual check in `/admin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
