### PR TITLE
fix(journal): render photos, fix layout and lightbox controls

### DIFF
--- a/app/[...path]/EssayView.tsx
+++ b/app/[...path]/EssayView.tsx
@@ -16,9 +16,22 @@ interface EssayViewProps {
   title?: string;
   subtitle?: string;
   watermark?: LightboxWatermark;
+  /**
+   * Client proofing — favorite hearts, the selection bar and the send-off modal.
+   * Off by default: proofing is a delivery workflow for album handovers, and a
+   * published story is not one. Album views opt in.
+   */
+  proofing?: boolean;
 }
 
-function EssayViewContent({ essay, assets, title, subtitle, watermark }: EssayViewProps) {
+function EssayViewContent({
+  essay,
+  assets,
+  title,
+  subtitle,
+  watermark,
+  proofing: proofingEnabled = false,
+}: EssayViewProps) {
   const proofing = useProofing();
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
 
@@ -54,11 +67,7 @@ function EssayViewContent({ essay, assets, title, subtitle, watermark }: EssayVi
 
       case 'paragraph':
         return (
-          <div
-            key={idx}
-            className="essay-prose"
-            dangerouslySetInnerHTML={{ __html: block.html }}
-          />
+          <div key={idx} className="essay-prose" dangerouslySetInnerHTML={{ __html: block.html }} />
         );
 
       case 'quote':
@@ -94,8 +103,8 @@ function EssayViewContent({ essay, assets, title, subtitle, watermark }: EssayVi
                     block.layout === 'fullbleed'
                       ? '100vw'
                       : block.layout === 'wide'
-                      ? '(max-width: 1100px) 100vw, 1100px'
-                      : '(max-width: 768px) 100vw, 680px'
+                        ? '(max-width: 1100px) 100vw, 1100px'
+                        : '(max-width: 768px) 100vw, 680px'
                   }
                   loading={idx < 4 ? 'eager' : 'lazy'}
                   {...(item.blurDataURL
@@ -129,7 +138,14 @@ function EssayViewContent({ essay, assets, title, subtitle, watermark }: EssayVi
                       filter: 'drop-shadow(0 2px 4px rgba(0,0,0,0.6))',
                     }}
                   >
-                    <svg viewBox="0 0 24 24" width="24" height="24" fill={isFav ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth="2">
+                    <svg
+                      viewBox="0 0 24 24"
+                      width="24"
+                      height="24"
+                      fill={isFav ? 'currentColor' : 'none'}
+                      stroke="currentColor"
+                      strokeWidth="2"
+                    >
                       <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
                     </svg>
                   </button>
@@ -164,7 +180,9 @@ function EssayViewContent({ essay, assets, title, subtitle, watermark }: EssayVi
                       onClick={() => setLightboxIndex(index)}
                       style={{
                         ...(item.dominantColor ? { backgroundColor: item.dominantColor } : {}),
-                        ...(item.aspectRatio ? { aspectRatio: `${item.aspectRatio}` } : {}),
+                        // Width proportional to the ratio — see .essay-pair-grid.
+                        flexGrow: item.aspectRatio ?? 1.5,
+                        aspectRatio: `${item.aspectRatio ?? 1.5}`,
                       }}
                     >
                       <Image
@@ -203,7 +221,14 @@ function EssayViewContent({ essay, assets, title, subtitle, watermark }: EssayVi
                             filter: 'drop-shadow(0 2px 4px rgba(0,0,0,0.6))',
                           }}
                         >
-                          <svg viewBox="0 0 24 24" width="24" height="24" fill={isFav ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth="2">
+                          <svg
+                            viewBox="0 0 24 24"
+                            width="24"
+                            height="24"
+                            fill={isFav ? 'currentColor' : 'none'}
+                            stroke="currentColor"
+                            strokeWidth="2"
+                          >
                             <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
                           </svg>
                         </button>
@@ -294,7 +319,9 @@ function EssayViewContent({ essay, assets, title, subtitle, watermark }: EssayVi
             type="button"
             onClick={() => proofing.setIsFilterActive((prev) => !prev)}
             style={{
-              background: proofing.isFilterActive ? 'var(--accent, #e60012)' : 'rgba(255,255,255,0.15)',
+              background: proofing.isFilterActive
+                ? 'var(--accent, #e60012)'
+                : 'rgba(255,255,255,0.15)',
               color: '#fff',
               border: 'none',
               padding: '6px 14px',
@@ -324,16 +351,23 @@ function EssayViewContent({ essay, assets, title, subtitle, watermark }: EssayVi
         </div>
       )}
 
-      <ProofingModal />
+      {proofingEnabled && <ProofingModal />}
 
       {lightboxIndex !== null && (
         <Lightbox
           assets={assets}
           currentIndex={lightboxIndex}
           onClose={() => setLightboxIndex(null)}
-          onNext={() => setLightboxIndex((prev) => (prev !== null ? (prev + 1) % assets.length : null))}
-          onPrev={() => setLightboxIndex((prev) => (prev !== null ? (prev - 1 + assets.length) % assets.length : null))}
+          onNext={() =>
+            setLightboxIndex((prev) => (prev !== null ? (prev + 1) % assets.length : null))
+          }
+          onPrev={() =>
+            setLightboxIndex((prev) =>
+              prev !== null ? (prev - 1 + assets.length) % assets.length : null,
+            )
+          }
           watermark={watermark}
+          showExifToggle={false}
         />
       )}
     </div>
@@ -342,6 +376,12 @@ function EssayViewContent({ essay, assets, title, subtitle, watermark }: EssayVi
 
 export function EssayView(props: EssayViewProps) {
   const albumTokens = useMemo(() => props.assets.map((a) => a.id), [props.assets]);
+
+  // Without the provider useProofing() returns null, and every proofing control
+  // (hearts in the grid and in the lightbox, selection bar) drops out on its own.
+  if (!props.proofing) {
+    return <EssayViewContent {...props} />;
+  }
 
   return (
     <ProofingProvider albumTokens={albumTokens}>

--- a/app/[...path]/PhotoGrid.tsx
+++ b/app/[...path]/PhotoGrid.tsx
@@ -116,32 +116,7 @@ function PhotoGridInner({ assets, layout = 'masonry', gridStyle, watermark }: Ph
     setLightboxIndex((prev) => (prev !== null ? (prev - 1 + displayedAssets.length) % displayedAssets.length : null));
   }, [displayedAssets.length]);
 
-  // Keyboard navigation
-  useEffect(() => {
-    if (lightboxIndex === null) return;
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      switch (e.key) {
-        case 'Escape':
-          closeLightbox();
-          break;
-        case 'ArrowRight':
-          goNext();
-          break;
-        case 'ArrowLeft':
-          goPrev();
-          break;
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown);
-    document.body.style.overflow = 'hidden';
-
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown);
-      document.body.style.overflow = '';
-    };
-  }, [lightboxIndex, closeLightbox, goNext, goPrev]);
+  // Keyboard navigation and the scroll lock live in <Lightbox/>.
 
   const gridItems = useMemo(() => {
     return displayedAssets.map((asset, index) => {

--- a/app/[...path]/essay.css
+++ b/app/[...path]/essay.css
@@ -1,6 +1,23 @@
 /* Photo Essay & Storytelling Mode Styles */
 
 .essay-container {
+  /*
+   * One shared measure for every block, so headings, prose and figures line up
+   * on the same left edge. Deliberately in rem, not the `68ch` this replaces:
+   * `ch` is relative to each element's own font, so a serif heading resolved to
+   * a wider column than the body text and started further left. 40rem matches
+   * what 68ch produced for the body font. Custom properties are substituted as
+   * raw tokens, so a `ch` value here would be re-resolved per element and bring
+   * the bug straight back — keep this font-independent.
+   *
+   * `--essay-bleed` / `--essay-wide` are viewport-based by default and get
+   * overridden where the essay renders inside a narrower box (e.g. the admin
+   * Journal Studio preview pane).
+   */
+  --essay-measure: 40rem;
+  --essay-wide: 1100px;
+  --essay-bleed: 100vw;
+
   width: 100%;
   max-width: 100%;
   margin: 0 auto;
@@ -9,7 +26,7 @@
 
 /* Header & Cover */
 .essay-header {
-  max-width: 68ch;
+  max-width: var(--essay-measure);
   margin: 0 auto 3.5rem auto;
   text-align: center;
 }
@@ -41,7 +58,7 @@
 
 /* Reading column */
 .essay-prose {
-  max-width: 68ch;
+  max-width: var(--essay-measure);
   margin: 0 auto 2.5rem auto;
   font-family: var(--font-body, sans-serif);
   font-size: clamp(1.05rem, 2vw, 1.2rem);
@@ -55,19 +72,25 @@
 
 .essay-heading {
   font-family: var(--font-heading, serif);
-  max-width: 68ch;
+  max-width: var(--essay-measure);
   margin: 3.5rem auto 1.5rem auto;
   font-weight: 600;
   line-height: 1.25;
 }
 
-.essay-heading--1 { font-size: clamp(1.8rem, 3.5vw, 2.5rem); }
-.essay-heading--2 { font-size: clamp(1.5rem, 3vw, 2rem); }
-.essay-heading--3 { font-size: clamp(1.25rem, 2.5vw, 1.6rem); }
+.essay-heading--1 {
+  font-size: clamp(1.8rem, 3.5vw, 2.5rem);
+}
+.essay-heading--2 {
+  font-size: clamp(1.5rem, 3vw, 2rem);
+}
+.essay-heading--3 {
+  font-size: clamp(1.25rem, 2.5vw, 1.6rem);
+}
 
 /* Pullquote */
 .essay-quote {
-  max-width: 68ch;
+  max-width: var(--essay-measure);
   margin: 3.5rem auto;
   padding: 1.5rem 2rem;
   border-left: 3px solid var(--accent, #e60012);
@@ -96,17 +119,23 @@
 }
 
 .essay-figure--contained {
-  max-width: 68ch;
+  max-width: var(--essay-measure);
 }
 
 .essay-figure--wide {
-  max-width: 1100px;
+  max-width: var(--essay-wide);
 }
 
+/*
+ * `width` has to be set too, not just max-width: .essay-figure is width: 100%,
+ * which over-constrains the box so the negative right margin is dropped and only
+ * the left side bleeds.
+ */
 .essay-figure--fullbleed {
-  max-width: 100vw;
-  margin-left: calc(-50vw + 50%);
-  margin-right: calc(-50vw + 50%);
+  width: var(--essay-bleed);
+  max-width: var(--essay-bleed);
+  margin-left: calc(-0.5 * var(--essay-bleed) + 50%);
+  margin-right: calc(-0.5 * var(--essay-bleed) + 50%);
 }
 
 .essay-image-wrapper {
@@ -131,7 +160,7 @@
 }
 
 .essay-figcaption {
-  max-width: 68ch;
+  max-width: var(--essay-measure);
   margin: 0.75rem auto 0 auto;
   text-align: center;
   font-family: var(--font-caption, monospace);
@@ -140,18 +169,34 @@
 }
 
 /* Side by side photo pair */
+/*
+ * Justified row: each photo keeps its own aspect ratio, and its width is given
+ * by `flex-grow: <aspect ratio>` (set inline from the asset). Since width ∝ ratio
+ * and height = width / ratio, both photos end up exactly the same height without
+ * a single pixel being cropped — a shared baseline instead of one portrait
+ * towering over a landscape.
+ */
 .essay-pair-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
+  display: flex;
   gap: 1.5rem;
   width: 100%;
-  max-width: 1100px;
+  max-width: var(--essay-wide);
   margin: 3.5rem auto;
 }
 
+.essay-pair-grid > .essay-image-wrapper {
+  flex-basis: 0;
+  min-width: 0;
+}
+
 @media (max-width: 640px) {
+  /* Stacked: full width each, height from the photo's own ratio. */
   .essay-pair-grid {
-    grid-template-columns: 1fr;
+    flex-direction: column;
     gap: 1.5rem;
+  }
+
+  .essay-pair-grid > .essay-image-wrapper {
+    flex: none;
   }
 }

--- a/app/journal/[slug]/page.tsx
+++ b/app/journal/[slug]/page.tsx
@@ -2,10 +2,17 @@ import { notFound } from 'next/navigation';
 import { cookies } from 'next/headers';
 import type { Metadata } from 'next';
 import { readJournalEntry } from '@/lib/admin/journal-service';
+import type { ParsedJournal } from '@/lib/journal';
 import { isAdminAuthenticated } from '@/lib/admin/auth';
 import { getConfig } from '@/lib/config';
 import { immich } from '@/lib/immich';
-import { imageUrl, exifUrl, assetPlaceholder, assetAspectRatio, assetExifSummary } from '@/lib/urls';
+import {
+  imageUrl,
+  exifUrl,
+  assetPlaceholder,
+  assetAspectRatio,
+  assetExifSummary,
+} from '@/lib/urls';
 import { encodeAssetId } from '@/lib/tokens';
 import { EssayView } from '@/app/[...path]/EssayView';
 import type { PhotoItem } from '@/app/[...path]/PhotoGrid';
@@ -46,7 +53,11 @@ export async function generateMetadata({ params }: JournalDetailPageProps): Prom
 }
 
 /** Check if journal entry password cookie is valid */
-function isJournalAuthenticated(slug: string, storedPassword?: string, cookieVal?: string): boolean {
+function isJournalAuthenticated(
+  slug: string,
+  storedPassword?: string,
+  cookieVal?: string,
+): boolean {
   if (!storedPassword) return true;
   if (!cookieVal) return false;
 
@@ -94,13 +105,7 @@ export default async function JournalDetailPage({ params }: JournalDetailPagePro
     const cookieVal = cookieStore.get(`lb_auth_journal_${slug}`)?.value;
 
     if (!isJournalAuthenticated(slug, frontmatter.password, cookieVal)) {
-      return (
-        <PasswordGate
-          slug={slug}
-          title={frontmatter.title || slug}
-          type="journal"
-        />
-      );
+      return <PasswordGate slug={slug} title={frontmatter.title || slug} type="journal" />;
     }
   }
 
@@ -118,6 +123,51 @@ export default async function JournalDetailPage({ params }: JournalDetailPagePro
 
   const rawAssets = (await Promise.all(assetPromises)).filter((a): a is ImmichAsset => a !== null);
 
+  // EssayView drops photo blocks it cannot resolve, which is right for visitors
+  // but leaves no trace of *why* a photo vanished. Legacy positional references
+  // ("1", "2") are the usual cause: they only resolved against a subpage album,
+  // and a standalone journal entry has none.
+  if (rawAssets.length < referencedAssetIds.length) {
+    const resolved = new Set(rawAssets.map((a) => a.id));
+    const missing = referencedAssetIds.filter((id) => !resolved.has(id));
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[journal] ${slug}: ${missing.length} photo reference(s) could not be resolved and will not render: ${missing.join(', ')}`,
+    );
+  }
+
+  /*
+   * EssayView resolves a block's photo through PhotoItem.id, and those ids are
+   * encrypted tokens — while the blocks coming out of the Markdown carry raw
+   * asset UUIDs. Without this translation every photo block fails its lookup and
+   * is dropped, so a correctly authored entry renders text only. Doing it here
+   * also keeps raw UUIDs out of the client payload, per the project rule that
+   * they must never reach the browser. Unresolvable references collapse to an
+   * empty string, which EssayView skips.
+   */
+  const tokenByAssetId = new Map(rawAssets.map((a) => [a.id, encodeAssetId(a.id)]));
+  const toToken = (assetId: string) => tokenByAssetId.get(assetId) ?? '';
+
+  const essayForClient: ParsedJournal = {
+    frontmatter: {
+      ...frontmatter,
+      coverAssetId: frontmatter.coverAssetId ? toToken(frontmatter.coverAssetId) : undefined,
+    },
+    blocks: blocks.map((block) => {
+      if (block.type === 'photo') {
+        return { ...block, assetId: toToken(block.assetId) };
+      }
+      if (block.type === 'photo-pair') {
+        return {
+          ...block,
+          assetIds: [toToken(block.assetIds[0]), toToken(block.assetIds[1])] as [string, string],
+        };
+      }
+      return block;
+    }),
+    referencedAssetIds: rawAssets.map((a) => encodeAssetId(a.id)),
+  };
+
   const images: PhotoItem[] = rawAssets
     .filter((a) => a.type === 'IMAGE' || a.type === 'VIDEO')
     .map((a) => {
@@ -126,7 +176,6 @@ export default async function JournalDetailPage({ params }: JournalDetailPagePro
       const isVideo = a.type === 'VIDEO';
       return {
         id: encodeAssetId(a.id),
-        rawId: a.id,
         type: isVideo ? 'video' : 'image',
         thumbUrl: imageUrl(a.id, 'preview'),
         previewUrl: imageUrl(a.id, 'preview'),
@@ -143,7 +192,7 @@ export default async function JournalDetailPage({ params }: JournalDetailPagePro
         <BackLink href="/journal" label="Back to Journal" />
       </div>
       <EssayView
-        essay={entry.parsed}
+        essay={essayForClient}
         assets={images}
         title={frontmatter.title}
         subtitle={frontmatter.subtitle}

--- a/app/journal/page.tsx
+++ b/app/journal/page.tsx
@@ -53,7 +53,7 @@ export default async function JournalIndexPage() {
           coverUrl: imageUrl(entry.frontmatter.coverAssetId, 'preview'),
         };
       }
-    })
+    }),
   );
 
   return (
@@ -85,11 +85,7 @@ export default async function JournalIndexPage() {
               : null;
 
             return (
-              <Link
-                key={entry.slug}
-                href={`/journal/${entry.slug}`}
-                className="journal-card"
-              >
+              <Link key={entry.slug} href={`/journal/${entry.slug}`} className="journal-card">
                 <div
                   className="journal-card__cover"
                   style={{
@@ -114,36 +110,30 @@ export default async function JournalIndexPage() {
                   <div className="journal-card__meta">
                     {dateStr && <span>{dateStr}</span>}
                     {dateStr && entry.readingTimeMinutes && <span>•</span>}
-                    {entry.readingTimeMinutes && (
-                      <span>{entry.readingTimeMinutes} min read</span>
-                    )}
+                    {entry.readingTimeMinutes && <span>{entry.readingTimeMinutes} min read</span>}
                     {entry.frontmatter.draft && (
                       <span className="journal-card__draft-badge">Draft</span>
                     )}
                   </div>
 
-                  <h2 className="journal-card__title">
-                    {entry.frontmatter.title || entry.slug}
-                  </h2>
+                  <h2 className="journal-card__title">{entry.frontmatter.title || entry.slug}</h2>
 
                   {entry.frontmatter.subtitle && (
-                    <p className="journal-card__subtitle">
-                      {entry.frontmatter.subtitle}
-                    </p>
+                    <p className="journal-card__subtitle">{entry.frontmatter.subtitle}</p>
                   )}
 
-                  {entry.excerpt && (
+                  {/*
+                    extractExcerpt() falls back to the subtitle when there is
+                    one, so rendering both printed the same sentence twice.
+                  */}
+                  {entry.excerpt && entry.excerpt !== entry.frontmatter.subtitle && (
                     <p className="journal-card__excerpt">{entry.excerpt}</p>
                   )}
 
                   <div className="journal-card__footer">
-                    <span className="journal-card__read-more">
-                      Read Story →
-                    </span>
+                    <span className="journal-card__read-more">Read Story →</span>
                     {entry.frontmatter.author && (
-                      <span style={{ opacity: 0.65 }}>
-                        by {entry.frontmatter.author}
-                      </span>
+                      <span style={{ opacity: 0.65 }}>by {entry.frontmatter.author}</span>
                     )}
                   </div>
                 </div>

--- a/components/Lightbox.tsx
+++ b/components/Lightbox.tsx
@@ -33,9 +33,22 @@ interface LightboxProps {
   onNext: () => void;
   onPrev: () => void;
   watermark?: LightboxWatermark;
+  /**
+   * Show the EXIF ("Info") toggle. Off for editorial contexts such as journal
+   * entries, where a technical data panel interrupts the story.
+   */
+  showExifToggle?: boolean;
 }
 
-export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev, watermark }: LightboxProps) {
+export function Lightbox({
+  assets,
+  currentIndex,
+  onClose,
+  onNext,
+  onPrev,
+  watermark,
+  showExifToggle = true,
+}: LightboxProps) {
   const [showExif, setShowExif] = useState(false);
   const { exifData, exifLoading, fetchExif, clearExif } = useExif();
   const [imageLoaded, setImageLoaded] = useState(false);
@@ -95,16 +108,39 @@ export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev, waterm
     onSwipeRight: onPrev,
   });
 
-  // Listen for 'i' key to toggle EXIF
+  /*
+   * Keyboard control and the scroll lock belong to the lightbox, not to whoever
+   * opens it: PhotoGrid used to install the arrow keys itself, so every other
+   * caller (EssayView, i.e. journal entries and photo essays) silently had no
+   * keyboard navigation at all.
+   */
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'i' || e.key === 'I') {
-        handleExifToggle();
+      switch (e.key) {
+        case 'Escape':
+          onClose();
+          break;
+        case 'ArrowRight':
+          onNext();
+          break;
+        case 'ArrowLeft':
+          onPrev();
+          break;
+        case 'i':
+        case 'I':
+          if (showExifToggle) handleExifToggle();
+          break;
       }
     };
+
     document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [handleExifToggle]);
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = '';
+    };
+  }, [handleExifToggle, onClose, onNext, onPrev, showExifToggle]);
 
   // Click on overlay background → close
   const handleOverlayClick = useCallback(
@@ -211,8 +247,8 @@ export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev, waterm
               watermark.position === 'bottom-left'
                 ? styles.watermark_bottom_left
                 : watermark.position === 'center'
-                ? styles.watermark_center
-                : styles.watermark_bottom_right
+                  ? styles.watermark_center
+                  : styles.watermark_bottom_right
             }`}
             style={{ opacity: (watermark.opacity ?? 50) / 100 }}
           >
@@ -268,16 +304,18 @@ export function Lightbox({ assets, currentIndex, onClose, onNext, onPrev, waterm
       )}
 
       {/* EXIF toggle */}
-      <button
-        className={styles.infoToggle}
-        onClick={handleExifToggle}
-        aria-expanded={showExif}
-        aria-controls="exif-panel"
-        aria-label="Toggle photo info"
-        title="Toggle photo info (i)"
-      >
-        {showExif ? 'Hide Info' : 'Info'}
-      </button>
+      {showExifToggle && (
+        <button
+          className={styles.infoToggle}
+          onClick={handleExifToggle}
+          aria-expanded={showExif}
+          aria-controls="exif-panel"
+          aria-label="Toggle photo info"
+          title="Toggle photo info (i)"
+        >
+          {showExif ? 'Hide Info' : 'Info'}
+        </button>
+      )}
 
       {/* EXIF panel */}
       {showExif && (


### PR DESCRIPTION
Five independent bugs in the public journal and essay view, all confirmed by measuring in the browser.

## Photo blocks never rendered

`EssayView` resolves a photo through `PhotoItem.id`, and those are encrypted tokens. The blocks coming out of the Markdown carry raw asset UUIDs, so every lookup missed — and unresolvable blocks are dropped silently (`if (!resolved) return null`). The ids are now translated server-side.

Side effect: raw UUIDs disappear from the client payload. They were previously present in the HTML, which contradicts the project rule that Immich UUIDs must never reach the browser. The unused `rawId` field, which also carried the UUID, is gone. Unresolvable references are now logged server-side instead of vanishing without a trace.

| | before | after |
|---|---|---|
| rendered `essay-figure` | 0 | 1 |
| raw UUIDs in HTML | 1 | 0 |

## Headings sat further left than the body text

Every block carried its own `max-width: 68ch`. `ch` is relative to each element's font, so the serif heading resolved to a wider column and started further left. Replaced by a shared, deliberately font-independent `--essay-measure` in `rem`.

## Full-bleed photos only bled to the left

`.essay-figure` is `width: 100%`, which over-constrains the box so CSS drops the negative right margin. On the public page the photo fell 1.5rem short on the right. Fixed by setting `width` as well.

## Photo pairs: portrait twice as tall as landscape

Instead of two equal columns, the pair is now a justified row — width proportional to the aspect ratio. Since height = width ÷ ratio, both photos end up exactly the same height with no cropping.

Measured at 1100px column width:

| case | left | right | height delta |
|---|---|---|---|
| 4:3 + 3:4 | 689 × 516 | 387 × 516 | 0 px |
| 16:9 + 2:3 | 783 × 440 | 293 × 440 | 0 px |
| 3:2 + 3:2 | 538 × 359 | 538 × 359 | 0 px |

## Lightbox had no keyboard control in the journal

Arrow keys, Escape and the scroll lock lived in `PhotoGrid`, i.e. only in the album grid — `EssayView` never installed a handler. All of it moved into the lightbox itself, which already knows `onNext`/`onPrev`/`onClose` as props. The duplicate handler in `PhotoGrid` was removed; keeping it would have advanced two photos per key press.

## Proofing and EXIF in editorial mode

The favorite hearts belong to client proofing — a customer marking images from an album handover. A published story has nothing to select. `EssayView` installed the `ProofingProvider` unconditionally. There is now a `proofing` prop, off by default; album views are untouched. The EXIF panel is switchable via `showExifToggle` and off in the journal.

## Index: subtitle rendered twice

`extractExcerpt()` falls back to the subtitle, and the card renders both — so every entry with a subtitle showed the same sentence twice.

## Verification

`npm run build`, `npx tsc --noEmit` and 363 unit tests pass in isolation on this branch. The measurements above come from the running dev server and from the DOM rebuilt with the real CSS files.