### PR TITLE
fix(admin): restore the portalled listbox theme, lock the page behind modals

### DIFF
--- a/app/admin/admin.css
+++ b/app/admin/admin.css
@@ -3,7 +3,11 @@
 /* Supports light/dark mode via data-theme attribute on <html>. */
 
 /* ── Theme Variables ───────────────────────────────────────── */
-.admin-layout {
+/* .admin-listbox-popup is listed alongside .admin-layout because it is
+   portalled to <body>, outside the layout subtree. Without its own copy every
+   var below resolves to nothing there, and the popup paints transparent. */
+.admin-layout,
+.admin-listbox-popup {
   /* Dark mode (default) */
   --admin-bg: #111111;
   --admin-bg-raised: #1a1a1a;
@@ -26,7 +30,8 @@
   --admin-overlay: rgba(0, 0, 0, 0.7);
 }
 
-[data-theme='light'] .admin-layout {
+[data-theme='light'] .admin-layout,
+[data-theme='light'] .admin-listbox-popup {
   --admin-bg: #f8f8f8;
   --admin-bg-raised: #ffffff;
   --admin-bg-elevated: #f0f0f0;
@@ -255,9 +260,14 @@
   position: fixed;
   z-index: 1100;
   overflow-y: auto;
+  /* A long list scrolls internally; without this, reaching its end hands the
+     wheel to whatever is behind the modal. */
+  overscroll-behavior: contain;
   margin: 0;
   padding: 0.25rem;
   list-style: none;
+  /* Also outside .admin-layout, so the font does not inherit either. */
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
   background: var(--admin-bg-elevated);
   border: 1px solid var(--admin-border);
   border-radius: 8px;
@@ -1081,6 +1091,7 @@
 .picker-list {
   flex: 1;
   overflow-y: auto;
+  overscroll-behavior: contain;
   padding: 0.5rem;
 }
 
@@ -1652,6 +1663,7 @@
   flex: 1;
   min-height: 0;
   overflow-y: auto;
+  overscroll-behavior: contain;
   padding: 0.75rem;
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
@@ -2124,6 +2136,8 @@ h3 .svg-icon {
   flex: 1;
   min-height: 0;
   overflow-y: auto;
+  /* Stop the scroll handing off to the page once the form hits its end. */
+  overscroll-behavior: contain;
   padding: 1.75rem;
   display: flex;
   flex-direction: column;
@@ -2509,6 +2523,7 @@ h3 .svg-icon {
 .backup-modal-body {
   flex: 1;
   overflow-y: auto;
+  overscroll-behavior: contain;
   padding: 1rem 1.5rem;
 }
 
@@ -3366,6 +3381,7 @@ h3 .svg-icon {
 .subpage-drawer-body {
   padding: 1.5rem;
   overflow-y: auto;
+  overscroll-behavior: contain;
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -3966,6 +3982,7 @@ h3 .svg-icon {
   flex: 1;
   min-height: 0;
   overflow-y: auto;
+  overscroll-behavior: contain;
   padding: 0.75rem;
 }
 

--- a/app/admin/components/AlbumPicker.tsx
+++ b/app/admin/components/AlbumPicker.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useMemo } from 'react';
+import { useScrollLock } from './useScrollLock';
 
 interface ImmichAlbumInfo {
   id: string;
@@ -19,6 +20,7 @@ interface Props {
 }
 
 export default function AlbumPicker({ albums, onSelect, onClose, usedAlbumIds }: Props) {
+  useScrollLock(true);
   const [search, setSearch] = useState('');
 
   const filtered = useMemo(() => {

--- a/app/admin/components/AssetOrderEditor.tsx
+++ b/app/admin/components/AssetOrderEditor.tsx
@@ -18,6 +18,7 @@ import {
   rectSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
+import { useScrollLock } from './useScrollLock';
 
 interface AssetInfo {
   id: string;
@@ -92,6 +93,7 @@ export default function AssetOrderEditor({
   onSave,
   onClose,
 }: Props) {
+  useScrollLock(true);
   const [assets, setAssets] = useState<AssetInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');

--- a/app/admin/components/AssetPicker.tsx
+++ b/app/admin/components/AssetPicker.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { IconFolder, IconImage, IconStar } from './Icons';
+import { useScrollLock } from './useScrollLock';
 
 interface AssetInfo {
   id: string;
@@ -27,6 +28,7 @@ export default function AssetPicker({
   albumId,
   title,
 }: Props) {
+  useScrollLock(true);
   const [tab, setTab] = useState<Tab>(albumId ? 'album' : 'favorites');
   const [assets, setAssets] = useState<AssetInfo[]>([]);
   const [loading, setLoading] = useState(true);

--- a/app/admin/components/BackupManagerModal.tsx
+++ b/app/admin/components/BackupManagerModal.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import type { BackupItem } from '@/app/api/admin/backups/route';
 import * as Icons from './Icons';
+import { useScrollLock } from './useScrollLock';
 
 interface Props {
   isOpen: boolean;
@@ -48,6 +49,8 @@ export default function BackupManagerModal({ isOpen, onClose, onRestoreSuccess }
       setShowAllBackups(false);
     }
   }, [isOpen, fetchBackups]);
+
+  useScrollLock(isOpen);
 
   if (!isOpen) return null;
 

--- a/app/admin/components/PageBuilder.tsx
+++ b/app/admin/components/PageBuilder.tsx
@@ -24,6 +24,7 @@ import AssetPicker from './AssetPicker';
 import AssetOrderEditor from './AssetOrderEditor';
 import { EssayBlockEditor } from './EssayBlockEditor';
 import SaveBar from './SaveBar';
+import { useScrollLock } from './useScrollLock';
 import {
   ALBUM_SORT_MODES,
   DEFAULT_ALBUM_SORT,
@@ -385,6 +386,11 @@ export default function PageBuilder() {
   } | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [editingAlbumAddress, setEditingAlbumAddress] = useState<ActiveEditAlbumAddress | null>(null);
+
+  // Keep the builder still behind either drawer. One combined lock rather than
+  // one per drawer: the album drawer opens from inside the subpage drawer, and
+  // a single condition avoids two locks racing over the same inline style.
+  useScrollLock(editingAlbumAddress !== null || expandedSubpage !== null);
 
   // DnD sensors
   const sensors = useSensors(

--- a/app/admin/components/useScrollLock.ts
+++ b/app/admin/components/useScrollLock.ts
@@ -1,0 +1,41 @@
+'use client';
+
+import { useEffect } from 'react';
+
+/**
+ * Freezes the page behind a modal for as long as `active` is true.
+ *
+ * An overlay covers the page but does not absorb wheel events: a scroll that
+ * starts over the backdrop — or one that continues past the end of the modal's
+ * own scroll container — reaches the document and moves the page underneath.
+ * `overscroll-behavior` alone cannot fix that, because it only applies to
+ * scroll containers, and the backdrop is not one.
+ *
+ * Nesting works without a counter: each lock captures whatever inline value it
+ * found and restores exactly that, so a picker opened from the album drawer
+ * restores the drawer's `hidden` rather than clearing it.
+ */
+export function useScrollLock(active: boolean) {
+  useEffect(() => {
+    if (!active) return;
+
+    const { body } = document;
+    const previousOverflow = body.style.overflow;
+    const previousPaddingRight = body.style.paddingRight;
+
+    // Hiding the scrollbar widens the viewport and shifts the page under the
+    // overlay. Pad by exactly the width it gave up so nothing moves. Overlay
+    // scrollbars (most touch devices) measure 0 and need no compensation.
+    const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
+    if (scrollbarWidth > 0) {
+      const current = parseFloat(getComputedStyle(body).paddingRight) || 0;
+      body.style.paddingRight = `${current + scrollbarWidth}px`;
+    }
+    body.style.overflow = 'hidden';
+
+    return () => {
+      body.style.overflow = previousOverflow;
+      body.style.paddingRight = previousPaddingRight;
+    };
+  }, [active]);
+}


### PR DESCRIPTION
Two defects in the album editor, reported after #428 went live.

## The listbox popup painted transparent

Every `--admin-*` variable is scoped to `.admin-layout`. Since #428 moved the popup into `document.body` via `createPortal`, it sits outside that subtree, so `background`, `border` and `color` all resolved to nothing — and an invalid colour falls back to transparent. The font it silently stopped inheriting too.

The popup now carries its own copy of the palette in both colour schemes, keyed off `[data-theme]` on `<html>` so the light-mode selector still reaches it from `<body>`. Moving the variables to `:root` would have worked as well, but that leaks the admin palette into the public gallery, which the stylesheet deliberately avoids.

## Scrolling inside a modal moved the page behind it

This predates #428 — no admin modal ever locked body scroll. The overlay covers the page but does not absorb wheel events, so a scroll starting on the backdrop, or one continuing past the end of the modal's own scroller, reaches the document. `overscroll-behavior` cannot cover that on its own: it only applies to scroll containers, and the backdrop is not one.

`useScrollLock` freezes `body` while a modal is open and pads by the width the scrollbar gives up, so nothing shifts underneath. Each lock restores the inline value it found rather than clearing it, which makes nesting work without a counter — a picker opened from the album drawer restores the drawer's `hidden` state on close. Applied to both drawers and all four picker modals, which share the defect. `overscroll-behavior: contain` on the scrollers handles the chaining they can stop themselves.

## Notes

`PageBuilder.tsx` and `BackupManagerModal.tsx` are not Prettier-clean on `dev` (265 and 10 deviating lines). They are left that way here — reformatting them would bury a six-line change under several hundred lines of unrelated churn.

## Verification

- `npx tsc --noEmit` — 0 errors
- `npm run build` — passes
- `npm run lint` — unchanged against `dev` (the pre-existing errors are all pre-existing; nothing new in the touched files)

Not yet verified visually in a running instance — that happens on the next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)