### PR TITLE
experimental: Adobe-Portfolio-Features (justified layout, unlisted pages, captions, per-album grid, focal point, nav links, cover hero)

### DIFF
--- a/app/[...path]/PhotoGrid.tsx
+++ b/app/[...path]/PhotoGrid.tsx
@@ -34,7 +34,14 @@ export interface PhotoItem {
 
 interface PhotoGridProps {
   assets: PhotoItem[];
-  layout?: 'masonry' | 'uniform' | 'showcase' | 'filmstrip' | 'editorial-flow' | 'essay' | 'justified';
+  layout?:
+    | 'masonry'
+    | 'uniform'
+    | 'showcase'
+    | 'filmstrip'
+    | 'editorial-flow'
+    | 'essay'
+    | 'justified';
   gridStyle?: React.CSSProperties;
   watermark?: LightboxWatermark;
 }

--- a/app/[...path]/PhotoGrid.tsx
+++ b/app/[...path]/PhotoGrid.tsx
@@ -34,7 +34,7 @@ export interface PhotoItem {
 
 interface PhotoGridProps {
   assets: PhotoItem[];
-  layout?: 'masonry' | 'uniform' | 'showcase' | 'filmstrip' | 'editorial-flow' | 'essay';
+  layout?: 'masonry' | 'uniform' | 'showcase' | 'filmstrip' | 'editorial-flow' | 'essay' | 'justified';
   gridStyle?: React.CSSProperties;
   watermark?: LightboxWatermark;
 }
@@ -147,8 +147,21 @@ function PhotoGridInner({ assets, layout = 'masonry', gridStyle, watermark }: Ph
     return displayedAssets.map((asset, index) => {
       const isFav = proofing ? proofing.isFavorite(asset.id) : false;
 
+      // Justified rows: the flex sizing must sit on the outermost grid child,
+      // which is the FadeIn wrapper — not the .photo-grid__item inside it.
+      // Aspect ratio drives both grow factor and basis; ~3:2 fallback for
+      // assets without dimensions (e.g. videos) keeps the row math sane.
+      const justifiedAr = asset.aspectRatio || 1.5;
+      const justifiedStyle: React.CSSProperties | undefined =
+        layout === 'justified'
+          ? {
+              flexGrow: justifiedAr,
+              flexBasis: `calc(var(--grid-row-height, 300px) * ${justifiedAr})`,
+            }
+          : undefined;
+
       return (
-        <FadeIn key={asset.id} delay={index < 12 ? index * 50 : 0}>
+        <FadeIn key={asset.id} delay={index < 12 ? index * 50 : 0} style={justifiedStyle}>
           <div
             className={`photo-grid__item${
               layout === 'showcase' && index === 0 ? ' photo-grid__featured' : ''

--- a/app/[...path]/SubpageGridView.tsx
+++ b/app/[...path]/SubpageGridView.tsx
@@ -9,6 +9,8 @@ interface SubpageAlbum {
   albumName: string;
   assetCount: number;
   albumThumbnailAssetId: string | null;
+  /** EXPERIMENTAL: focal point for the cover crop (CSS object-position) */
+  coverPosition?: string;
 }
 
 interface Placeholder {
@@ -59,6 +61,7 @@ function AlbumGrid({
                   fill
                   sizes="(max-width: 600px) 100vw, (max-width: 1000px) 50vw, 33vw"
                   loading="lazy"
+                  {...(album.coverPosition ? { style: { objectPosition: album.coverPosition } } : {})}
                   {...(ph ? { placeholder: 'blur' as const, blurDataURL: ph.blurDataURL } : {})}
                 />
               ) : (

--- a/app/[...path]/page.tsx
+++ b/app/[...path]/page.tsx
@@ -181,6 +181,17 @@ export default async function PathPage({ params, searchParams }: PathPageProps) 
   const resolveLayout = (overrides?: Partial<GridConfig>) =>
     overrides?.layout ?? config.grid.layout;
 
+  // EXPERIMENTAL: per-album grid override — merged over the subpage grid so
+  // the precedence is global < subpage < album.
+  const mergeAlbumGrid = (
+    albumId: string,
+    spGrid?: Partial<GridConfig>,
+  ): Partial<GridConfig> | undefined => {
+    const albumGrid = config.albumGrids[albumId];
+    if (!albumGrid) return spGrid;
+    return { ...spGrid, ...albumGrid };
+  };
+
   if (!path || path.length === 0) {
     notFound();
   }
@@ -224,8 +235,8 @@ export default async function PathPage({ params, searchParams }: PathPageProps) 
       <AlbumDetailView
         album={album}
         images={images}
-        layout={resolveLayout(spGrid)}
-        gridStyle={buildGridStyle(spGrid)}
+        layout={resolveLayout(mergeAlbumGrid(album.id, spGrid))}
+        gridStyle={buildGridStyle(mergeAlbumGrid(album.id, spGrid))}
         backLinkHref={`/${subpageSlug}`}
         backLinkLabel={`Back to ${subpageName}`}
         watermark={config.watermark}
@@ -340,8 +351,8 @@ export default async function PathPage({ params, searchParams }: PathPageProps) 
         <AlbumDetailView
           album={album}
           images={images}
-          layout={resolveLayout(result.subpage.grid)}
-          gridStyle={buildGridStyle(result.subpage.grid)}
+          layout={resolveLayout(mergeAlbumGrid(album.id, result.subpage.grid))}
+          gridStyle={buildGridStyle(mergeAlbumGrid(album.id, result.subpage.grid))}
           subtitle={result.subpage.subtitle}
           backLinkHref="/"
           backLinkLabel="Back to Gallery"
@@ -411,8 +422,8 @@ export default async function PathPage({ params, searchParams }: PathPageProps) 
     <AlbumDetailView
       album={album}
       images={images}
-      layout={resolveLayout()}
-      gridStyle={buildGridStyle()}
+      layout={resolveLayout(mergeAlbumGrid(album.id))}
+      gridStyle={buildGridStyle(mergeAlbumGrid(album.id))}
       backLinkHref="/"
       backLinkLabel="Back to Gallery"
       watermark={config.watermark}

--- a/app/[...path]/page.tsx
+++ b/app/[...path]/page.tsx
@@ -367,7 +367,14 @@ export default async function PathPage({ params, searchParams }: PathPageProps) 
     // Override albumThumbnailAssetId with the configured hero image (if any)
     const albumsWithHero = albums.map((album) => {
       const heroId = config.albumHeroImages[album.id];
-      return heroId ? { ...album, albumThumbnailAssetId: heroId } : album;
+      // EXPERIMENTAL: coverPosition rides along so the card crop can honour
+      // the configured focal point.
+      const coverPosition = config.albumCoverPositions[album.id];
+      return {
+        ...album,
+        ...(heroId ? { albumThumbnailAssetId: heroId } : {}),
+        ...(coverPosition ? { coverPosition } : {}),
+      };
     });
 
     // Batch-fetch ThumbHash for album cover placeholders

--- a/app/admin/components/PageBuilder.tsx
+++ b/app/admin/components/PageBuilder.tsx
@@ -93,6 +93,8 @@ interface AlbumEntry {
   assetOrder?: string[];
   /** EXPERIMENTAL: per-album grid override (layout only in the UI for now) */
   grid?: { columns?: number; gap?: number; aspectRatio?: string; layout?: string };
+  /** EXPERIMENTAL: focal point for the cover crop, e.g. "50% 25%" or "top" */
+  coverPosition?: string;
 }
 
 interface Section {
@@ -157,7 +159,8 @@ function hasAlbumOptions(entry: AlbumEntry): boolean {
     entry.heroImage ||
     (entry.sort && entry.sort !== DEFAULT_ALBUM_SORT) ||
     entry.assetOrder?.length ||
-    entry.grid,
+    entry.grid ||
+    entry.coverPosition,
   );
 }
 
@@ -176,6 +179,7 @@ function parseAlbumEntries(raw: RawAlbumEntry[] | undefined): AlbumEntry[] {
       sort: isAlbumSortMode(value.sort) ? value.sort : undefined,
       assetOrder: value.assetOrder,
       grid: value.grid,
+      coverPosition: value.coverPosition,
     };
   });
 }
@@ -198,6 +202,7 @@ function serializeAlbumEntries(entries: AlbumEntry[]): RawAlbumEntry[] {
     // throw away a hand-curated order.
     if (entry.assetOrder?.length) val.assetOrder = entry.assetOrder;
     if (entry.grid) val.grid = entry.grid;
+    if (entry.coverPosition) val.coverPosition = entry.coverPosition;
     return { [entry.id]: val };
   });
 }
@@ -1607,6 +1612,15 @@ export default function PageBuilder() {
                     <option value="editorial-flow">Editorial Flow</option>
                     <option value="justified">Justified (Experimental)</option>
                   </select>
+                </div>
+
+                <div className="admin-field">
+                  <label>Cover focal point (Experimental)</label>
+                  <input
+                    value={album.coverPosition || ''}
+                    onChange={(e) => onUpdate({ coverPosition: e.target.value || undefined })}
+                    placeholder={'e.g. "50% 25%" or "top" — where the cover crop should anchor'}
+                  />
                 </div>
 
                 {/* Hero Image Selection */}

--- a/app/admin/components/PageBuilder.tsx
+++ b/app/admin/components/PageBuilder.tsx
@@ -105,6 +105,8 @@ interface Subpage {
   subtitle?: string;
   password?: string;
   enabled?: boolean;
+  /** EXPERIMENTAL: reachable by direct link, but not shown in navigation */
+  hidden?: boolean;
   essayText?: string;
   essayFile?: string;
   sections?: Section[];
@@ -325,6 +327,12 @@ function SortableSubpageTile({
         </span>
       )}
 
+      {sp.hidden === true && sp.enabled !== false && (
+        <span className="subpage-badge-protected" title="Hidden from navigation, reachable by direct link">
+          Unlisted
+        </span>
+      )}
+
       {sp.password && (
         <span className="subpage-badge-protected" title="Password protected">
           <IconLock size={12} /> Password
@@ -469,6 +477,7 @@ export default function PageBuilder() {
         subtitle: sp.subtitle as string | undefined,
         password: sp.password as string | undefined,
         enabled: sp.enabled !== false,
+        hidden: sp.hidden === true,
         essayText: sp.essayText as string | undefined,
         essayFile: sp.essayFile as string | undefined,
         albums: parseAlbumEntries(sp.albums as Array<string | Record<string, string>> | undefined),
@@ -493,6 +502,7 @@ export default function PageBuilder() {
           subtitle: sp.subtitle as string | undefined,
           password: sp.password as string | undefined,
           enabled: sp.enabled !== false,
+          hidden: sp.hidden === true,
           essayText: sp.essayText as string | undefined,
           essayFile: sp.essayFile as string | undefined,
           albums: parseAlbumEntries(
@@ -532,6 +542,7 @@ export default function PageBuilder() {
         if (sp.subtitle) entry.subtitle = sp.subtitle;
         if (sp.password) entry.password = sp.password;
         if (sp.enabled === false) entry.enabled = false;
+        if (sp.hidden === true) entry.hidden = true;
         if (sp.essayText) entry.essayText = sp.essayText;
         if (sp.essayFile) entry.essayFile = sp.essayFile;
         if (sp.grid) entry.grid = sp.grid;
@@ -1248,6 +1259,30 @@ export default function PageBuilder() {
                               </span>
                             </div>
                             <div className={`switch-toggle ${sp.enabled !== false ? 'on' : ''}`}>
+                              <span className="switch-slider" />
+                            </div>
+                          </button>
+                        </div>
+
+                        <div className="admin-field" style={{ marginTop: '1rem' }}>
+                          <label>Navigation Listing (Experimental)</label>
+                          <button
+                            type="button"
+                            className={`admin-toggle-card ${sp.hidden === true ? 'active' : ''}`}
+                            onClick={() => updateSubpage(spIndex, { hidden: sp.hidden !== true })}
+                            style={{ padding: '10px 14px', width: '100%', display: 'flex', alignItems: 'center', justifyContent: 'space-between', borderRadius: '8px', cursor: 'pointer' }}
+                          >
+                            <div className="toggle-card-info" style={{ textAlign: 'left' }}>
+                              <span className="toggle-card-title" style={{ fontWeight: 600 }}>
+                                {sp.hidden === true ? '🙈 Unlisted' : '📋 Listed in navigation'}
+                              </span>
+                              <span className="toggle-card-desc" style={{ fontSize: '0.8rem', display: 'block', opacity: 0.75 }}>
+                                {sp.hidden === true
+                                  ? 'Not shown in menus or on the homepage, but reachable via direct link'
+                                  : 'Shown in the header menu and homepage lists'}
+                              </span>
+                            </div>
+                            <div className={`switch-toggle ${sp.hidden === true ? 'on' : ''}`}>
                               <span className="switch-slider" />
                             </div>
                           </button>

--- a/app/admin/components/PageBuilder.tsx
+++ b/app/admin/components/PageBuilder.tsx
@@ -91,6 +91,8 @@ interface AlbumEntry {
   sort?: AlbumSortMode;
   /** Pinned asset UUIDs for `sort: manual`; everything else follows automatically. */
   assetOrder?: string[];
+  /** EXPERIMENTAL: per-album grid override (layout only in the UI for now) */
+  grid?: { columns?: number; gap?: number; aspectRatio?: string; layout?: string };
 }
 
 interface Section {
@@ -154,7 +156,8 @@ function hasAlbumOptions(entry: AlbumEntry): boolean {
     entry.password ||
     entry.heroImage ||
     (entry.sort && entry.sort !== DEFAULT_ALBUM_SORT) ||
-    entry.assetOrder?.length,
+    entry.assetOrder?.length ||
+    entry.grid,
   );
 }
 
@@ -172,6 +175,7 @@ function parseAlbumEntries(raw: RawAlbumEntry[] | undefined): AlbumEntry[] {
       heroImage: value.heroImage,
       sort: isAlbumSortMode(value.sort) ? value.sort : undefined,
       assetOrder: value.assetOrder,
+      grid: value.grid,
     };
   });
 }
@@ -193,6 +197,7 @@ function serializeAlbumEntries(entries: AlbumEntry[]): RawAlbumEntry[] {
     // Persisted regardless of the mode, so manual → newest → manual does not
     // throw away a hand-curated order.
     if (entry.assetOrder?.length) val.assetOrder = entry.assetOrder;
+    if (entry.grid) val.grid = entry.grid;
     return { [entry.id]: val };
   });
 }
@@ -1580,6 +1585,28 @@ export default function PageBuilder() {
                       placeholder="Leave empty for public access"
                     />
                   </div>
+                </div>
+
+                <div className="admin-field">
+                  <label>Layout override (Experimental)</label>
+                  <select
+                    value={album.grid?.layout || ''}
+                    onChange={(e) => {
+                      const layout = e.target.value || undefined;
+                      // Only the layout is exposed here; drop the grid object
+                      // entirely when it goes back to "inherit" so the YAML
+                      // stays clean.
+                      onUpdate({ grid: layout ? { ...(album.grid || {}), layout } : undefined });
+                    }}
+                  >
+                    <option value="">Inherit from page / global settings</option>
+                    <option value="masonry">Masonry</option>
+                    <option value="uniform">Uniform Grid</option>
+                    <option value="showcase">Showcase</option>
+                    <option value="filmstrip">Filmstrip</option>
+                    <option value="editorial-flow">Editorial Flow</option>
+                    <option value="justified">Justified (Experimental)</option>
+                  </select>
                 </div>
 
                 {/* Hero Image Selection */}

--- a/app/admin/components/SettingsEditor.tsx
+++ b/app/admin/components/SettingsEditor.tsx
@@ -73,7 +73,7 @@ interface Settings {
 const PRESETS = ['studio', 'studio-modern', 'minimal', 'editorial', 'classic', 'noir', 'monograph'];
 const LAYOUTS = ['masonry', 'uniform', 'showcase', 'filmstrip', 'editorial-flow', 'justified'];
 const PHOTO_FRAMES = ['none', 'passepartout', 'shadow'];
-const HERO_STYLES = ['split', 'fullbleed', 'minimal', 'stacked', 'typographic', 'mosaic'];
+const HERO_STYLES = ['split', 'fullbleed', 'minimal', 'stacked', 'typographic', 'mosaic', 'cover'];
 const ASPECT_RATIOS = ['1', '3/2', '2/3', '16/9', 'auto'];
 
 const THEME_INFO: Record<string, { desc: string; label: string; accent: string; bg: string; tile: string }> = {
@@ -659,6 +659,7 @@ export default function SettingsEditor() {
                       stacked: { label: 'Stacked', desc: 'Title stacked directly over photo' },
                       typographic: { label: 'Typographic', desc: 'Oversized magazine masthead' },
                       mosaic: { label: 'Mosaic', desc: 'Dynamic photo collage layout' },
+                      cover: { label: 'Cover (Experimental)', desc: 'Fullscreen splash with a single Enter link' },
                     }[s] || { label: s, desc: '' };
                     const isActive = (settings.theme?.heroStyle || 'split') === s;
 

--- a/app/admin/components/SettingsEditor.tsx
+++ b/app/admin/components/SettingsEditor.tsx
@@ -33,6 +33,8 @@ interface Settings {
     email?: string;
     website?: string;
   };
+  /** EXPERIMENTAL: external links appended to the header navigation */
+  navLinks?: Array<{ label?: string; url?: string }>;
   legal?: {
     enabled?: boolean;
     name?: string;
@@ -954,6 +956,59 @@ export default function SettingsEditor() {
                   />
                 </div>
               </div>
+
+              <div className="settings-section-header" style={{ marginTop: '2rem' }}>
+                <h3><Icons.IconLink size={18} /> Header Navigation Links (Experimental)</h3>
+                <p className="settings-section-sub">External links shown after your pages in the header menu. Only http(s) URLs are allowed; they open in a new tab.</p>
+              </div>
+
+              {(settings.navLinks || []).map((link, i) => (
+                <div className="admin-field-row" key={i}>
+                  <div className="admin-field">
+                    <label>Label</label>
+                    <input
+                      value={link.label || ''}
+                      onChange={(e) => {
+                        const next = [...(settings.navLinks || [])];
+                        next[i] = { ...next[i], label: e.target.value };
+                        update('navLinks', next);
+                      }}
+                      placeholder="Shop"
+                    />
+                  </div>
+                  <div className="admin-field">
+                    <label>URL</label>
+                    <input
+                      value={link.url || ''}
+                      onChange={(e) => {
+                        const next = [...(settings.navLinks || [])];
+                        next[i] = { ...next[i], url: e.target.value };
+                        update('navLinks', next);
+                      }}
+                      placeholder="https://shop.example.com"
+                    />
+                  </div>
+                  <button
+                    type="button"
+                    className="admin-btn admin-btn-sm"
+                    style={{ alignSelf: 'flex-end' }}
+                    onClick={() => {
+                      const next = (settings.navLinks || []).filter((_, j) => j !== i);
+                      update('navLinks', next.length > 0 ? next : undefined);
+                    }}
+                    title="Remove link"
+                  >
+                    Remove
+                  </button>
+                </div>
+              ))}
+              <button
+                type="button"
+                className="admin-btn admin-btn-sm"
+                onClick={() => update('navLinks', [...(settings.navLinks || []), { label: '', url: '' }])}
+              >
+                + Add external link
+              </button>
             </div>
           )}
 

--- a/app/admin/components/SettingsEditor.tsx
+++ b/app/admin/components/SettingsEditor.tsx
@@ -69,7 +69,7 @@ interface Settings {
 }
 
 const PRESETS = ['studio', 'studio-modern', 'minimal', 'editorial', 'classic', 'noir', 'monograph'];
-const LAYOUTS = ['masonry', 'uniform', 'showcase', 'filmstrip', 'editorial-flow'];
+const LAYOUTS = ['masonry', 'uniform', 'showcase', 'filmstrip', 'editorial-flow', 'justified'];
 const PHOTO_FRAMES = ['none', 'passepartout', 'shadow'];
 const HERO_STYLES = ['split', 'fullbleed', 'minimal', 'stacked', 'typographic', 'mosaic'];
 const ASPECT_RATIOS = ['1', '3/2', '2/3', '16/9', 'auto'];
@@ -785,6 +785,7 @@ export default function SettingsEditor() {
                       showcase: { label: 'Showcase', desc: 'Featured hero photos mixed with smaller tiles' },
                       filmstrip: { label: 'Filmstrip', desc: 'Horizontal scrollable film strip timeline' },
                       'editorial-flow': { label: 'Editorial Flow', desc: 'Magazine story layout with varying photo sizes' },
+                      justified: { label: 'Justified (Experimental)', desc: 'Equal-height rows that fill the full width' },
                     }[l] || { label: l, desc: '' };
                     const isActive = (settings.grid?.layout || 'masonry') === l;
 
@@ -825,6 +826,12 @@ export default function SettingsEditor() {
                               <div className="demo-editorial-flow">
                                 <div className="demo-tile wide" />
                                 <div className="demo-row"><div className="demo-tile" /><div className="demo-tile" /></div>
+                              </div>
+                            )}
+                            {l === 'justified' && (
+                              <div className="demo-editorial-flow">
+                                <div className="demo-row"><div className="demo-tile wide" /><div className="demo-tile" /></div>
+                                <div className="demo-row"><div className="demo-tile" /><div className="demo-tile wide" /></div>
                               </div>
                             )}
                           </div>

--- a/app/api/exif/[id]/route.ts
+++ b/app/api/exif/[id]/route.ts
@@ -14,10 +14,10 @@ import { checkRateLimit, getClientIp, retryAfterSeconds } from '@/lib/rate-limit
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const config = getConfig();
 
-  // Security: If EXIF is globally disabled, do not serve it via API either
-  if (!config.exifOnHover) {
-    return NextResponse.json({ error: 'EXIF metadata is disabled' }, { status: 403 });
-  }
+  // exifOnHover only gates the *technical* fields below. The asset description
+  // (EXPERIMENTAL caption) is editorial content, so the route stays reachable
+  // and serves captions even when EXIF display is disabled.
+  const exifEnabled = config.exifOnHover;
 
   // ── Rate limiting ──────────────────────────────────
   const ip = getClientIp(request);
@@ -64,17 +64,23 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
   }
 
   const exif = asset.exifInfo;
+  const caption = exif.description?.trim() || undefined;
   return NextResponse.json(
     {
-      make: exif.make,
-      model: exif.model,
-      lensModel: exif.lensModel,
-      focalLength: exif.focalLength,
-      fNumber: exif.fNumber,
-      exposureTime: exif.exposureTime,
-      iso: exif.iso,
-      city: exif.city,
-      country: exif.country,
+      ...(exifEnabled
+        ? {
+            make: exif.make,
+            model: exif.model,
+            lensModel: exif.lensModel,
+            focalLength: exif.focalLength,
+            fNumber: exif.fNumber,
+            exposureTime: exif.exposureTime,
+            iso: exif.iso,
+            city: exif.city,
+            country: exif.country,
+          }
+        : {}),
+      ...(caption ? { description: caption } : {}),
     },
     {
       headers: {

--- a/app/api/exif/__tests__/exif-route.test.ts
+++ b/app/api/exif/__tests__/exif-route.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * EXPERIMENTAL captions (L10): the route serves the Immich asset description
+ * as a caption. Captions are editorial, not technical — so exifOnHover: false
+ * must strip the technical fields but still serve the caption, instead of the
+ * old blanket 403.
+ */
+
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(),
+}));
+
+vi.mock('@/lib/immich', () => ({
+  immich: { getAssetInfo: vi.fn() },
+  ImmichUnavailableError: class ImmichUnavailableError extends Error {},
+}));
+
+vi.mock('@/lib/tokens', () => ({
+  decodeAssetId: vi.fn(() => 'asset-uuid'),
+}));
+
+vi.mock('@/lib/rate-limit', () => ({
+  checkRateLimit: vi.fn(() => ({ success: true, resetAt: 0 })),
+  getClientIp: vi.fn(() => '127.0.0.1'),
+  retryAfterSeconds: vi.fn(() => 60),
+}));
+
+import { GET } from '../[id]/route';
+import { getConfig } from '@/lib/config';
+import { immich } from '@/lib/immich';
+import { NextRequest } from 'next/server';
+
+const mockConfig = getConfig as unknown as ReturnType<typeof vi.fn>;
+const mockAssetInfo = immich.getAssetInfo as unknown as ReturnType<typeof vi.fn>;
+
+const EXIF_ASSET = {
+  exifInfo: {
+    make: 'Fujifilm',
+    model: 'X-T5',
+    lensModel: 'XF 35mm',
+    focalLength: 35,
+    fNumber: 2,
+    exposureTime: '1/250',
+    iso: 200,
+    city: 'Vienna',
+    country: 'Austria',
+    description: '  A quiet morning at the Danube.  ',
+  },
+};
+
+function makeRequest() {
+  return new NextRequest('http://localhost/api/exif/token123');
+}
+
+const params = { params: Promise.resolve({ id: 'token123' }) };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAssetInfo.mockResolvedValue(EXIF_ASSET);
+});
+
+describe('GET /api/exif/[id] captions', () => {
+  it('includes the trimmed description alongside technical fields', async () => {
+    mockConfig.mockReturnValue({ exifOnHover: true, rateLimitRpm: 120 });
+
+    const res = await GET(makeRequest(), params);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.model).toBe('X-T5');
+    expect(body.description).toBe('A quiet morning at the Danube.');
+  });
+
+  it('serves only the caption when exifOnHover is disabled', async () => {
+    mockConfig.mockReturnValue({ exifOnHover: false, rateLimitRpm: 120 });
+
+    const res = await GET(makeRequest(), params);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.description).toBe('A quiet morning at the Danube.');
+    expect(body).not.toHaveProperty('model');
+    expect(body).not.toHaveProperty('iso');
+  });
+
+  it('omits the description entirely when the asset has none', async () => {
+    mockConfig.mockReturnValue({ exifOnHover: true, rateLimitRpm: 120 });
+    mockAssetInfo.mockResolvedValue({
+      exifInfo: { ...EXIF_ASSET.exifInfo, description: null },
+    });
+
+    const res = await GET(makeRequest(), params);
+    const body = await res.json();
+    expect(body).not.toHaveProperty('description');
+  });
+});

--- a/app/globals.css
+++ b/app/globals.css
@@ -244,6 +244,76 @@
   overflow: hidden;
 }
 
+/* ── Cover / Splash hero (EXPERIMENTAL) ───────────── */
+/* Fullscreen welcome page: one image, the title, a single Enter link. */
+.hero--cover {
+  position: relative;
+  min-height: calc(100vh - 56px);
+  min-height: calc(100dvh - 56px);
+  overflow: hidden;
+}
+
+.hero--cover > span,
+.hero--cover > img {
+  position: absolute !important;
+  inset: 0;
+  width: 100% !important;
+  height: 100% !important;
+  object-fit: cover;
+}
+
+.hero__cover-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 64px 40px;
+  background: radial-gradient(ellipse at center, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.1) 75%);
+  color: #fff;
+}
+
+.hero--cover .hero__title,
+.hero--cover .hero__subtitle {
+  color: #fff;
+}
+
+.hero__cover-enter {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 36px;
+  padding: 12px 32px;
+  border: 1px solid rgba(255, 255, 255, 0.7);
+  border-radius: var(--radius-lg, 4px);
+  color: #fff;
+  font-family: var(--font-caption);
+  font-size: 0.85rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  text-decoration: none;
+  transition:
+    background var(--transition-normal),
+    color var(--transition-normal);
+}
+
+.hero__cover-enter:hover,
+.hero__cover-enter:focus-visible {
+  background: #fff;
+  color: #000;
+}
+
+.hero__cover-enter-arrow {
+  transition: transform var(--transition-normal);
+}
+
+.hero__cover-enter:hover .hero__cover-enter-arrow {
+  transform: translateX(4px);
+}
+
 /* HeroCarousel images fill the entire container */
 .hero--fullbleed > span,
 .hero--fullbleed > img {

--- a/app/globals.css
+++ b/app/globals.css
@@ -1084,6 +1084,51 @@
   }
 }
 
+/* ── Justified Rows Layout (EXPERIMENTAL) ───────── */
+/* Adobe-Portfolio-style rows: every row fills the container width, all
+   images in a row share the same height, aspect ratios stay intact.
+   Flex sizing (grow = aspect ratio) lives inline on the .fade-in wrapper. */
+.photo-grid--justified {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--grid-gap, 12px);
+  column-count: unset;
+  /* More columns → shorter rows, mirroring the density of the other layouts */
+  --grid-row-height: calc(900px / var(--grid-columns, 3));
+}
+
+/* Filler that soaks up leftover space so the last row keeps natural sizes
+   instead of stretching a lone image to full width */
+.photo-grid--justified::after {
+  content: '';
+  flex-grow: 999999;
+  min-width: 0;
+}
+
+.photo-grid--justified > .fade-in {
+  height: var(--grid-row-height);
+  min-width: 0;
+}
+
+.photo-grid--justified .photo-grid__item {
+  height: 100%;
+  margin-bottom: 0;
+  /* Inline aspect-ratio is not set for justified items; the row height and
+     flex-basis already encode the ratio */
+}
+
+@media (max-width: 1024px) {
+  .photo-grid--justified {
+    --grid-row-height: 240px;
+  }
+}
+
+@media (max-width: 640px) {
+  .photo-grid--justified {
+    --grid-row-height: 160px;
+  }
+}
+
 .photo-grid__item img {
   width: 100%;
   height: 100%;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -137,6 +137,38 @@ export default async function HomePage() {
 
   const heroStyle = config.theme.heroStyle;
 
+  // ── Cover (EXPERIMENTAL): fullscreen splash + single "Enter" link ─
+  // Adobe-Portfolio-style welcome page: one fullbleed image, the site
+  // title, and one link into the portfolio (the first nav entry).
+  if (heroStyle === 'cover') {
+    const entries = heroNavEntries(subpages, albums);
+    const enterHref = entries[0]?.href ?? '/about';
+
+    return (
+      <div className="hero hero--cover">
+        <HeroCarousel images={heroData} />
+        <div className="hero__cover-overlay">
+          <FadeIn delay={0}>
+            <h1 className="hero__title">{config.siteTitle}</h1>
+          </FadeIn>
+          {config.siteSubtitle && (
+            <FadeIn delay={100}>
+              <p className="hero__subtitle">{config.siteSubtitle}</p>
+            </FadeIn>
+          )}
+          <FadeIn delay={250}>
+            <Link href={enterHref} className="hero__cover-enter">
+              Enter
+              <span className="hero__cover-enter-arrow" aria-hidden="true">
+                →
+              </span>
+            </Link>
+          </FadeIn>
+        </div>
+      </div>
+    );
+  }
+
   // ── Typographic: no image, pure text ───────────────────────────
   if (heroStyle === 'typographic') {
     return (

--- a/components/FadeIn.tsx
+++ b/components/FadeIn.tsx
@@ -18,9 +18,11 @@ interface FadeInProps {
   direction?: 'up' | 'none';
   /** CSS class name for the wrapper */
   className?: string;
+  /** Extra inline styles for the wrapper (e.g. flex sizing in justified grids) */
+  style?: React.CSSProperties;
 }
 
-export function FadeIn({ children, delay = 0, direction = 'up', className }: FadeInProps) {
+export function FadeIn({ children, delay = 0, direction = 'up', className, style }: FadeInProps) {
   const ref = useRef<HTMLDivElement>(null);
 
   const reveal = useCallback(() => {
@@ -55,7 +57,7 @@ export function FadeIn({ children, delay = 0, direction = 'up', className }: Fad
     <div
       ref={ref}
       className={`fade-in ${direction === 'up' ? 'fade-in--up' : ''} ${className ?? ''}`}
-      style={{ transitionDelay: `${delay}ms` }}
+      style={{ ...style, transitionDelay: `${delay}ms` }}
     >
       {children}
     </div>

--- a/components/Lightbox.module.css
+++ b/components/Lightbox.module.css
@@ -184,6 +184,17 @@
   animation: exif-slide-up var(--transition-normal) ease forwards;
 }
 
+/* EXPERIMENTAL: editorial caption (Immich asset description) above the tech rows */
+.exifCaption {
+  margin: 0 0 12px;
+  max-width: 280px;
+  font-family: var(--font-caption);
+  font-size: 0.85rem;
+  line-height: 1.5;
+  font-style: italic;
+  color: rgba(255, 255, 255, 0.85);
+}
+
 @keyframes exif-slide-up {
   from {
     opacity: 0;

--- a/components/Lightbox.tsx
+++ b/components/Lightbox.tsx
@@ -288,6 +288,9 @@ export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev, waterm
             </div>
           ) : exifData ? (
             <>
+              {exifData.description && (
+                <p className={styles.exifCaption}>{exifData.description}</p>
+              )}
               {exifData.model && (
                 <div className={styles.exifRow}>
                   <span className={styles.exifLabel}>Camera</span>

--- a/components/SubpageNav.tsx
+++ b/components/SubpageNav.tsx
@@ -5,12 +5,16 @@
 
 import Link from 'next/link';
 import { immich } from '@/lib/immich';
+import { getConfig } from '@/lib/config';
 
 export async function SubpageNav() {
   const [subpages, standaloneAlbums] = await Promise.all([
     immich.getSubpages(),
     immich.getStandaloneAlbums(),
   ]);
+  // EXPERIMENTAL: external nav links from settings.yaml, appended after the
+  // internal entries. Sanitised to http(s) in getConfig().
+  const navLinks = getConfig().navLinks;
 
   return (
     <>
@@ -23,6 +27,17 @@ export async function SubpageNav() {
         <Link key={album.id} href={`/${album.slug}`} className="header__nav-link">
           {album.albumName}
         </Link>
+      ))}
+      {navLinks.map((link) => (
+        <a
+          key={link.url}
+          href={link.url}
+          className="header__nav-link header__nav-link--external"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {link.label}
+        </a>
       ))}
     </>
   );

--- a/content/gallery.yaml.example
+++ b/content/gallery.yaml.example
@@ -61,6 +61,7 @@ subpages:
           # grid: # EXPERIMENTAL: per-album grid override (wins over page/global grid)
           #   layout: "justified"
           #   columns: 2
+          # coverPosition: "50% 25%" # EXPERIMENTAL: focal point for the cover crop ("top", "center bottom", "50% 25%")
 
 # ── Subpage with Sections ──────────────────────────────────────────
 # Use sections to group albums by location, theme, or any other logic.

--- a/content/gallery.yaml.example
+++ b/content/gallery.yaml.example
@@ -51,6 +51,7 @@ subpages:
     title: "My Creative Projects" # Optional: Header title, defaults to Navigation key ("Projects")
     subtitle: "A collection of 2026 highlights in 35mm film." # Optional: Sub-text for headers
     password: "your-password" # Optional protection
+    # hidden: true # EXPERIMENTAL: reachable by direct link, but not shown in navigation
     albums:
       - "album-uuid-5"
       - "album-uuid-6":

--- a/content/gallery.yaml.example
+++ b/content/gallery.yaml.example
@@ -58,6 +58,9 @@ subpages:
           title: "Private Project #7"
           description: "Shot on 35mm film in Vienna, spring 2025." # Optional: shown below album title
           password: "scrypt:..." # Recommended: secure hash (generated via logs)
+          # grid: # EXPERIMENTAL: per-album grid override (wins over page/global grid)
+          #   layout: "justified"
+          #   columns: 2
 
 # ── Subpage with Sections ──────────────────────────────────────────
 # Use sections to group albums by location, theme, or any other logic.

--- a/content/settings.yaml.example
+++ b/content/settings.yaml.example
@@ -44,7 +44,7 @@ grid:
   columns: 3
   gap: 12
   aspectRatio: "1" # "1" (square), "3/2", "2/3", "16/9", "auto"
-  layout: "masonry" # masonry, uniform, showcase, filmstrip, editorial-flow
+  layout: "masonry" # masonry, uniform, showcase, filmstrip, editorial-flow, justified (EXPERIMENTAL)
 
 # ── Footer & Social ──────────────────────────────────────────────
 footer:

--- a/content/settings.yaml.example
+++ b/content/settings.yaml.example
@@ -36,7 +36,7 @@ theme:
   # accent: "#e60012"
   # photoFrame: "passepartout" # none, passepartout, shadow
   # grain: true
-  # heroStyle: "split" # split, fullbleed, minimal, stacked, typographic, mosaic
+  # heroStyle: "split" # split, fullbleed, minimal, stacked, typographic, mosaic, cover (EXPERIMENTAL)
   #   Note: "mosaic" needs at least 3 hero images in gallery.yaml (optimal: 6)
 
 # ── Grid configuration ───────────────────────────────────────────

--- a/content/settings.yaml.example
+++ b/content/settings.yaml.example
@@ -46,6 +46,15 @@ grid:
   aspectRatio: "1" # "1" (square), "3/2", "2/3", "16/9", "auto"
   layout: "masonry" # masonry, uniform, showcase, filmstrip, editorial-flow, justified (EXPERIMENTAL)
 
+# ── Navigation ────────────────────────────────────────────────────
+# EXPERIMENTAL: external links appended to the header navigation.
+# Only http(s) URLs are allowed; they open in a new tab.
+# navLinks:
+#   - label: "Shop"
+#     url: "https://shop.example.com"
+#   - label: "Instagram"
+#     url: "https://instagram.com/your-handle"
+
 # ── Footer & Social ──────────────────────────────────────────────
 footer:
   name: "My Photography"

--- a/docs/superpowers/plans/2026-08-13-adobe-portfolio-experimental.md
+++ b/docs/superpowers/plans/2026-08-13-adobe-portfolio-experimental.md
@@ -1,0 +1,198 @@
+# Adobe-Portfolio-Features (experimental) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Sieben Adobe-Portfolio-Lücken (L7, L3, L10, L8, L11, L2, L1) als klar gekennzeichnete experimentelle Features auf `dev` schließen.
+
+**Architecture:** Alle Features erweitern die bestehende YAML→`AppConfig`-Pipeline (`lib/config/`), werden in den bestehenden Views gerendert und im Admin-Panel editierbar gemacht. Kein neues Routing, keine neue Persistenz. Jedes Feature ist ein eigener Commit mit Scope `feat(experimental): …` auf Branch `experimental/adobe-portfolio`.
+
+**Tech Stack:** Next.js 16, TypeScript strict, Vanilla CSS, Vitest.
+
+## Global Constraints
+
+- Basis: `origin/dev`, Branch `experimental/adobe-portfolio`, Commits `feat(experimental): …`
+- Justified ist **zusätzliches** Layout, ersetzt nichts (Nutzer-Entscheidung Q1)
+- Jede neue Option muss im Admin-Panel editierbar sein (Nutzer-Entscheidung Q2)
+- Struktur bleibt zweistufig — keine verschachtelte Navigation (Q3 vertagt)
+- Vor jedem Commit: `npx tsc --noEmit` = 0 Fehler; betroffene Tests grün
+- Neue YAML-Optionen in den `.example`-Dateien mit `# EXPERIMENTAL`-Kommentar dokumentieren
+- Keine rohen Asset-UUIDs im Client-HTML (bestehende Sicherheitsregel)
+
+---
+
+### Task 1: Justified-Rows-Layout (L7)
+
+**Files:**
+- Modify: `lib/config/schema.ts` (layout-Union, 3 Stellen)
+- Modify: `lib/config/theme.ts:85` (`VALID_LAYOUTS`)
+- Modify: `app/[...path]/PhotoGrid.tsx` (Props-Union, Item-Styles)
+- Modify: `app/globals.css` (`.photo-grid--justified`)
+- Modify: `app/admin/components/SettingsEditor.tsx:72` (`LAYOUTS`) + Layout-Karte
+- Modify: `content/settings.yaml.example`
+- Test: `lib/__tests__/config.test.ts` (Layout-Validierung)
+
+**Interfaces:**
+- Produces: Layout-Wert `'justified'` in `GridConfig['layout']`; CSS-Klasse `photo-grid--justified`; nutzt `--grid-gap` und neue Var `--grid-row-height` (Default 300px, via `columns` skaliert: `calc(2000px / var(--grid-columns)))`.
+
+**Technik:** Flexbox-Justified ohne JS-Messung: Container `display:flex; flex-wrap:wrap`. Jedes Item bekommt inline `flex-grow: aspectRatio` und `flex-basis: calc(var(--row-h) * AR)`, Höhe wächst mit. Letzte Zeile wird per `::after { content:''; flex-grow: 1e4 }` am Aufblähen gehindert.
+
+- [ ] **Step 1: Failing test** — in `lib/__tests__/config.test.ts` (Muster der Datei übernehmen): settings mit `grid.layout: 'justified'` → `getConfig().grid.layout === 'justified'` (heute fällt es auf `'masonry'` zurück).
+- [ ] **Step 2: Test läuft rot** — `npm run test:unit -- config`
+- [ ] **Step 3: Implementierung**
+  - `theme.ts`: `'justified'` in `VALID_LAYOUTS` aufnehmen.
+  - `schema.ts`: Union an allen drei Stellen um `'justified'` erweitern (Zeilen 80, 179, 219 sind `layout`-Vorkommen).
+  - `PhotoGrid.tsx`: Props-Union erweitern; im Item-Style-Block:
+    ```tsx
+    ...(layout === 'justified' && asset.aspectRatio
+      ? {
+          flexGrow: asset.aspectRatio,
+          flexBasis: `calc(var(--grid-row-height, 300px) * ${asset.aspectRatio})`,
+        }
+      : {}),
+    ```
+    Achtung: `FadeIn` wrappt das Item — prüfen, ob FadeIn ein eigenes DOM-Element rendert; falls ja, müssen flex-Styles auf dem FadeIn-Wrapper landen (via `style`-Prop oder CSS `display:contents`).
+  - `globals.css`:
+    ```css
+    .photo-grid--justified {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--grid-gap, 12px);
+      --grid-row-height: calc(900px / var(--grid-columns, 3));
+    }
+    .photo-grid--justified .photo-grid__item {
+      position: relative;
+      height: var(--grid-row-height);
+      min-width: 120px;
+    }
+    .photo-grid--justified::after { content: ''; flex-grow: 999999; }
+    ```
+    (Genaue Selektoren an FadeIn-Realität anpassen; Mobile-Breakpoints analog zu `--filmstrip` ergänzen.)
+  - `SettingsEditor.tsx`: `'justified'` in `LAYOUTS` + Karte `{ label: 'Justified', desc: 'Row-based layout with equal heights (EXPERIMENTAL)' }` + Mini-Demo analog bestehender.
+  - `settings.yaml.example`: Kommentar `# masonry, uniform, showcase, filmstrip, editorial-flow, justified (EXPERIMENTAL)`.
+- [ ] **Step 4: Test grün + tsc** — `npm run test:unit -- config && npx tsc --noEmit`
+- [ ] **Step 5: Visuelle Prüfung** — Dev-Server, Layout in settings.yaml auf justified, Screenshot.
+- [ ] **Step 6: Commit** — `feat(experimental): add justified rows gallery layout`
+
+### Task 2: Versteckte Subpages (L3)
+
+**Files:**
+- Modify: `lib/config/schema.ts` (`SubpageConfig.hidden`, `SubpageObjectValue.hidden`, `GalleryYaml`-Subpage)
+- Modify: `lib/config/index.ts` (`deriveGallery`: beide Zweige `hidden: sp.hidden === true`)
+- Modify: `components/SubpageNav.tsx` (Filter `!sp.hidden`)
+- Modify: `app/page.tsx` (`heroNavEntries`/Homepage-Listen filtern)
+- Modify: `app/admin/components/PageBuilder.tsx` (Toggle „Hidden from navigation" neben `enabled`, Round-Trip in Parse/Serialize ~Z. 470/533)
+- Modify: `content/gallery.yaml.example`
+- Test: `lib/__tests__/derive-gallery.test.ts`
+
+**Interfaces:**
+- Produces: `SubpageConfig.hidden?: boolean`. Semantik: `hidden` → nicht in Nav/Homepage/Hero-Listen, aber per Slug erreichbar (`isValidSubpage`/`getSubpage` unverändert). `enabled:false` bleibt 404.
+
+- [ ] **Step 1: Failing test** — deriveGallery mit `{ name: 'X', hidden: true, albums: [uuid] }` → `subpages[0].hidden === true`; ohne Angabe → `undefined`/falsy.
+- [ ] **Step 2: rot** — `npm run test:unit -- derive-gallery`
+- [ ] **Step 3: Implementierung** — Schema + beide deriveGallery-Zweige + Nav/Homepage-Filter + PageBuilder-Toggle (Badge „hidden" analog zum bestehenden `enabled === false`-Badge ~Z. 322) + Beispiel-Kommentar `hidden: true # EXPERIMENTAL: reachable by direct link, not shown in navigation`.
+- [ ] **Step 4: grün + tsc**
+- [ ] **Step 5: Commit** — `feat(experimental): hide subpages from navigation while keeping them reachable`
+
+### Task 3: Bildunterschriften in der Lightbox (L10)
+
+**Files:**
+- Modify: `app/api/exif/[id]/route.ts` (Description mitliefern; Gate auftrennen)
+- Modify: `hooks/useExif.ts` (`description?: string | null`)
+- Modify: `components/Lightbox.tsx` (Caption-Anzeige)
+- Modify: `components/Lightbox.module.css`
+- Test: `app/api/exif/__tests__/route.test.ts` (neu; Muster von bestehenden Route-Tests, z. B. admin-auth)
+
+**Interfaces:**
+- Consumes: `immich.getAssetInfo(id)` → Immich liefert `exifInfo.description`.
+- Produces: Response-Feld `description`; bei `exifOnHover: false` NICHT mehr 403, sondern `{ description }` ohne Technikfelder (Kopplung Caption/EXIF aufgetrennt, siehe Gap-Analyse L10).
+
+- [ ] **Step 1: Failing tests** — Route-Test: (a) exifOnHover=true → Response enthält `description`; (b) exifOnHover=false → 200 mit NUR `description`, keine `model`/`iso`-Felder.
+- [ ] **Step 2: rot**
+- [ ] **Step 3: Implementierung**
+  - Route: 403-Gate ersetzen durch `const exifEnabled = config.exifOnHover;` Antwort:
+    ```ts
+    const caption = exif.description?.trim() || undefined;
+    return NextResponse.json(
+      exifEnabled
+        ? { make: …, model: …, …, country: exif.country, description: caption }
+        : { description: caption },
+      { headers: { … } },
+    );
+    ```
+    404-Fall (`!asset?.exifInfo`) bleibt.
+  - Lightbox: unter dem Bild (oder im Panel oben) `{exifData?.description && <p className={styles.caption}>{exifData.description}</p>}` — Caption auch ohne offenes Panel sichtbar machen: separater Fetch-on-Navigate existiert schon (`fetchExif` bei Bildwechsel, Z. 67/77) — prüfen; falls Fetch nur bei offenem Panel läuft, Caption nur im Panel zeigen (YAGNI).
+- [ ] **Step 4: grün + tsc**
+- [ ] **Step 5: Commit** — `feat(experimental): show Immich asset descriptions as lightbox captions`
+
+### Task 4: Grid-Override pro Album (L8)
+
+**Files:**
+- Modify: `lib/config/schema.ts` (`AlbumEntryObject.grid`, `AppConfig.albumGrids`)
+- Modify: `lib/config/index.ts` (`processAlbumEntry` sammelt `albumGrids[uuid] = buildSubpageGrid(value.grid).grid`; Derivation + getConfig + Dummy-Config)
+- Modify: `app/[...path]/page.tsx` (AlbumDetailView-Pfade: `buildGridStyle({ ...spGrid, ...albumGrid })`, Layout-Merge ebenso)
+- Modify: `app/admin/components/PageBuilder.tsx` (Layout-Select im Album-Editor, wo title/description/password editiert werden)
+- Modify: `content/gallery.yaml.example`
+- Test: `lib/__tests__/derive-gallery.test.ts`
+
+**Interfaces:**
+- Produces: `AppConfig.albumGrids: Record<string, Partial<GridConfig>>`; Merge-Reihenfolge global < subpage < album.
+
+- [ ] **Step 1: Failing test** — Album-Entry `{ uuid: { title: 'T', grid: { layout: 'filmstrip', columns: 2 } } }` → `albumGrids[uuid]` = `{ layout: 'filmstrip', columns: 2 }`.
+- [ ] **Step 2: rot**
+- [ ] **Step 3: Implementierung** — GalleryDerivation um `albumGrids` erweitern (alle Rückgaben inkl. Dummy in getConfig), page.tsx an den drei `buildGridStyle`-Aufrufstellen (Z. 228/344/415) Album-Override mergen wo ein konkretes Album gerendert wird, PageBuilder Select (Werte = `VALID_LAYOUTS` + leer für „inherit"), Beispiel mit `# EXPERIMENTAL`.
+- [ ] **Step 4: grün + tsc**
+- [ ] **Step 5: Commit** — `feat(experimental): per-album grid overrides`
+
+### Task 5: Cover-Fokuspunkt pro Album (L11)
+
+**Files:**
+- Modify: `lib/config/schema.ts` (`AlbumEntryObject.coverPosition`, `AppConfig.albumCoverPositions`)
+- Modify: `lib/config/index.ts` (validieren: Pattern `/^\d{1,3}% \d{1,3}%$/` oder Schlüsselwörter `center|top|bottom|left|right`-Kombis; bei Verstoß throw analog `sort`)
+- Modify: `app/[...path]/SubpageGridView.tsx` + Homepage-Albumkarten (`style={{ objectPosition }}` aufs Cover-`<Image>`)
+- Modify: `app/admin/components/PageBuilder.tsx` (Textfeld im Album-Editor)
+- Modify: `content/gallery.yaml.example`
+- Test: `lib/__tests__/derive-gallery.test.ts`
+
+- [ ] **Step 1: Failing test** — `coverPosition: '50% 25%'` → `albumCoverPositions[uuid] === '50% 25%'`; `coverPosition: 'javascript:x'` → throw.
+- [ ] **Step 2: rot**
+- [ ] **Step 3: Implementierung** — Durchstich Schema→Derivation→beide Cover-Renderstellen→PageBuilder→Beispiel (`coverPosition: "50% 25%" # EXPERIMENTAL: focal point for cover crop`).
+- [ ] **Step 4: grün + tsc**
+- [ ] **Step 5: Commit** — `feat(experimental): per-album cover focal point`
+
+### Task 6: Externe Navigations-Links (L2)
+
+**Files:**
+- Modify: `lib/config/schema.ts` (`SettingsYaml.navLinks`, `AppConfig.navLinks: Array<{ label: string; url: string }>`)
+- Modify: `lib/config/index.ts` (übernehmen; nur `http(s)://`-URLs zulassen, sonst Eintrag verwerfen + `console.warn`; Dummy-Config: `[]`)
+- Modify: `components/SubpageNav.tsx` oder `app/layout.tsx` (nach den internen Links: `<a href target="_blank" rel="noopener noreferrer" className="header__nav-link header__nav-link--external">`)
+- Modify: `app/admin/components/SettingsEditor.tsx` (Liste label+url mit Add/Remove)
+- Modify: `content/settings.yaml.example`
+- Test: `lib/__tests__/config.test.ts`
+
+- [ ] **Step 1: Failing test** — settings mit `navLinks: [{label: 'Shop', url: 'https://x.y'}, {label: 'Bad', url: 'javascript:alert(1)'}]` → config.navLinks enthält nur den Shop-Eintrag.
+- [ ] **Step 2: rot**
+- [ ] **Step 3: Implementierung** — inkl. `# EXPERIMENTAL`-Beispielblock.
+- [ ] **Step 4: grün + tsc**
+- [ ] **Step 5: Commit** — `feat(experimental): external links in header navigation`
+
+### Task 7: Cover-/Splash-Hero (L1)
+
+**Files:**
+- Modify: `lib/config/schema.ts` (`ThemeConfig.heroStyle` Union + `'cover'`)
+- Modify: `lib/config/theme.ts` (heroStyle-Validierung, falls vorhanden)
+- Modify: `app/page.tsx` (Branch `heroStyle === 'cover'`: 100dvh-Fullbleed mit Titel, Untertitel, „Enter"-Anchor auf `#gallery`; bestehende Content-Sektion bekommt `id="gallery"`)
+- Modify: `app/globals.css` (`.hero--cover`, Scroll-Hint-Pfeil, `scroll-behavior: smooth` falls nicht vorhanden)
+- Modify: `app/admin/components/SettingsEditor.tsx` (heroStyle-Karte `cover`, ~Z. 659)
+- Modify: `content/settings.yaml.example`
+
+**Hinweis:** Bewusst KEINE Nav-Unterdrückung im Layout (Server-Layout kennt die Route nicht sauber) — der Cover füllt den Viewport unterhalb des Headers; das ist der YAGNI-Schnitt. Kein Test nötig (reines Rendering), aber visuelle Prüfung Pflicht.
+
+- [ ] **Step 1: Implementierung** wie beschrieben, erste Hero-Grafik als Hintergrund (bestehender `heroData[0]`-Pfad mit `imageUrl`).
+- [ ] **Step 2: tsc + Dev-Server-Screenshot**
+- [ ] **Step 3: Commit** — `feat(experimental): cover splash hero style`
+
+### Task 8: Abschluss
+
+- [ ] `npm run test:unit` komplett, `npm run lint`, `npm run build`
+- [ ] Beispieldateien-Konsistenz prüfen (alle neuen Optionen dokumentiert, alle mit EXPERIMENTAL markiert)
+- [ ] PR gegen `dev` mit Label/Titel-Präfix „experimental", Verweis auf Gap-Analyse

--- a/docs/superpowers/specs/2026-08-13-adobe-portfolio-gap-analysis.md
+++ b/docs/superpowers/specs/2026-08-13-adobe-portfolio-gap-analysis.md
@@ -1,0 +1,196 @@
+# Adobe Portfolio — Feature-Gap-Analyse (Seiten & Struktur, Galerien)
+
+**Datum:** 2026-08-13
+**Status:** Analyse — keine Implementierung, keine Entscheidung getroffen
+**Scope:** Nur die beiden Bereiche „Seiten & Struktur" und „Galerien". Branding/Theming, SEO,
+Kontaktformular, Domain-Handling und Analytics sind bewusst ausgeklammert.
+
+## Zweck
+
+Immich Folio und Adobe Portfolio lösen dasselbe Problem — Fotoalben aus einem
+Katalog als kuratierte Website ausspielen. Adobe Portfolio zieht aus Lightroom-Alben,
+Immich Folio aus Immich-Alben. Dieses Dokument hält fest, welche Funktionen der
+beiden Bereiche bereits existieren und wo echte Lücken sind, als Grundlage für die
+Priorisierung.
+
+Alle „vorhanden"-Aussagen sind am Code des Branches `claude/adobe-portfolio-features-1d1a47`
+verifiziert, nicht aus der Dokumentation übernommen.
+
+---
+
+## 1. Seiten & Struktur
+
+### Vorhanden
+
+| Funktion                | Umsetzung                                                                   |
+| ----------------------- | --------------------------------------------------------------------------- |
+| Subpages mit Slug       | `gallery.yaml` → `subpages`, Slug via `slugify()` (`lib/config/schema.ts:222`) |
+| Sections innerhalb Seite | `SubpageSectionConfig`, rendert typografisches Inhaltsverzeichnis            |
+| Titel/Untertitel je Seite | `title`, `subtitle` pro Subpage                                            |
+| Passwortschutz je Seite  | `password`, HMAC-Cookie `lb_auth_<slug>` (`lib/auth.ts`)                     |
+| Passwortschutz je Album  | `lb_auth_album_<slug>`                                                      |
+| Seite deaktivieren       | `enabled: false` — Seite verschwindet vollständig (`lib/immich.ts:461`)      |
+| Grid-Override je Seite   | `grid` pro Subpage überschreibt globales Grid                               |
+| Essay-/Storytelling-Seiten | `essayFile` / `essayText`, Layout `essay` (`app/[...path]/EssayView.tsx`)  |
+| About-Seite              | `content/about.md` mit Frontmatter (`app/about/page.tsx`)                   |
+| Impressum                | `/impressum`, gesteuert über `legal.enabled`                                |
+| Kartenansicht            | `/map`, gesteuert über `map: true`                                          |
+| Routing                  | Ein Catch-all (`app/[...path]/page.tsx`) für alle drei Seitenformen         |
+
+Die Struktur ist damit **zweistufig**: Subpage → Album, plus Sections als
+Gruppierung *innerhalb* einer Subpage.
+
+### Lücken
+
+**L1 — Cover-/Splash-Page.**
+Adobe Portfolio bietet als Alternative zur Startseite mit Navigation eine
+Welcome-Page: ein einzelnes formatfüllendes Bild mit Titel und einem Eintritts-Link,
+Navigation ausgeblendet. Immich Folio hat sechs Hero-Stile, aber keinen Modus, der
+die Navigation unterdrückt und einen expliziten Eintritt erzwingt.
+*Berührt:* `app/page.tsx`, `layout.tsx`, `ThemeConfig.heroStyle` oder ein neues
+Settings-Feld.
+
+**L2 — Externe Links in der Navigation.**
+`SubpageNav` rendert ausschließlich Subpages und Standalone-Alben als interne
+`Link`s (`components/SubpageNav.tsx`). Ein Menüeintrag, der auf Instagram, einen
+Shop oder ein Behance-Profil zeigt, ist nicht abbildbar.
+*Berührt:* `SubpageNav`, `GalleryYaml`-Schema.
+
+**L3 — Navigationsreihenfolge und -sichtbarkeit.**
+Die Reihenfolge ergibt sich implizit aus der YAML-Reihenfolge, und Subpages stehen
+immer vor Standalone-Alben. Es gibt kein „im Menü verstecken, per Direktlink
+erreichbar" — `enabled: false` entfernt die Seite komplett (404), was für
+Client-Vorschauen oder unveröffentlichte Arbeiten das falsche Verhalten ist.
+*Berührt:* `SubpageConfig` (neues Feld, z. B. `hidden`), `SubpageNav`, `lib/immich.ts:663`.
+
+**L4 — Verschachtelte Navigation.**
+Adobe Portfolio erlaubt Dropdown-Menüs (Seite mit Untereinträgen). Immich Folio
+ist strikt flach; Sections gruppieren nur innerhalb einer Seite und tauchen im
+Menü nicht auf.
+*Bewertung:* Die geringste Dringlichkeit der vier — Sections decken den Großteil
+des Bedarfs ab, und eine dritte Ebene verkompliziert Routing und Breadcrumbs
+erheblich.
+
+**L5 — Redirects.**
+Keine Möglichkeit, alte URLs auf neue Slugs zu mappen. Relevant, sobald jemand
+eine bestehende Site migriert oder eine Seite umbenennt — beim Umbenennen ändert
+sich der Slug still, und alle geteilten Links brechen.
+*Berührt:* `proxy.ts` oder `next.config` Redirects aus Settings.
+
+**L6 — Freie Inhaltsseiten.**
+`about.md` und Essays decken zwei feste Formen ab. Eine beliebig anlegbare
+Textseite („Kontakt", „Preise", „Prints") gibt es nicht.
+*Bewertung:* Essays sind funktional bereits sehr nah dran — dies ist eher eine
+Verallgemeinerung des Bestehenden als ein neues Feature.
+
+---
+
+## 2. Galerien
+
+### Vorhanden
+
+| Funktion                    | Umsetzung                                                          |
+| --------------------------- | ------------------------------------------------------------------ |
+| 6 Layouts                   | `masonry`, `uniform`, `showcase`, `filmstrip`, `editorial-flow`, `essay` (`GridConfig.layout`) |
+| Spalten, Gap, Seitenverhältnis | `grid.columns`, `grid.gap`, `grid.aspectRatio`                   |
+| Cover-Bild je Album         | `heroImage` in `AlbumEntryObject`                                  |
+| Titel-Override je Album     | `albumOverrides`                                                   |
+| Beschreibung je Album       | `albumDescriptions`                                                |
+| Sortierung                  | `album.order` (`asc`/`desc`) aus Immich, explizit nachsortiert über `fileCreatedAt` (`lib/immich.ts:608`) |
+| Lightbox                    | Tastatur-Navigation, EXIF-Panel (`i`), Favoriten (`components/Lightbox.tsx`) |
+| EXIF beim Hover             | `exifOnHover`                                                      |
+| Bildschutz                  | `protection.disableRightClick`, `disableImageDrag`                 |
+| Wasserzeichen               | `watermark.text`, `opacity`, `position`                            |
+| Client-Proofing             | `proofing.enabled` — Favoritenauswahl, in Adobe Portfolio gar nicht enthalten |
+| Blur-Platzhalter            | `lib/thumbhash.ts`                                                 |
+
+### Lücken
+
+**L7 — Justified-Rows-Layout.**
+Adobes charakteristisches Galerie-Layout: Bilder werden zeilenweise so skaliert,
+dass jede Zeile exakt die Containerbreite füllt und alle Bilder einer Zeile
+dieselbe Höhe haben. Das Seitenverhältnis bleibt dabei unangetastet. `masonry`
+löst dasselbe Problem spaltenweise und erzeugt ein deutlich anderes, weniger
+„redaktionelles" Bild. Die vorhandenen `aspectRatio`-Daten pro Asset
+(`PhotoGrid.tsx:31`) sind die Voraussetzung dafür und bereits da.
+*Bewertung:* Die inhaltlich größte und sichtbarste Lücke der gesamten Analyse.
+*Berührt:* `GridConfig.layout` (neuer Wert), `PhotoGrid.tsx`, `app/globals.css`.
+*Offene Frage:* CSS-only mit `flex-grow`-Trick oder berechnete Zeilenumbrüche —
+CSS-only bricht bei der letzten Zeile und ohne bekannte Bildhöhen serverseitig.
+
+**L8 — Grid-Override auf Album-Ebene.**
+`grid` lässt sich global und pro Subpage setzen, aber nicht pro Album. Ein Album
+mit Panoramen braucht andere Spaltenzahl als eines mit Porträts.
+*Berührt:* `AlbumEntryObject`, Merge-Logik in `lib/config/index.ts`.
+
+**L9 — Konfigurierbare Hover-Effekte.**
+Der Hover-Zustand ist fest verdrahtet (plus optionales EXIF-Overlay). Adobe
+Portfolio bietet Zoom, Fade, Titel-Overlay und „kein Effekt" zur Auswahl.
+*Bewertung:* Rein kosmetisch, aber billig — im Wesentlichen ein
+`data`-Attribut plus CSS je Variante.
+
+**L10 — Bildunterschriften.**
+Das Lightbox-Panel zeigt EXIF-Technikdaten (Kamera, Objektiv, ISO), aber keine
+redaktionelle Bildunterschrift. Immich pflegt pro Asset eine `description` — die
+wird derzeit nicht ausgespielt.
+Der EXIF-Endpunkt gibt nur neun feste Felder zurück (`make` … `country`,
+`app/api/exif/[id]/route.ts:68`) — `description` ist nicht dabei.
+*Berührt:* `app/api/exif/[id]/route.ts`, `components/Lightbox.tsx`.
+*Architektonischer Stolperstein:* die Route ist komplett hinter `exifOnHover`
+gesperrt (403, Zeile 19). Eine Bildunterschrift ist aber kein Technikdatum —
+wer EXIF ausschaltet, will trotzdem Bildunterschriften. Die Kopplung muss also
+aufgetrennt werden, statt die Description einfach in dieselbe Antwort zu legen.
+
+**L11 — Fokuspunkt fürs Cover-Cropping.**
+Cover-Bilder werden mittig beschnitten. Bei Porträts im Querformat schneidet das
+regelmäßig Köpfe ab. Ein Fokuspunkt je Album (`object-position`) löst das.
+*Berührt:* `AlbumEntryObject`, Cover-Rendering.
+
+**L12 — Sortierung in der YAML steuerbar.**
+Die Reihenfolge kommt aus dem Immich-Album (`order`). Wer die Website anders
+sortieren will als den Katalog, muss den Katalog ändern.
+*Bewertung:* Bewusster Trade-off der bestehenden Architektur, nicht zwingend ein
+Defekt. Nur relevant, wenn sich das als echter Schmerzpunkt zeigt.
+
+---
+
+## 3. Was Immich Folio hat und Adobe Portfolio nicht
+
+Zur Einordnung — der Rückstand ist einseitig kleiner, als die Listen suggerieren:
+Client-Proofing mit Favoritenauswahl, Kartenansicht mit GPS-Aggregation,
+Wasserzeichen, Essay-Layouts, sieben Theme-Presets mit freier Anpassung,
+Passwortschutz auf Album-*und*-Seitenebene, sowie Self-Hosting ohne Abo.
+
+---
+
+## 4. Priorisierungsvorschlag
+
+Nach Verhältnis von sichtbarer Wirkung zu Aufwand:
+
+**Erste Gruppe — hohe Wirkung, klar abgegrenzt**
+
+- L7 Justified-Rows-Layout — der prägendste optische Unterschied
+- L3 Navigations-Sichtbarkeit (`hidden`) — kleines Feld, löst einen realen Anwendungsfall
+- L10 Bildunterschriften — Daten liegen in Immich bereits vor
+
+**Zweite Gruppe — nützlich, moderater Aufwand**
+
+- L1 Cover-/Splash-Page
+- L8 Grid-Override je Album
+- L2 Externe Nav-Links
+- L11 Cover-Fokuspunkt
+
+**Dritte Gruppe — später oder gar nicht**
+
+- L9 Hover-Effekte (kosmetisch)
+- L5 Redirects (erst bei Migrationsbedarf)
+- L6 Freie Inhaltsseiten (Essays decken viel ab)
+- L12 Sortierung in YAML (architektonischer Trade-off)
+- L4 Verschachtelte Navigation (hoher Aufwand, geringer Nutzen)
+
+## 5. Offene Fragen
+
+1. Soll das Justified-Layout `masonry` ersetzen oder als siebte Option danebenstehen?
+2. Muss jede neue Option auch im Admin-Panel (`app/admin/components/SettingsEditor.tsx`,
+   `PageBuilder.tsx`) editierbar sein, oder reicht zunächst YAML?
+3. Bleibt die Struktur bewusst zweistufig (L4 dauerhaft abgelehnt) oder nur vertagt?

--- a/hooks/useExif.ts
+++ b/hooks/useExif.ts
@@ -10,6 +10,8 @@ export interface ExifData {
   iso?: number | null;
   city?: string | null;
   country?: string | null;
+  /** EXPERIMENTAL: editorial caption from the Immich asset description */
+  description?: string | null;
 }
 
 export function useExif() {

--- a/lib/__tests__/config.test.ts
+++ b/lib/__tests__/config.test.ts
@@ -12,7 +12,38 @@ vi.mock('@/lib/env', () => ({
   },
 }));
 
-import { slugify, buildSubpageGrid } from '@/lib/config';
+import { slugify, buildSubpageGrid, sanitizeNavLinks } from '@/lib/config';
+
+// EXPERIMENTAL: external navigation links — rendered as <a href> in the
+// header, so only http(s) URLs may survive sanitisation.
+describe('sanitizeNavLinks', () => {
+  it('keeps well-formed http(s) links', () => {
+    expect(
+      sanitizeNavLinks([
+        { label: 'Shop', url: 'https://shop.example.com' },
+        { label: 'Blog', url: 'http://blog.example.com/a?b=c' },
+      ]),
+    ).toEqual([
+      { label: 'Shop', url: 'https://shop.example.com' },
+      { label: 'Blog', url: 'http://blog.example.com/a?b=c' },
+    ]);
+  });
+
+  it('drops non-http schemes and entries without label or url', () => {
+    expect(
+      sanitizeNavLinks([
+        { label: 'Bad', url: 'javascript:alert(1)' },
+        { label: 'AlsoBad', url: 'data:text/html,x' },
+        { label: '', url: 'https://x.example' },
+        { label: 'NoUrl', url: '' },
+      ]),
+    ).toEqual([]);
+  });
+
+  it('returns empty for undefined input', () => {
+    expect(sanitizeNavLinks(undefined)).toEqual([]);
+  });
+});
 
 describe('slugify', () => {
   it('converts a simple name to lowercase with hyphens', () => {

--- a/lib/__tests__/config.test.ts
+++ b/lib/__tests__/config.test.ts
@@ -79,6 +79,12 @@ describe('buildSubpageGrid', () => {
     });
   });
 
+  it('preserves the experimental justified layout', () => {
+    expect(buildSubpageGrid({ layout: 'justified' })).toEqual({
+      grid: { layout: 'justified' },
+    });
+  });
+
   it('falls back to masonry for an unknown layout', () => {
     expect(buildSubpageGrid({ layout: 'unknown-layout' })).toEqual({
       grid: { layout: 'masonry' },

--- a/lib/__tests__/derive-gallery.test.ts
+++ b/lib/__tests__/derive-gallery.test.ts
@@ -178,6 +178,24 @@ describe('deriveGallery accepts valid structures', () => {
     expect(open?.hidden).toBeFalsy();
   });
 
+  // EXPERIMENTAL: per-album grid overrides — merged over subpage/global grid.
+  it('collects per-album grid overrides, dropping unknown layouts to masonry', () => {
+    const result = deriveGallery({
+      albums: [
+        { [A]: { title: 'Panoramas', grid: { layout: 'filmstrip', columns: 2 } } },
+        { [B]: { grid: { layout: 'not-a-layout' } } },
+      ],
+    } as unknown as GalleryYaml);
+
+    expect(result.albumGrids[A]).toEqual({ layout: 'filmstrip', columns: 2 });
+    expect(result.albumGrids[B]).toEqual({ layout: 'masonry' });
+  });
+
+  it('leaves albumGrids empty for entries without a grid', () => {
+    const result = deriveGallery({ albums: [A] } as unknown as GalleryYaml);
+    expect(result.albumGrids).toEqual({});
+  });
+
   it('ignores an empty asset order rather than storing one', () => {
     const result = deriveGallery({
       albums: [{ [A]: { sort: 'manual', assetOrder: [] } }],

--- a/lib/__tests__/derive-gallery.test.ts
+++ b/lib/__tests__/derive-gallery.test.ts
@@ -196,6 +196,26 @@ describe('deriveGallery accepts valid structures', () => {
     expect(result.albumGrids).toEqual({});
   });
 
+  // EXPERIMENTAL: coverPosition feeds object-position on cover images, so it
+  // must be a strict CSS position value — anything else is a typo or an
+  // injection attempt and both should fail loudly.
+  it('collects a valid coverPosition', () => {
+    const result = deriveGallery({
+      albums: [{ [A]: { coverPosition: '50% 25%' } }, { [B]: { coverPosition: 'top' } }],
+    } as unknown as GalleryYaml);
+
+    expect(result.albumCoverPositions[A]).toBe('50% 25%');
+    expect(result.albumCoverPositions[B]).toBe('top');
+  });
+
+  it('rejects a malformed coverPosition, naming the album', () => {
+    expect(() =>
+      deriveGallery({
+        albums: [{ [A]: { coverPosition: 'javascript:alert(1)' } }],
+      } as unknown as GalleryYaml),
+    ).toThrow(new RegExp(A));
+  });
+
   it('ignores an empty asset order rather than storing one', () => {
     const result = deriveGallery({
       albums: [{ [A]: { sort: 'manual', assetOrder: [] } }],

--- a/lib/__tests__/derive-gallery.test.ts
+++ b/lib/__tests__/derive-gallery.test.ts
@@ -156,6 +156,28 @@ describe('deriveGallery accepts valid structures', () => {
     expect(result.albumManualOrders[A]).toEqual([B]);
   });
 
+  // EXPERIMENTAL: hidden keeps a subpage reachable by direct link while
+  // removing it from navigation — distinct from enabled:false, which 404s.
+  it('derives the hidden flag on array-style subpages', () => {
+    const result = deriveGallery({
+      subpages: [{ name: 'Preview', hidden: true, albums: [A] }],
+    } as unknown as GalleryYaml);
+
+    expect(result.subpages[0].hidden).toBe(true);
+    expect(result.subpages[0].enabled).toBe(true);
+  });
+
+  it('derives the hidden flag on map-style subpages, defaulting to falsy', () => {
+    const result = deriveGallery({
+      subpages: { Preview: { hidden: true, albums: [A] }, Open: [B] },
+    } as unknown as GalleryYaml);
+
+    const preview = result.subpages.find((sp) => sp.name === 'Preview');
+    const open = result.subpages.find((sp) => sp.name === 'Open');
+    expect(preview?.hidden).toBe(true);
+    expect(open?.hidden).toBeFalsy();
+  });
+
   it('ignores an empty asset order rather than storing one', () => {
     const result = deriveGallery({
       albums: [{ [A]: { sort: 'manual', assetOrder: [] } }],

--- a/lib/config/index.ts
+++ b/lib/config/index.ts
@@ -218,6 +218,7 @@ export function deriveGallery(gallery: GalleryYaml): GalleryDerivation {
         essayFile: sp.essayFile,
         essayText: sp.essayText,
         enabled: sp.enabled !== false,
+        hidden: sp.hidden === true,
         ...buildSubpageGrid(sp.grid),
       };
     });
@@ -244,6 +245,7 @@ export function deriveGallery(gallery: GalleryYaml): GalleryDerivation {
         essayFile: sp.essayFile,
         essayText: sp.essayText,
         enabled: sp.enabled !== false,
+        hidden: sp.hidden === true,
         ...buildSubpageGrid(sp.grid),
       };
     });

--- a/lib/config/index.ts
+++ b/lib/config/index.ts
@@ -87,6 +87,7 @@ export interface GalleryDerivation {
   albumHeroImages: Record<string, string>;
   albumSortModes: Record<string, AlbumSortMode>;
   albumManualOrders: Record<string, string[]>;
+  albumGrids: Record<string, Partial<GridConfig>>;
 }
 
 /**
@@ -108,6 +109,7 @@ export function deriveGallery(gallery: GalleryYaml): GalleryDerivation {
   const albumHeroImages: Record<string, string> = {};
   const albumSortModes: Record<string, AlbumSortMode> = {};
   const albumManualOrders: Record<string, string[]> = {};
+  const albumGrids: Record<string, Partial<GridConfig>> = {};
 
   function processAlbumEntry(
     entry: string | Record<string, string | AlbumEntryObject>,
@@ -161,6 +163,13 @@ export function deriveGallery(gallery: GalleryYaml): GalleryDerivation {
         albumManualOrders[validatedUuid] = value.assetOrder.map((assetId, i) =>
           validateUuid(assetId, `${context} assetOrder[${i}] for album ${validatedUuid}`),
         );
+      }
+
+      // EXPERIMENTAL: per-album grid override — reuses the subpage-grid
+      // normalisation so unknown layouts degrade identically.
+      if (value.grid) {
+        const built = buildSubpageGrid(value.grid);
+        if ('grid' in built) albumGrids[validatedUuid] = built.grid;
       }
     }
     return validatedUuid;
@@ -264,6 +273,7 @@ export function deriveGallery(gallery: GalleryYaml): GalleryDerivation {
     albumHeroImages,
     albumSortModes,
     albumManualOrders,
+    albumGrids,
   };
 }
 
@@ -317,6 +327,7 @@ export function getConfig(): AppConfig {
       albumHeroImages: {},
       albumSortModes: {},
       albumManualOrders: {},
+      albumGrids: {},
       cacheTtl: env.CACHE_TTL * 1000,
       staleMaxAge: env.STALE_MAX_AGE * 1000,
       immichTimeoutMs: env.IMMICH_TIMEOUT_MS,
@@ -338,6 +349,7 @@ export function getConfig(): AppConfig {
     albumHeroImages,
     albumSortModes,
     albumManualOrders,
+    albumGrids,
   } = deriveGallery(gallery);
 
   const siteSeoTitle = settings.seo?.title || settings.title || env.SITE_TITLE || 'Gallery';
@@ -412,6 +424,7 @@ export function getConfig(): AppConfig {
     albumHeroImages,
     albumSortModes,
     albumManualOrders,
+    albumGrids,
     cacheTtl: env.CACHE_TTL * 1000,
     staleMaxAge: env.STALE_MAX_AGE * 1000,
     immichTimeoutMs: env.IMMICH_TIMEOUT_MS,

--- a/lib/config/index.ts
+++ b/lib/config/index.ts
@@ -88,6 +88,7 @@ export interface GalleryDerivation {
   albumSortModes: Record<string, AlbumSortMode>;
   albumManualOrders: Record<string, string[]>;
   albumGrids: Record<string, Partial<GridConfig>>;
+  albumCoverPositions: Record<string, string>;
 }
 
 /**
@@ -110,6 +111,7 @@ export function deriveGallery(gallery: GalleryYaml): GalleryDerivation {
   const albumSortModes: Record<string, AlbumSortMode> = {};
   const albumManualOrders: Record<string, string[]> = {};
   const albumGrids: Record<string, Partial<GridConfig>> = {};
+  const albumCoverPositions: Record<string, string> = {};
 
   function processAlbumEntry(
     entry: string | Record<string, string | AlbumEntryObject>,
@@ -170,6 +172,22 @@ export function deriveGallery(gallery: GalleryYaml): GalleryDerivation {
       if (value.grid) {
         const built = buildSubpageGrid(value.grid);
         if ('grid' in built) albumGrids[validatedUuid] = built.grid;
+      }
+
+      // EXPERIMENTAL: coverPosition lands in a style attribute, so only a
+      // strict CSS position grammar is allowed. Throw like `sort` does — a
+      // silent fallback would leave the owner wondering why nothing moves.
+      if (value.coverPosition != null) {
+        const pos = value.coverPosition.trim();
+        const keyword = /^(center|top|bottom|left|right)( (center|top|bottom|left|right))?$/;
+        const percent = /^\d{1,3}% \d{1,3}%$/;
+        if (!keyword.test(pos) && !percent.test(pos)) {
+          throw new Error(
+            `${context}: album ${validatedUuid} has an invalid coverPosition "${value.coverPosition}". ` +
+              `Use two percentages ("50% 25%") or CSS keywords ("top", "center bottom").`,
+          );
+        }
+        albumCoverPositions[validatedUuid] = pos;
       }
     }
     return validatedUuid;
@@ -274,6 +292,7 @@ export function deriveGallery(gallery: GalleryYaml): GalleryDerivation {
     albumSortModes,
     albumManualOrders,
     albumGrids,
+    albumCoverPositions,
   };
 }
 
@@ -328,6 +347,7 @@ export function getConfig(): AppConfig {
       albumSortModes: {},
       albumManualOrders: {},
       albumGrids: {},
+      albumCoverPositions: {},
       cacheTtl: env.CACHE_TTL * 1000,
       staleMaxAge: env.STALE_MAX_AGE * 1000,
       immichTimeoutMs: env.IMMICH_TIMEOUT_MS,
@@ -350,6 +370,7 @@ export function getConfig(): AppConfig {
     albumSortModes,
     albumManualOrders,
     albumGrids,
+    albumCoverPositions,
   } = deriveGallery(gallery);
 
   const siteSeoTitle = settings.seo?.title || settings.title || env.SITE_TITLE || 'Gallery';
@@ -425,6 +446,7 @@ export function getConfig(): AppConfig {
     albumSortModes,
     albumManualOrders,
     albumGrids,
+    albumCoverPositions,
     cacheTtl: env.CACHE_TTL * 1000,
     staleMaxAge: env.STALE_MAX_AGE * 1000,
     immichTimeoutMs: env.IMMICH_TIMEOUT_MS,

--- a/lib/config/index.ts
+++ b/lib/config/index.ts
@@ -76,6 +76,32 @@ export function buildSubpageGrid(raw?: {
   };
 }
 
+/**
+ * EXPERIMENTAL: keep only nav links that are safe to render as header <a>
+ * tags. Non-http(s) schemes (javascript:, data:) and incomplete entries are
+ * dropped with a warning rather than throwing — a bad external link should
+ * not take the site down.
+ */
+export function sanitizeNavLinks(
+  raw?: Array<{ label?: string; url?: string }>,
+): Array<{ label: string; url: string }> {
+  if (!raw) return [];
+  const links: Array<{ label: string; url: string }> = [];
+  for (const entry of raw) {
+    const label = entry.label?.trim();
+    const url = entry.url?.trim();
+    if (!label || !url || !/^https?:\/\//i.test(url)) {
+      console.warn(
+        `[Folio] settings.yaml navLinks: dropping entry ${JSON.stringify(entry)} — ` +
+          'label and an http(s) url are required.',
+      );
+      continue;
+    }
+    links.push({ label, url });
+  }
+  return links;
+}
+
 /** The parts of AppConfig that come from gallery.yaml. */
 export interface GalleryDerivation {
   albums: string[];
@@ -348,6 +374,7 @@ export function getConfig(): AppConfig {
       albumManualOrders: {},
       albumGrids: {},
       albumCoverPositions: {},
+      navLinks: [],
       cacheTtl: env.CACHE_TTL * 1000,
       staleMaxAge: env.STALE_MAX_AGE * 1000,
       immichTimeoutMs: env.IMMICH_TIMEOUT_MS,
@@ -447,6 +474,7 @@ export function getConfig(): AppConfig {
     albumManualOrders,
     albumGrids,
     albumCoverPositions,
+    navLinks: sanitizeNavLinks(settings.navLinks),
     cacheTtl: env.CACHE_TTL * 1000,
     staleMaxAge: env.STALE_MAX_AGE * 1000,
     immichTimeoutMs: env.IMMICH_TIMEOUT_MS,

--- a/lib/config/schema.ts
+++ b/lib/config/schema.ts
@@ -77,7 +77,7 @@ export interface GridConfig {
   columns: number;
   gap: number;
   aspectRatio: string;
-  layout: 'masonry' | 'uniform' | 'showcase' | 'filmstrip' | 'editorial-flow' | 'essay';
+  layout: 'masonry' | 'uniform' | 'showcase' | 'filmstrip' | 'editorial-flow' | 'essay' | 'justified';
 }
 
 export interface AppConfig {

--- a/lib/config/schema.ts
+++ b/lib/config/schema.ts
@@ -130,6 +130,8 @@ export interface AppConfig {
   albumManualOrders: Record<string, string[]>;
   /** EXPERIMENTAL: per-album grid overrides, merged over the subpage/global grid. */
   albumGrids: Record<string, Partial<GridConfig>>;
+  /** EXPERIMENTAL: per-album focal point for cover crops (CSS object-position). */
+  albumCoverPositions: Record<string, string>;
   cacheTtl: number;
   /** How long (ms) an expired cache entry may still be served while Immich is unreachable. */
   staleMaxAge: number;
@@ -165,6 +167,8 @@ export interface AlbumEntryObject {
   assetOrder?: string[];
   /** EXPERIMENTAL: per-album grid override, merged over the subpage/global grid */
   grid?: { columns?: number; gap?: number; aspectRatio?: string; layout?: string };
+  /** EXPERIMENTAL: focal point for the cover crop, e.g. "50% 25%" or "top" */
+  coverPosition?: string;
 }
 
 export interface GalleryYaml {

--- a/lib/config/schema.ts
+++ b/lib/config/schema.ts
@@ -80,7 +80,7 @@ export interface ThemeConfig {
   photoFrame: 'none' | 'passepartout' | 'shadow';
   grain: boolean;
   headerDot: boolean;
-  heroStyle: 'split' | 'fullbleed' | 'minimal' | 'stacked' | 'typographic' | 'mosaic';
+  heroStyle: 'split' | 'fullbleed' | 'minimal' | 'stacked' | 'typographic' | 'mosaic' | 'cover';
 }
 
 export interface GridConfig {

--- a/lib/config/schema.ts
+++ b/lib/config/schema.ts
@@ -20,6 +20,8 @@ export interface SubpageConfig {
   essayFile?: string;
   essayText?: string;
   enabled?: boolean;
+  /** EXPERIMENTAL: reachable by direct link, but not shown in navigation */
+  hidden?: boolean;
 }
 
 export interface SubpageObjectValue {
@@ -31,6 +33,8 @@ export interface SubpageObjectValue {
   essayFile?: string;
   essayText?: string;
   enabled?: boolean;
+  /** EXPERIMENTAL: reachable by direct link, but not shown in navigation */
+  hidden?: boolean;
   // Both album lists reuse AlbumEntryObject rather than inlining the shape:
   // the inline copies had already drifted (they never gained `heroImage`), and
   // this path is live for map-style subpages.
@@ -172,6 +176,7 @@ export interface GalleryYaml {
         essayFile?: string;
         essayText?: string;
         enabled?: boolean;
+        hidden?: boolean;
         grid?: {
           columns?: number;
           gap?: number;

--- a/lib/config/schema.ts
+++ b/lib/config/schema.ts
@@ -81,7 +81,14 @@ export interface GridConfig {
   columns: number;
   gap: number;
   aspectRatio: string;
-  layout: 'masonry' | 'uniform' | 'showcase' | 'filmstrip' | 'editorial-flow' | 'essay' | 'justified';
+  layout:
+    | 'masonry'
+    | 'uniform'
+    | 'showcase'
+    | 'filmstrip'
+    | 'editorial-flow'
+    | 'essay'
+    | 'justified';
 }
 
 export interface AppConfig {
@@ -121,6 +128,8 @@ export interface AppConfig {
   albumSortModes: Record<string, AlbumSortMode>;
   /** Pinned asset UUIDs per album for `sort: manual`, in display order. */
   albumManualOrders: Record<string, string[]>;
+  /** EXPERIMENTAL: per-album grid overrides, merged over the subpage/global grid. */
+  albumGrids: Record<string, Partial<GridConfig>>;
   cacheTtl: number;
   /** How long (ms) an expired cache entry may still be served while Immich is unreachable. */
   staleMaxAge: number;
@@ -154,6 +163,8 @@ export interface AlbumEntryObject {
   sort?: string;
   /** Pinned asset UUIDs for `sort: manual`. Everything else follows automatically. */
   assetOrder?: string[];
+  /** EXPERIMENTAL: per-album grid override, merged over the subpage/global grid */
+  grid?: { columns?: number; gap?: number; aspectRatio?: string; layout?: string };
 }
 
 export interface GalleryYaml {

--- a/lib/config/schema.ts
+++ b/lib/config/schema.ts
@@ -46,6 +46,12 @@ export interface SubpageObjectValue {
   }>;
 }
 
+/** EXPERIMENTAL: external link shown in the header navigation. */
+export interface NavLinkConfig {
+  label: string;
+  url: string;
+}
+
 export interface FooterConfig {
   name?: string;
   instagram?: string;
@@ -132,6 +138,8 @@ export interface AppConfig {
   albumGrids: Record<string, Partial<GridConfig>>;
   /** EXPERIMENTAL: per-album focal point for cover crops (CSS object-position). */
   albumCoverPositions: Record<string, string>;
+  /** EXPERIMENTAL: external links appended to the header navigation. */
+  navLinks: NavLinkConfig[];
   cacheTtl: number;
   /** How long (ms) an expired cache entry may still be served while Immich is unreachable. */
   staleMaxAge: number;
@@ -240,6 +248,8 @@ export interface SettingsYaml {
   };
   footer?: FooterConfig;
   legal?: Partial<LegalConfig>;
+  /** EXPERIMENTAL: external links appended to the header navigation. */
+  navLinks?: Array<{ label?: string; url?: string }>;
   protection?: {
     disableRightClick?: boolean;
     disableImageDrag?: boolean;

--- a/lib/config/theme.ts
+++ b/lib/config/theme.ts
@@ -82,7 +82,15 @@ export const VALID_HERO_STYLES = [
   'typographic',
   'mosaic',
 ];
-export const VALID_LAYOUTS = ['masonry', 'uniform', 'showcase', 'filmstrip', 'editorial-flow', 'essay'];
+export const VALID_LAYOUTS = [
+  'masonry',
+  'uniform',
+  'showcase',
+  'filmstrip',
+  'editorial-flow',
+  'essay',
+  'justified', // EXPERIMENTAL: row-based layout with equal heights
+];
 
 export function resolveTheme(raw?: SettingsYaml['theme']): ThemeConfig {
   if (!raw) return { ...THEME_PRESETS.studio };

--- a/lib/config/theme.ts
+++ b/lib/config/theme.ts
@@ -81,6 +81,7 @@ export const VALID_HERO_STYLES = [
   'stacked',
   'typographic',
   'mosaic',
+  'cover', // EXPERIMENTAL: fullscreen splash with a single "Enter" link
 ];
 export const VALID_LAYOUTS = [
   'masonry',

--- a/lib/immich.ts
+++ b/lib/immich.ts
@@ -461,7 +461,12 @@ class ImmichClient {
    * Get enriched subpage summaries for the homepage.
    */
   async getSubpages(forceFresh = false): Promise<SubpageSummary[]> {
-    const activeSubpages = this.config.subpages.filter((sp) => sp.enabled !== false);
+    // hidden (EXPERIMENTAL) drops a subpage from every list this feeds (nav,
+    // homepage, hero) while getSubpageAlbums()/isValidSubpage() still resolve
+    // it — unlike enabled:false, which 404s the page entirely.
+    const activeSubpages = this.config.subpages.filter(
+      (sp) => sp.enabled !== false && sp.hidden !== true,
+    );
     if (activeSubpages.length === 0) return [];
 
     const albums = await this.getAlbums(forceFresh);


### PR DESCRIPTION
## Was ist das?

Sieben Features aus der Adobe-Portfolio-Gap-Analyse (siehe `docs/superpowers/specs/2026-08-13-adobe-portfolio-gap-analysis.md`), alle als **experimental** gekennzeichnet — in YAML-Kommentaren, Admin-Panel-Labels und Commit-Scopes, damit sie einzeln nachvollziehbar und revertierbar bleiben.

## Features (je ein Commit)

| Commit | Feature |
| --- | --- |
| `justified rows gallery layout` | Neues Grid-Layout `justified` (L7): zeilenbasiert, gleiche Höhen, volle Breite — Flexbox ohne JS-Messung, letzte Zeile bleibt natürlich klein |
| `hide subpages from navigation` | `hidden: true` (L3): Seite aus Nav/Homepage raus, per Direktlink erreichbar — im Gegensatz zu `enabled: false` (404) |
| `lightbox captions` | Immich-Asset-Description als Bildunterschrift im Info-Panel (L10); EXIF-Route liefert bei `exifOnHover: false` jetzt nur noch die Caption statt 403 |
| `per-album grid overrides` | `grid:` pro Album-Eintrag (L8), Präzedenz global < Subpage < Album |
| `per-album cover focal point` | `coverPosition:` (L11) → `object-position` auf Cover-Karten, strikt validiert |
| `external links in header navigation` | `navLinks:` in settings.yaml (L2), nur http(s), sanitisiert |
| `cover splash hero style` | `heroStyle: cover` (L1): Fullscreen-Splash mit Enter-Link ins Portfolio |

Alle Optionen sind im Admin-Panel editierbar (PageBuilder / SettingsEditor).

## Tests

- 356 Unit-Tests grün (13 neue: deriveGallery hidden/grid/coverPosition, sanitizeNavLinks, EXIF-Route-Captions, justified-Layout-Validierung)
- `npx tsc --noEmit`: 0 Fehler
- `npm run build`: sauber
- Justified-Zeilenmathematik und Cover-Splash per Browser-Harness visuell/numerisch verifiziert (volle Zeilen enden exakt an der Containerkante, letzte Zeile bleibt natürlich)