### PR TITLE
fix(admin): stop the album sort dropdown clipping, and simplify the panel

### DIFF
--- a/app/admin/admin.css
+++ b/app/admin/admin.css
@@ -248,13 +248,12 @@
   transform: rotate(180deg);
 }
 
+/* Portalled to <body>, so it escapes the overflow of any scrolling ancestor.
+   left/top/bottom/width/max-height are measured from the trigger and set inline
+   by the component; the z-index clears the modal overlay (1000). */
 .admin-listbox-popup {
-  position: absolute;
-  z-index: 40;
-  top: calc(100% + 4px);
-  left: 0;
-  right: 0;
-  max-height: 260px;
+  position: fixed;
+  z-index: 1100;
   overflow-y: auto;
   margin: 0;
   padding: 0.25rem;

--- a/app/admin/admin.css
+++ b/app/admin/admin.css
@@ -2083,7 +2083,7 @@ h3 .svg-icon {
 
 .album-drawer {
   width: 100%;
-  max-width: 840px;
+  max-width: 620px;
   max-height: 90vh;
   background: var(--admin-bg-raised);
   border: 1px solid var(--admin-border);
@@ -2118,52 +2118,23 @@ h3 .svg-icon {
   gap: 0.5rem;
 }
 
-/* 2-Column Body Layout */
+/* Single-column body — and the drawer's only scroll container. Nesting a second
+   scroller here is what used to clip the sort listbox popup. */
 .album-drawer-body {
   flex: 1;
-  overflow-y: auto;
-  padding: 0;
-  display: grid;
-  grid-template-columns: 1.2fr 1.8fr;
   min-height: 0;
-}
-
-@media (max-width: 768px) {
-  .album-drawer-body {
-    grid-template-columns: 1fr;
-  }
-  .album-drawer {
-    max-height: 95vh;
-  }
-}
-
-.modal-left-column {
-  padding: 1.75rem;
-  background: var(--admin-bg-elevated);
-  border-right: 1px solid var(--admin-border);
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-}
-
-@media (max-width: 768px) {
-  .modal-left-column {
-    border-right: none;
-    border-bottom: 1px solid var(--admin-border);
-    padding: 1.25rem;
-  }
-}
-
-.modal-right-column {
+  overflow-y: auto;
   padding: 1.75rem;
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
-  overflow-y: auto;
 }
 
 @media (max-width: 768px) {
-  .modal-right-column {
+  .album-drawer {
+    max-height: 95vh;
+  }
+  .album-drawer-body {
     padding: 1.25rem;
   }
 }
@@ -2187,14 +2158,29 @@ h3 .svg-icon {
   border-top: 1px solid var(--admin-border);
   background: var(--admin-bg-elevated);
   display: flex;
+  align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
   gap: 0.75rem;
 }
 
-/* Left Column Cover Preview */
+/* Narrow screens cannot fit both buttons plus the UUID on one line; drop the
+   UUID onto its own row rather than squeezing the actions. */
+@media (max-width: 560px) {
+  .album-drawer-footer .uuid-copy-box {
+    order: 1;
+    flex-basis: 100%;
+  }
+}
+
+/* Cover banner across the top of the drawer. flex-shrink must be off: the img
+   inside is height:100%, so the box has no min-content height and the scrolling
+   flex column would otherwise crush it to a couple of pixels. */
 .modal-cover-container {
   width: 100%;
-  aspect-ratio: 16 / 10;
+  flex: none;
+  aspect-ratio: 21 / 9;
+  max-height: 180px;
   border-radius: 10px;
   overflow: hidden;
   border: 1px solid var(--admin-border);
@@ -2219,11 +2205,13 @@ h3 .svg-icon {
   font-size: 2.5rem;
 }
 
-/* Album metadata card in left column */
+/* Album name + photo count, directly under the cover banner */
 .modal-meta-box {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
+  padding-bottom: 0.25rem;
+  border-bottom: 1px solid var(--admin-border);
 }
 
 .modal-album-title {
@@ -2240,44 +2228,7 @@ h3 .svg-icon {
   color: var(--admin-text-secondary);
 }
 
-.modal-info-list {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  font-size: 0.8rem;
-  color: var(--admin-text-secondary);
-}
-
-.modal-info-item {
-  display: flex;
-  justify-content: space-between;
-  border-bottom: 1px dashed var(--admin-border);
-  padding-bottom: 0.25rem;
-}
-
-.modal-info-label {
-  color: var(--admin-text-muted);
-}
-
-.modal-info-value {
-  font-weight: 600;
-}
-
 /* Drawer Copy UUID element */
-.drawer-uuid-section {
-  padding-top: 0.75rem;
-  border-top: 1px solid var(--admin-border);
-}
-
-.drawer-uuid-section label {
-  font-size: 0.7rem;
-  color: var(--admin-text-muted);
-  font-weight: 600;
-  display: block;
-  margin-bottom: 0.35rem;
-  letter-spacing: 0.05em;
-}
-
 .uuid-copy-box {
   display: flex;
   align-items: center;
@@ -2295,6 +2246,21 @@ h3 .svg-icon {
   flex: 1;
   word-break: break-all;
   user-select: all;
+}
+
+/* In the footer the UUID is secondary to the two action buttons: it takes the
+   leftover width and truncates rather than wrapping the row onto two lines. */
+.album-drawer-footer .uuid-copy-box {
+  flex: 1;
+  min-width: 0;
+  padding: 0.3rem 0.35rem 0.3rem 0.6rem;
+}
+
+.album-drawer-footer .uuid-copy-box code {
+  word-break: normal;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .uuid-copy-btn {

--- a/app/admin/components/Listbox.tsx
+++ b/app/admin/components/Listbox.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { createPortal } from 'react-dom';
 import { IconCheck, IconChevronDown } from './Icons';
 
 /**
@@ -32,6 +33,26 @@ export interface ListboxProps<T extends string> {
 /** How long a type-ahead buffer keeps collecting characters. */
 const TYPEAHEAD_RESET_MS = 600;
 
+/** Gap between the trigger and the popup. */
+const POPUP_GAP = 4;
+/** Space kept clear of the viewport edge. */
+const VIEWPORT_MARGIN = 8;
+/** Tallest the popup ever gets; beyond this it scrolls internally. */
+const POPUP_MAX_HEIGHT = 260;
+/** Below this the flipped side is not worth using. */
+const POPUP_MIN_HEIGHT = 96;
+
+/** Viewport coordinates for the popup, measured from the trigger. */
+interface Placement {
+  left: number;
+  width: number;
+  /** Set when the popup hangs below the trigger. */
+  top?: number;
+  /** Set when the popup is flipped above it. */
+  bottom?: number;
+  maxHeight: number;
+}
+
 /**
  * A select replacement that can show markup in its options.
  *
@@ -41,6 +62,13 @@ const TYPEAHEAD_RESET_MS = 600;
  * the trigger button, and the active option is announced through
  * `aria-activedescendant`. Options are plain `<li>`s — not focusable — which
  * keeps focus management to a single element.
+ *
+ * The popup is portalled to `document.body` and positioned from the trigger's
+ * viewport rect. An absolutely positioned popup is clipped by any ancestor with
+ * a non-visible overflow — and z-index cannot rescue it, because clipping
+ * happens before stacking — so inside a scrolling modal the list would be cut
+ * off. Escaping to the body also lets it flip above the trigger when there is
+ * more room there.
  */
 export function Listbox<T extends string>({
   value,
@@ -58,6 +86,7 @@ export function Listbox<T extends string>({
     options.findIndex((o) => o.value === value),
   );
   const [activeIndex, setActiveIndex] = React.useState(selectedIndex);
+  const [placement, setPlacement] = React.useState<Placement | null>(null);
 
   const wrapperRef = React.useRef<HTMLDivElement>(null);
   const buttonRef = React.useRef<HTMLButtonElement>(null);
@@ -81,6 +110,7 @@ export function Listbox<T extends string>({
 
   const close = React.useCallback(() => {
     setOpen(false);
+    setPlacement(null);
     typeahead.current = { buffer: '', at: 0 };
   }, []);
 
@@ -96,14 +126,56 @@ export function Listbox<T extends string>({
   );
 
   // Dismiss on outside pointer press. pointerdown (not click) so a press that
-  // starts outside closes the popup before it can retarget the click.
+  // starts outside closes the popup before it can retarget the click. The popup
+  // is portalled, so it is not inside the wrapper — without the second test a
+  // press on an option would count as "outside" and close before it commits.
   React.useEffect(() => {
     if (!open) return;
     const onPointerDown = (event: PointerEvent) => {
-      if (!wrapperRef.current?.contains(event.target as Node)) close();
+      const target = event.target as Node;
+      if (!wrapperRef.current?.contains(target) && !listRef.current?.contains(target)) close();
     };
     document.addEventListener('pointerdown', onPointerDown);
     return () => document.removeEventListener('pointerdown', onPointerDown);
+  }, [open, close]);
+
+  // Measure once the popup is in the DOM but before paint, so it never shows at
+  // a stale position. Until then it renders hidden purely to be measurable.
+  React.useLayoutEffect(() => {
+    if (!open) return;
+    const trigger = buttonRef.current;
+    const list = listRef.current;
+    if (!trigger || !list) return;
+
+    const rect = trigger.getBoundingClientRect();
+    // scrollHeight ignores our own max-height, so this is the natural height.
+    const wanted = Math.min(POPUP_MAX_HEIGHT, list.scrollHeight + 2);
+    const below = window.innerHeight - rect.bottom - POPUP_GAP - VIEWPORT_MARGIN;
+    const above = rect.top - POPUP_GAP - VIEWPORT_MARGIN;
+    const flip = wanted > below && above > below;
+    const room = flip ? above : below;
+
+    setPlacement({
+      left: rect.left,
+      width: rect.width,
+      top: flip ? undefined : rect.bottom + POPUP_GAP,
+      bottom: flip ? window.innerHeight - rect.top + POPUP_GAP : undefined,
+      maxHeight: Math.max(POPUP_MIN_HEIGHT, Math.min(POPUP_MAX_HEIGHT, room)),
+    });
+  }, [open]);
+
+  // The popup is anchored in viewport coordinates, so anything that moves the
+  // trigger invalidates it. Dismiss rather than re-measure — that is what a
+  // native select does, and the measurement above only runs on open. Capture
+  // phase, because the scroll usually happens on an ancestor container.
+  React.useEffect(() => {
+    if (!open) return;
+    window.addEventListener('scroll', close, true);
+    window.addEventListener('resize', close);
+    return () => {
+      window.removeEventListener('scroll', close, true);
+      window.removeEventListener('resize', close);
+    };
   }, [open, close]);
 
   // Keep the active option visible while arrowing or typing through a long list.
@@ -219,31 +291,55 @@ export function Listbox<T extends string>({
         <IconChevronDown size={14} className="svg-icon admin-listbox-caret" aria-hidden="true" />
       </button>
 
-      {open && (
-        <ul ref={listRef} id={listId} role="listbox" className="admin-listbox-popup" tabIndex={-1}>
-          {options.map((option, index) => (
-            <li
-              key={option.value}
-              id={optionId(index)}
-              role="option"
-              aria-selected={option.value === value}
-              className={`admin-listbox-option${index === activeIndex ? ' is-active' : ''}${
-                option.value === value ? ' is-selected' : ''
-              }`}
-              // pointerdown would fire before the outside-press handler can run;
-              // click is enough because the press starts inside the wrapper.
-              onClick={() => commit(index)}
-              onMouseEnter={() => setActiveIndex(index)}
-            >
-              {option.icon}
-              <span className="admin-listbox-option-label">{option.label}</span>
-              {option.value === value && (
-                <IconCheck size={14} className="svg-icon admin-listbox-check" aria-hidden="true" />
-              )}
-            </li>
-          ))}
-        </ul>
-      )}
+      {open &&
+        createPortal(
+          <ul
+            ref={listRef}
+            id={listId}
+            role="listbox"
+            className="admin-listbox-popup"
+            tabIndex={-1}
+            style={
+              placement
+                ? {
+                    left: placement.left,
+                    width: placement.width,
+                    top: placement.top,
+                    bottom: placement.bottom,
+                    maxHeight: placement.maxHeight,
+                  }
+                : // First pass: laid out but invisible, only so it can be measured.
+                  { left: 0, top: 0, visibility: 'hidden' }
+            }
+          >
+            {options.map((option, index) => (
+              <li
+                key={option.value}
+                id={optionId(index)}
+                role="option"
+                aria-selected={option.value === value}
+                className={`admin-listbox-option${index === activeIndex ? ' is-active' : ''}${
+                  option.value === value ? ' is-selected' : ''
+                }`}
+                // pointerdown would fire before the outside-press handler can run;
+                // click is enough because that handler treats the popup as inside.
+                onClick={() => commit(index)}
+                onMouseEnter={() => setActiveIndex(index)}
+              >
+                {option.icon}
+                <span className="admin-listbox-option-label">{option.label}</span>
+                {option.value === value && (
+                  <IconCheck
+                    size={14}
+                    className="svg-icon admin-listbox-check"
+                    aria-hidden="true"
+                  />
+                )}
+              </li>
+            ))}
+          </ul>,
+          document.body,
+        )}
     </div>
   );
 }

--- a/app/admin/components/PageBuilder.tsx
+++ b/app/admin/components/PageBuilder.tsx
@@ -1489,168 +1489,133 @@ export default function PageBuilder() {
                   <IconX size={14} />
                 </button>
               </div>
+              {/* One scrolling column: cover banner, then the form. Anything the
+                  form already shows (password state, custom hero) is not
+                  repeated as a read-only stat. */}
               <div className="album-drawer-body">
-                {/* Left Column - Visual Info & Stats */}
-                <div className="modal-left-column">
-                  <div className="modal-cover-container">
-                    {heroThumb ? (
-                      <img src={`/api/admin/thumbnail/${heroThumb}`} alt="" loading="lazy" />
-                    ) : (
-                      <div className="modal-cover-placeholder">
-                        <IconCamera />
-                      </div>
-                    )}
-                  </div>
-                  <div className="modal-meta-box">
-                    <span className="modal-album-title">{album.title || name}</span>
-                    <span className="modal-album-subtitle">Original: {name}</span>
-                  </div>
-                  <div className="modal-info-list">
-                    <div className="modal-info-item">
-                      <span className="modal-info-label">Photo Count:</span>
-                      <span className="modal-info-value">{count} photos</span>
+                <div className="modal-cover-container">
+                  {heroThumb ? (
+                    <img src={`/api/admin/thumbnail/${heroThumb}`} alt="" loading="lazy" />
+                  ) : (
+                    <div className="modal-cover-placeholder">
+                      <IconCamera />
                     </div>
-                    <div className="modal-info-item">
-                      <span className="modal-info-label">Status:</span>
-                      <span className="modal-info-value">
-                        {album.password ? 'Password Protected' : 'Public Access'}
-                      </span>
-                    </div>
-                    <div className="modal-info-item">
-                      <span className="modal-info-label">Custom Hero:</span>
-                      <span className="modal-info-value">
-                        {album.heroImage ? 'Yes' : 'No'}
-                      </span>
-                    </div>
-                  </div>
+                  )}
+                </div>
+                <div className="modal-meta-box">
+                  <span className="modal-album-title">{album.title || name}</span>
+                  <span className="modal-album-subtitle">
+                    {count} {count === 1 ? 'photo' : 'photos'}
+                    {album.title ? ` · Original: ${name}` : ''}
+                  </span>
+                </div>
 
-                  {/* Technical UUID */}
-                  <div className="drawer-uuid-section">
-                    <label className="admin-field-label">IMMICH ALBUM UUID</label>
-                    <div className="uuid-copy-box">
-                      <code>{album.id}</code>
-                      <button
-                        className="uuid-copy-btn"
-                        onClick={() => {
-                          navigator.clipboard.writeText(album.id);
-                        }}
-                        title="Copy UUID"
-                      >
-                        <IconCopy size={12} />
-                      </button>
-                    </div>
+                <div className="admin-field">
+                  <label>Title override</label>
+                  <input
+                    value={album.title || ''}
+                    onChange={(e) => onUpdate({ title: e.target.value || undefined })}
+                    placeholder={name}
+                  />
+                </div>
+
+                <div className="admin-field">
+                  <label>Description</label>
+                  <textarea
+                    value={album.description || ''}
+                    onChange={(e) => onUpdate({ description: e.target.value || undefined })}
+                    placeholder="Optional description for visitors"
+                    rows={4}
+                  />
+                </div>
+
+                <div className="admin-field">
+                  <label>Password protection</label>
+                  <div className="input-with-icon">
+                    <input
+                      type="password"
+                      value={album.password || ''}
+                      onChange={(e) => onUpdate({ password: e.target.value || undefined })}
+                      placeholder="Leave empty for public access"
+                    />
                   </div>
                 </div>
 
-                {/* Right Column - Form Fields */}
-                <div className="modal-right-column">
-                  <div className="admin-field">
-                    <label>Title override</label>
-                    <input
-                      value={album.title || ''}
-                      onChange={(e) => onUpdate({ title: e.target.value || undefined })}
-                      placeholder={name}
-                    />
+                {/* Hero Image Selection */}
+                <div className="admin-field">
+                  <label>Custom Hero Image</label>
+                  <div className="album-hero-field">
+                    {album.heroImage ? (
+                      <div className="album-hero-preview">
+                        <img src={`/api/admin/thumbnail/${album.heroImage}`} alt="Hero" />
+                        <button
+                          className="album-hero-remove"
+                          onClick={() => onUpdate({ heroImage: undefined })}
+                          title="Remove custom hero image"
+                        >
+                          <IconX size={14} />
+                        </button>
+                      </div>
+                    ) : (
+                      <span className="album-hero-empty">Using default album cover</span>
+                    )}
+                    <button
+                      className="admin-btn admin-btn-sm"
+                      onClick={() =>
+                        setHeroPickerTarget({
+                          albumId: album.id,
+                          onSelect: (assetId) => {
+                            onUpdate({ heroImage: assetId });
+                            setHeroPickerTarget(null);
+                          },
+                          currentAssetIds: album.heroImage ? [album.heroImage] : [],
+                          title: `Pick Hero Image for ${name}`,
+                        })
+                      }
+                    >
+                      <IconImage size={12} /> {album.heroImage ? 'Change Image' : 'Pick Hero Image'}
+                    </button>
                   </div>
+                </div>
 
-                  <div className="admin-field">
-                    <label>Description</label>
-                    <textarea
-                      value={album.description || ''}
-                      onChange={(e) => onUpdate({ description: e.target.value || undefined })}
-                      placeholder="Optional description for visitors"
-                      rows={4}
-                    />
-                  </div>
+                {/* Photo order */}
+                <div className="admin-field">
+                  <label id="album-sort-label">Photo order</label>
+                  <Listbox
+                    labelledBy="album-sort-label"
+                    value={album.sort || DEFAULT_ALBUM_SORT}
+                    options={SORT_OPTIONS}
+                    onChange={(mode) => onUpdate({ sort: mode })}
+                  />
+                  <span className="admin-field-hint">
+                    {album.sort === 'manual'
+                      ? 'Pinned photos come first, in the order you set. Everything else follows in the album’s Immich order.'
+                      : 'Immich order follows the album’s own sort setting in Immich.'}
+                  </span>
 
-                  <div className="admin-field">
-                    <label>Password protection</label>
-                    <div className="input-with-icon">
-                      <input
-                        type="password"
-                        value={album.password || ''}
-                        onChange={(e) => onUpdate({ password: e.target.value || undefined })}
-                        placeholder="Leave empty for public access"
-                      />
-                    </div>
-                  </div>
-
-                  {/* Hero Image Selection */}
-                  <div className="admin-field">
-                    <label>Custom Hero Image</label>
-                    <div className="album-hero-field">
-                      {album.heroImage ? (
-                        <div className="album-hero-preview">
-                          <img src={`/api/admin/thumbnail/${album.heroImage}`} alt="Hero" />
-                          <button
-                            className="album-hero-remove"
-                            onClick={() => onUpdate({ heroImage: undefined })}
-                            title="Remove custom hero image"
-                          >
-                            <IconX size={14} />
-                          </button>
-                        </div>
-                      ) : (
-                        <span className="album-hero-empty">Using default album cover</span>
-                      )}
+                  {album.sort === 'manual' && (
+                    <div style={{ marginTop: '0.75rem' }}>
                       <button
                         className="admin-btn admin-btn-sm"
                         onClick={() =>
-                          setHeroPickerTarget({
+                          setOrderEditorTarget({
                             albumId: album.id,
-                            onSelect: (assetId) => {
-                              onUpdate({ heroImage: assetId });
-                              setHeroPickerTarget(null);
+                            albumName: album.title || name,
+                            assetOrder: album.assetOrder || [],
+                            onSave: (assetOrder) => {
+                              onUpdate({ assetOrder });
+                              setOrderEditorTarget(null);
                             },
-                            currentAssetIds: album.heroImage ? [album.heroImage] : [],
-                            title: `Pick Hero Image for ${name}`,
                           })
                         }
                       >
-                        <IconImage size={12} /> {album.heroImage ? 'Change Image' : 'Pick Hero Image'}
+                        <IconGripVertical size={18} className="svg-icon svg-drag" />{' '}
+                        {album.assetOrder?.length
+                          ? `Reorder photos (${album.assetOrder.length} pinned)`
+                          : 'Reorder photos'}
                       </button>
                     </div>
-                  </div>
-
-                  {/* Photo order */}
-                  <div className="admin-field">
-                    <label id="album-sort-label">Photo order</label>
-                    <Listbox
-                      labelledBy="album-sort-label"
-                      value={album.sort || DEFAULT_ALBUM_SORT}
-                      options={SORT_OPTIONS}
-                      onChange={(mode) => onUpdate({ sort: mode })}
-                    />
-                    <span className="admin-field-hint">
-                      {album.sort === 'manual'
-                        ? 'Pinned photos come first, in the order you set. Everything else follows in the album’s Immich order.'
-                        : 'Immich order follows the album’s own sort setting in Immich.'}
-                    </span>
-
-                    {album.sort === 'manual' && (
-                      <div style={{ marginTop: '0.75rem' }}>
-                        <button
-                          className="admin-btn admin-btn-sm"
-                          onClick={() =>
-                            setOrderEditorTarget({
-                              albumId: album.id,
-                              albumName: album.title || name,
-                              assetOrder: album.assetOrder || [],
-                              onSave: (assetOrder) => {
-                                onUpdate({ assetOrder });
-                                setOrderEditorTarget(null);
-                              },
-                            })
-                          }
-                        >
-                          <IconGripVertical size={18} className="svg-icon svg-drag" />{' '}
-                          {album.assetOrder?.length
-                            ? `Reorder photos (${album.assetOrder.length} pinned)`
-                            : 'Reorder photos'}
-                        </button>
-                      </div>
-                    )}
-                  </div>
+                  )}
                 </div>
               </div>
               <div className="album-drawer-footer">
@@ -1661,6 +1626,19 @@ export default function PageBuilder() {
                 >
                   <IconTrash size={14} /> Remove Album
                 </button>
+                <div className="uuid-copy-box" title="Immich album UUID">
+                  <code>{album.id}</code>
+                  <button
+                    className="uuid-copy-btn"
+                    onClick={() => {
+                      navigator.clipboard.writeText(album.id);
+                    }}
+                    title="Copy UUID"
+                    aria-label="Copy Immich album UUID"
+                  >
+                    <IconCopy size={12} />
+                  </button>
+                </div>
                 <button
                   className="admin-btn admin-btn-primary"
                   onClick={() => setEditingAlbumAddress(null)}


### PR DESCRIPTION
The "Photo order" dropdown in *Edit Album Details* was cut off at the bottom edge of the modal.

## Why it happened

The popup was `position: absolute` inside three clipping ancestors:

```
.album-drawer          { overflow: hidden }
 └ .album-drawer-body  { overflow-y: auto }
    └ .modal-right-column { overflow-y: auto }
       └ .admin-listbox-popup { position: absolute; top: calc(100% + 4px) }
```

An absolutely positioned box is clipped by *every* ancestor with a non-visible overflow, and `z-index: 40` cannot rescue it because clipping happens before stacking. It was aggravated by the popup never flipping upward, and by the sort field being the last control in the column.

Underneath that sat a layout problem: the left column spent 1.2fr on a cover thumbnail and three stat rows — two of which (`Status`, `Custom Hero`) only restated the form fields opposite them — while the form itself was squeezed into 1.8fr behind a second, nested scroller.

## What changed

**`fix(admin)` — portal the listbox popup**

- `createPortal` to `document.body`, `position: fixed`, positioned from the trigger's viewport rect.
- Flips above the trigger when there is more room there; `max-height` is capped to the space available, so it scrolls internally rather than overflowing.
- Dismissed on scroll and resize, since the anchor is only measured on open.
- The outside-`pointerdown` handler now also treats the popup as inside. **Worth a reviewer's eye:** without that, the portalled list counts as "outside" and a click on an option would close it before the selection commits.

**`refactor(admin)` — single-column album panel**

- Cover becomes a banner, then the form at full width; UUID moves into the footer.
- `Status` / `Custom Hero` rows dropped (they mirrored editable fields two inches away).
- `.album-drawer-body` is now the only scroll container, which also removes one of the clipping ancestors. `max-width` 840px → 620px.

All the affected classes (`.modal-*`, `.drawer-uuid-section`, `.uuid-copy-box`, `.album-drawer*`) are used only by this modal, so no other admin dialog is touched.

## Verification

Screenshots were not obtainable (the browser pane renders black in this environment), so the layout was verified by measuring geometry in the live page:

- Popup is a child of `<body>`, `position: fixed`, `z-index: 1100`; all five options fully inside the viewport.
- At a 460px-tall viewport it flips above — room below 157px < the 194px needed — with a 4px gap and nothing clipped. This is the exact case from the bug report.
- Clicking "Manual" commits, popup closes, modal stays open, the conditional "Reorder photos" button appears.
- Keyboard: ArrowDown opens, focus stays on the trigger, `aria-activedescendant` is set, type-ahead "f" → Filename, Escape closes.
- Scroll dismissal fires (window capture listener catches the non-bubbling scroll event).
- Light theme resolves through the existing `--admin-*` tokens; no horizontal page overflow; no console errors from this code.

Two bugs the verification pass caught and this PR also fixes:

- The cover banner collapsed to **2px** — its `<img>` is `height: 100%`, so the box has no min-content height and the scrolling flex column crushed it. Fixed with `flex: none`.
- The footer now holds three items instead of two and would overflow below ~375px, so the UUID drops to its own row there.

`tsc --noEmit`, `test:unit` (343 passing) and `build` are green.

**Note on lint:** `npm run lint` fails repo-wide on `dev` already — Prettier is wired up as an ESLint error but, per the comment in `ci.yml`, has never been run in CI. `PageBuilder.tsx` had 273 errors before this branch and has 272 after, none of them inside the changed region. I deliberately did **not** run `prettier --write` across that file, since it would have reformatted ~900 unrelated lines.
