### PR TITLE
feat(admin): themed listbox for the album sort control

### DIFF
--- a/app/admin/admin.css
+++ b/app/admin/admin.css
@@ -182,6 +182,128 @@
   min-height: 60px;
 }
 
+/* ── Listbox (select replacement that can render SVG icons) ────── */
+
+.admin-listbox {
+  position: relative;
+  width: 100%;
+}
+
+.admin-listbox-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.6rem 0.75rem;
+  background: var(--admin-bg-input);
+  border: 1px solid var(--admin-border);
+  border-radius: 6px;
+  color: var(--admin-text);
+  font-size: 0.875rem;
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.15s;
+}
+
+.admin-listbox-trigger:hover:not(:disabled) {
+  border-color: var(--admin-border-hover);
+}
+
+.admin-listbox-trigger:focus-visible {
+  outline: none;
+  border-color: var(--admin-border-focus);
+}
+
+.admin-listbox-trigger:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.admin-listbox-value {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.admin-listbox-value > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.admin-listbox-value .svg-icon,
+.admin-listbox-option > .svg-icon {
+  color: var(--admin-text-secondary);
+}
+
+.admin-listbox-caret {
+  color: var(--admin-text-secondary);
+  transition: transform 0.15s ease;
+}
+
+.admin-listbox-trigger[aria-expanded='true'] .admin-listbox-caret {
+  transform: rotate(180deg);
+}
+
+.admin-listbox-popup {
+  position: absolute;
+  z-index: 40;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  max-height: 260px;
+  overflow-y: auto;
+  margin: 0;
+  padding: 0.25rem;
+  list-style: none;
+  background: var(--admin-bg-elevated);
+  border: 1px solid var(--admin-border);
+  border-radius: 8px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+}
+
+[data-theme='light'] .admin-listbox-popup {
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.12);
+}
+
+.admin-listbox-option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.5rem;
+  border-radius: 5px;
+  color: var(--admin-text);
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+
+.admin-listbox-option.is-active {
+  background: var(--admin-bg-raised);
+}
+
+.admin-listbox-option.is-selected {
+  color: var(--admin-accent);
+}
+
+.admin-listbox-option.is-selected > .svg-icon {
+  color: var(--admin-accent);
+}
+
+.admin-listbox-option-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.admin-listbox-check {
+  color: var(--admin-accent);
+}
+
 .admin-field-row {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/app/admin/components/Icons.tsx
+++ b/app/admin/components/Icons.tsx
@@ -360,3 +360,47 @@ export function IconArrowLeftRight({ size = 16, className = 'svg-icon', strokeWi
   );
 }
 
+export function IconCalendar({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+      <rect width="18" height="18" x="3" y="4" rx="2" />
+      <path d="M8 2v4M16 2v4M3 10h18" />
+    </svg>
+  );
+}
+
+export function IconArrowDown({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+      <path d="M12 5v14M19 12l-7 7-7-7" />
+    </svg>
+  );
+}
+
+export function IconArrowUp({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+      <path d="M12 19V5M5 12l7-7 7 7" />
+    </svg>
+  );
+}
+
+/** An "A→Z" marker for alphabetical / filename ordering. */
+export function IconSortAlpha({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+      <path d="M4 10 7 3l3 7M4.9 8.2h4.2" />
+      <path d="M14 3h6l-6 7h6" />
+      <path d="M17 14v7M14 18l3 3 3-3" />
+    </svg>
+  );
+}
+
+export function IconCheck({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+      <path d="M20 6 9 17l-5-5" />
+    </svg>
+  );
+}
+

--- a/app/admin/components/Listbox.tsx
+++ b/app/admin/components/Listbox.tsx
@@ -1,0 +1,249 @@
+'use client';
+
+import React from 'react';
+import { IconCheck, IconChevronDown } from './Icons';
+
+/**
+ * A single choice in a {@link Listbox}.
+ *
+ * `label` stays plain text so the same option table can feed a `title`
+ * attribute or an aria-label; `icon` is the themed glyph shown beside it.
+ */
+export interface ListboxOption<T extends string> {
+  value: T;
+  label: string;
+  icon?: React.ReactNode;
+}
+
+export interface ListboxProps<T extends string> {
+  value: T;
+  options: readonly ListboxOption<T>[];
+  onChange: (value: T) => void;
+  /** Accessible name. Prefer `labelledBy` when a visible <label> exists. */
+  ariaLabel?: string;
+  /** id of the visible label element. */
+  labelledBy?: string;
+  disabled?: boolean;
+  className?: string;
+  /** Width of the trigger; the popup always matches it. */
+  style?: React.CSSProperties;
+}
+
+/** How long a type-ahead buffer keeps collecting characters. */
+const TYPEAHEAD_RESET_MS = 600;
+
+/**
+ * A select replacement that can show markup in its options.
+ *
+ * The native `<option>` element strips markup, so the admin panel's
+ * `currentColor` SVG set cannot be used inside a real `<select>`. This
+ * implements the ARIA combobox/listbox pattern instead: DOM focus never leaves
+ * the trigger button, and the active option is announced through
+ * `aria-activedescendant`. Options are plain `<li>`s — not focusable — which
+ * keeps focus management to a single element.
+ */
+export function Listbox<T extends string>({
+  value,
+  options,
+  onChange,
+  ariaLabel,
+  labelledBy,
+  disabled = false,
+  className = '',
+  style,
+}: ListboxProps<T>) {
+  const [open, setOpen] = React.useState(false);
+  const selectedIndex = Math.max(
+    0,
+    options.findIndex((o) => o.value === value),
+  );
+  const [activeIndex, setActiveIndex] = React.useState(selectedIndex);
+
+  const wrapperRef = React.useRef<HTMLDivElement>(null);
+  const buttonRef = React.useRef<HTMLButtonElement>(null);
+  const listRef = React.useRef<HTMLUListElement>(null);
+  const typeahead = React.useRef({ buffer: '', at: 0 });
+
+  const baseId = React.useId();
+  const listId = `${baseId}-list`;
+  const optionId = (index: number) => `${baseId}-opt-${index}`;
+
+  const selected = options[selectedIndex];
+
+  const openList = React.useCallback(
+    (index = selectedIndex) => {
+      if (disabled) return;
+      setActiveIndex(index);
+      setOpen(true);
+    },
+    [disabled, selectedIndex],
+  );
+
+  const close = React.useCallback(() => {
+    setOpen(false);
+    typeahead.current = { buffer: '', at: 0 };
+  }, []);
+
+  const commit = React.useCallback(
+    (index: number) => {
+      const option = options[index];
+      if (option) onChange(option.value);
+      close();
+      // Focus never left the trigger, but a pointer selection can blur it.
+      buttonRef.current?.focus();
+    },
+    [close, onChange, options],
+  );
+
+  // Dismiss on outside pointer press. pointerdown (not click) so a press that
+  // starts outside closes the popup before it can retarget the click.
+  React.useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (event: PointerEvent) => {
+      if (!wrapperRef.current?.contains(event.target as Node)) close();
+    };
+    document.addEventListener('pointerdown', onPointerDown);
+    return () => document.removeEventListener('pointerdown', onPointerDown);
+  }, [open, close]);
+
+  // Keep the active option visible while arrowing or typing through a long list.
+  React.useEffect(() => {
+    if (!open) return;
+    listRef.current
+      ?.querySelector(`#${CSS.escape(optionId(activeIndex))}`)
+      ?.scrollIntoView({ block: 'nearest' });
+    // optionId is derived from baseId, which is stable for the component's life.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, activeIndex, baseId]);
+
+  /** Jump to the next option whose label starts with the accumulated buffer. */
+  const runTypeahead = (char: string) => {
+    const now = Date.now();
+    const buffer =
+      now - typeahead.current.at > TYPEAHEAD_RESET_MS ? char : typeahead.current.buffer + char;
+    typeahead.current = { buffer, at: now };
+
+    // A repeated single character cycles through matches instead of sticking.
+    const repeat = buffer.length > 1 && buffer.split('').every((c) => c === buffer[0]);
+    const needle = repeat ? buffer[0] : buffer;
+    const from = repeat || buffer.length === 1 ? activeIndex + 1 : activeIndex;
+
+    for (let i = 0; i < options.length; i++) {
+      const index = (from + i) % options.length;
+      if (options[index].label.toLowerCase().startsWith(needle.toLowerCase())) {
+        setActiveIndex(index);
+        return index;
+      }
+    }
+    return null;
+  };
+
+  const onKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (disabled) return;
+    const last = options.length - 1;
+
+    switch (event.key) {
+      case 'ArrowDown':
+      case 'ArrowUp': {
+        event.preventDefault();
+        const step = event.key === 'ArrowDown' ? 1 : -1;
+        if (!open) {
+          openList(Math.min(last, Math.max(0, selectedIndex + step)));
+        } else {
+          setActiveIndex((i) => Math.min(last, Math.max(0, i + step)));
+        }
+        return;
+      }
+      case 'Home':
+      case 'End': {
+        event.preventDefault();
+        const index = event.key === 'Home' ? 0 : last;
+        if (open) setActiveIndex(index);
+        else openList(index);
+        return;
+      }
+      case 'Enter':
+      case ' ':
+        event.preventDefault();
+        if (open) commit(activeIndex);
+        else openList();
+        return;
+      case 'Escape':
+        if (open) {
+          event.preventDefault();
+          close();
+        }
+        return;
+      case 'Tab':
+        // Let focus move on, but commit what the user was looking at.
+        if (open) commit(activeIndex);
+        return;
+      default:
+        break;
+    }
+
+    // Type-ahead: a single printable character, no modifiers.
+    if (event.key.length === 1 && !event.ctrlKey && !event.metaKey && !event.altKey) {
+      event.preventDefault();
+      if (!open) {
+        setOpen(true);
+        const match = runTypeahead(event.key);
+        if (match === null) setActiveIndex(selectedIndex);
+        return;
+      }
+      runTypeahead(event.key);
+    }
+  };
+
+  return (
+    <div ref={wrapperRef} className={`admin-listbox ${className}`.trim()} style={style}>
+      <button
+        ref={buttonRef}
+        type="button"
+        role="combobox"
+        aria-controls={listId}
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        aria-activedescendant={open ? optionId(activeIndex) : undefined}
+        aria-label={ariaLabel}
+        aria-labelledby={labelledBy}
+        disabled={disabled}
+        className="admin-listbox-trigger"
+        onClick={() => (open ? close() : openList())}
+        onKeyDown={onKeyDown}
+      >
+        <span className="admin-listbox-value">
+          {selected?.icon}
+          <span>{selected?.label ?? ''}</span>
+        </span>
+        <IconChevronDown size={14} className="svg-icon admin-listbox-caret" aria-hidden="true" />
+      </button>
+
+      {open && (
+        <ul ref={listRef} id={listId} role="listbox" className="admin-listbox-popup" tabIndex={-1}>
+          {options.map((option, index) => (
+            <li
+              key={option.value}
+              id={optionId(index)}
+              role="option"
+              aria-selected={option.value === value}
+              className={`admin-listbox-option${index === activeIndex ? ' is-active' : ''}${
+                option.value === value ? ' is-selected' : ''
+              }`}
+              // pointerdown would fire before the outside-press handler can run;
+              // click is enough because the press starts inside the wrapper.
+              onClick={() => commit(index)}
+              onMouseEnter={() => setActiveIndex(index)}
+            >
+              {option.icon}
+              <span className="admin-listbox-option-label">{option.label}</span>
+              {option.value === value && (
+                <IconCheck size={14} className="svg-icon admin-listbox-check" aria-hidden="true" />
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/app/admin/components/PageBuilder.tsx
+++ b/app/admin/components/PageBuilder.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, type ReactNode } from 'react';
 import {
   DndContext,
   closestCenter,
@@ -32,6 +32,9 @@ import {
 } from '@/lib/albumSort';
 import type { AlbumEntryObject } from '@/lib/config/schema';
 import {
+  IconArrowDown,
+  IconArrowUp,
+  IconCalendar,
   IconCamera,
   IconCopy,
   IconFolder,
@@ -42,16 +45,17 @@ import {
   IconPencil,
   IconPlus,
   IconSearch,
+  IconSortAlpha,
   IconTrash,
   IconX,
 } from './Icons';
+import { Listbox, type ListboxOption } from './Listbox';
 
 /**
- * Labels for the per-album sort select. Order matches ALBUM_SORT_MODES.
+ * Labels for the per-album sort control.
  *
- * Plain text, no emoji: an <option> cannot contain markup, so the SVG set from
- * `./Icons` is not available here — and a decorative emoji is not a substitute
- * for it. The badge on the album card uses a real icon instead.
+ * Kept as plain text on their own because they also feed the `title` attribute
+ * on the album card's sort badge, where markup is not an option.
  */
 const SORT_LABELS: Record<AlbumSortMode, string> = {
   immich: 'Immich order (default)',
@@ -60,6 +64,21 @@ const SORT_LABELS: Record<AlbumSortMode, string> = {
   filename: 'Filename',
   manual: 'Manual',
 };
+
+/** Manual reuses the drag glyph so the control matches the card's badge. */
+const SORT_ICONS: Record<AlbumSortMode, ReactNode> = {
+  immich: <IconCalendar />,
+  newest: <IconArrowDown />,
+  oldest: <IconArrowUp />,
+  filename: <IconSortAlpha />,
+  manual: <IconGripVertical />,
+};
+
+const SORT_OPTIONS: readonly ListboxOption<AlbumSortMode>[] = ALBUM_SORT_MODES.map((mode) => ({
+  value: mode,
+  label: SORT_LABELS[mode],
+  icon: SORT_ICONS[mode],
+}));
 
 // ── Types ──────────────────────────────────────────────────────
 interface AlbumEntry {
@@ -1595,27 +1614,13 @@ export default function PageBuilder() {
 
                   {/* Photo order */}
                   <div className="admin-field">
-                    <label>Photo order</label>
-                    <select
+                    <label id="album-sort-label">Photo order</label>
+                    <Listbox
+                      labelledBy="album-sort-label"
                       value={album.sort || DEFAULT_ALBUM_SORT}
-                      onChange={(e) =>
-                        onUpdate({
-                          sort: isAlbumSortMode(e.target.value) ? e.target.value : undefined,
-                        })
-                      }
-                      style={{
-                        padding: '8px 12px',
-                        borderRadius: '6px',
-                        width: '100%',
-                        fontSize: '0.9rem',
-                      }}
-                    >
-                      {ALBUM_SORT_MODES.map((mode) => (
-                        <option key={mode} value={mode}>
-                          {SORT_LABELS[mode]}
-                        </option>
-                      ))}
-                    </select>
+                      options={SORT_OPTIONS}
+                      onChange={(mode) => onUpdate({ sort: mode })}
+                    />
                     <span className="admin-field-hint">
                       {album.sort === 'manual'
                         ? 'Pinned photos come first, in the order you set. Everything else follows in the album’s Immich order.'


### PR DESCRIPTION
Closes #417.

The per-album "Photo order" control was a native `<select>`. An `<option>` cannot contain markup, so its choices could not use the admin panel's `currentColor` SVG set — which is why #415 had to fall back to plain text after dropping the colour emoji. This adds the custom listbox that #417 sketched out, so the options can carry a real glyph.

## Changes

- **`app/admin/components/Listbox.tsx`** (new) — a `<select>` replacement following the ARIA combobox/listbox pattern:
  - DOM focus stays on the trigger button and the active option is announced through `aria-activedescendant`, keeping focus management to a single element; options are non-focusable `<li>`s.
  - Keyboard: arrow keys (clamped at the ends, like a native select), Home/End, Enter/Space to commit, Escape to cancel, Tab commits and moves focus on, and prefix type-ahead with a repeat-key cycle.
  - Outside dismissal listens on `pointerdown`, so a press starting outside closes the popup before the click can retarget.
  - Generic over the value type, so the settings selects can adopt it later.
- **`Icons.tsx`** — adds `IconCalendar`, `IconArrowDown`, `IconArrowUp`, `IconSortAlpha` (an A→Z marker) and `IconCheck`. Manual ordering reuses `IconGripVertical`, matching the badge the album card already shows.
- **`PageBuilder.tsx`** — the "Photo order" field renders the `Listbox`. `SORT_LABELS` stays plain text on its own, because the sort badge feeds it to a `title` attribute.
- **`admin.css`** — listbox styling built on the existing `--admin-*` tokens, so it follows the panel in light/dark mode and under theme overrides such as `studio-modern`.

Left for a follow-up: the `SettingsEditor` and `EssayBlockEditor` selects. Their options are plain text, so they are not part of this bug; they can migrate to `Listbox` when there is a reason to.

## Verification

- `npx tsc --noEmit` clean, `npm run build` passes, 343 unit tests pass.
- No new Prettier/ESLint findings. `PageBuilder.tsx` carries 272 pre-existing Prettier errors before and after this branch, and `Icons.tsx` was already unformatted, so the new glyphs match the file's existing single-line style rather than reformatting it.
- Immich was not reachable from the machine this was written on, so the album drawer that hosts the control could not be opened. The component was instead driven with Playwright on a throwaway route that imports the real `admin.css`: ARIA attributes and accessible name, one SVG per option, mouse selection, every keyboard path above, type-ahead, and outside dismissal — 7 checks, all passing, plus a screenshot confirming monochrome glyphs and the selected-state check mark. That harness is not part of this branch. The drawer wiring itself is a single JSX swap and is type-checked, but has not been exercised in a browser — worth a click-through before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)