### PR TITLE
feat(admin): dedicated URLs for every section, reworked Journal Studio

### DIFF
--- a/app/admin/AdminShell.tsx
+++ b/app/admin/AdminShell.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useState, useEffect, type ReactNode } from 'react';
+import AdminLogin from './components/AdminLogin';
+import AdminDashboard from './components/AdminDashboard';
+import './admin.css';
+
+/**
+ * Auth gate and panel chrome for every /admin route. Lives in the admin layout
+ * rather than in each page, so navigating between tabs keeps the session check
+ * and the header mounted instead of re-running them per route.
+ */
+export default function AdminShell({ children }: { children: ReactNode }) {
+  const [authenticated, setAuthenticated] = useState<boolean | null>(null);
+  const [enabled, setEnabled] = useState(true);
+
+  useEffect(() => {
+    async function checkAuth() {
+      try {
+        const res = await fetch('/api/admin/auth');
+        const data = await res.json();
+        setAuthenticated(data.authenticated);
+        setEnabled(data.enabled);
+      } catch {
+        setAuthenticated(false);
+      }
+    }
+    checkAuth();
+  }, []);
+
+  if (authenticated === null) {
+    return (
+      <div className="admin-loading">
+        <div className="admin-spinner" />
+      </div>
+    );
+  }
+
+  if (!enabled) {
+    return (
+      <div className="admin-disabled">
+        <div className="admin-disabled-card">
+          <h1>Admin Panel</h1>
+          <p>
+            The admin panel is not enabled. Set <code>ADMIN_PASSWORD</code> in your environment
+            variables to activate it.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!authenticated) {
+    return <AdminLogin onSuccess={() => setAuthenticated(true)} />;
+  }
+
+  return <AdminDashboard onLogout={() => setAuthenticated(false)}>{children}</AdminDashboard>;
+}

--- a/app/admin/analytics/page.tsx
+++ b/app/admin/analytics/page.tsx
@@ -1,0 +1,5 @@
+import AnalyticsView from '../components/AnalyticsView';
+
+export default function AdminAnalyticsPage() {
+  return <AnalyticsView />;
+}

--- a/app/admin/components/AdminDashboard.tsx
+++ b/app/admin/components/AdminDashboard.tsx
@@ -1,21 +1,26 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-import PageBuilder from './PageBuilder';
-import SettingsEditor from './SettingsEditor';
-import AnalyticsView from './AnalyticsView';
+import { useState, useEffect, type ReactNode } from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import BackupManagerModal from './BackupManagerModal';
-import { JournalStudio } from './JournalStudio';
 import * as Icons from './Icons';
 
 interface Props {
   onLogout: () => void;
+  /** The active route's panel — Pages, Journal Studio, Settings or Analytics. */
+  children: ReactNode;
 }
 
-type Tab = 'pages' | 'journal' | 'settings' | 'analytics';
+const TABS = [
+  { label: 'Pages', href: '/admin/pages', match: /^\/admin(\/pages)?$/ },
+  { label: 'Journal', href: '/admin/journal', match: /^\/admin\/journal/ },
+  { label: 'Settings', href: '/admin/settings', match: /^\/admin\/settings/ },
+  { label: 'Analytics', href: '/admin/analytics', match: /^\/admin\/analytics/ },
+];
 
-export default function AdminDashboard({ onLogout }: Props) {
-  const [activeTab, setActiveTab] = useState<Tab>('pages');
+export default function AdminDashboard({ onLogout, children }: Props) {
+  const pathname = usePathname();
   const [saving, setSaving] = useState(false);
 
   // Diagnostics & Backup state
@@ -92,30 +97,15 @@ export default function AdminDashboard({ onLogout }: Props) {
         <div className="admin-header-left">
           <h1>Immich Folio</h1>
           <nav className="admin-tabs">
-            <button
-              className={`admin-tab ${activeTab === 'pages' ? 'active' : ''}`}
-              onClick={() => setActiveTab('pages')}
-            >
-              Pages
-            </button>
-            <button
-              className={`admin-tab ${activeTab === 'journal' ? 'active' : ''}`}
-              onClick={() => setActiveTab('journal')}
-            >
-              Journal
-            </button>
-            <button
-              className={`admin-tab ${activeTab === 'settings' ? 'active' : ''}`}
-              onClick={() => setActiveTab('settings')}
-            >
-              Settings
-            </button>
-            <button
-              className={`admin-tab ${activeTab === 'analytics' ? 'active' : ''}`}
-              onClick={() => setActiveTab('analytics')}
-            >
-              Analytics
-            </button>
+            {TABS.map((t) => (
+              <Link
+                key={t.href}
+                href={t.href}
+                className={`admin-tab ${t.match.test(pathname) ? 'active' : ''}`}
+              >
+                {t.label}
+              </Link>
+            ))}
           </nav>
         </div>
         <div className="admin-header-right">
@@ -202,6 +192,8 @@ export default function AdminDashboard({ onLogout }: Props) {
             )}
           </div>
 
+          <span className="admin-header-divider" aria-hidden="true" />
+
           <a
             href="/?fresh=1"
             target="_blank"
@@ -232,12 +224,7 @@ export default function AdminDashboard({ onLogout }: Props) {
         </div>
       </header>
 
-      <main className="admin-main">
-        {activeTab === 'pages' && <PageBuilder />}
-        {activeTab === 'journal' && <JournalStudio />}
-        {activeTab === 'settings' && <SettingsEditor />}
-        {activeTab === 'analytics' && <AnalyticsView />}
-      </main>
+      <main className="admin-main">{children}</main>
 
       <BackupManagerModal
         isOpen={showBackupModal}

--- a/app/admin/components/BlockBadge.tsx
+++ b/app/admin/components/BlockBadge.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import type { JournalBlock } from '@/lib/journal';
+import { IconFileText, IconSparkles, IconQuote, IconCamera, IconArrowLeftRight } from './Icons';
+
+type BlockType = JournalBlock['type'];
+
+/**
+ * Block type chips for the Journal Studio and the Pages essay builder.
+ *
+ * Deliberately monochrome: the panel's colour language is neutral surfaces plus
+ * a single accent, and these chips label a block rather than reporting a state,
+ * so they carry no colour of their own. The block type is told apart by its
+ * icon — the same icon the "Add Block" toolbar uses for it.
+ */
+const BLOCK_META: Record<BlockType, { label: string; Icon: typeof IconFileText }> = {
+  paragraph: { label: 'Text', Icon: IconFileText },
+  heading: { label: 'Heading', Icon: IconSparkles },
+  quote: { label: 'Quote', Icon: IconQuote },
+  photo: { label: 'Photo', Icon: IconCamera },
+  'photo-pair': { label: 'Photo Pair', Icon: IconArrowLeftRight },
+};
+
+interface BlockBadgeProps {
+  type: BlockType;
+  /** Optional position prefix, e.g. "3" renders as "3 · Quote". */
+  index?: number;
+}
+
+export function BlockBadge({ type, index }: BlockBadgeProps) {
+  const meta = BLOCK_META[type];
+  if (!meta) return <span className="essay-block-badge">{type}</span>;
+
+  const { label, Icon } = meta;
+  return (
+    <span className="essay-block-badge">
+      <Icon size={11} />
+      {index != null && <span className="essay-block-badge-index">{index}</span>}
+      {label}
+    </span>
+  );
+}

--- a/app/admin/components/Icons.tsx
+++ b/app/admin/components/Icons.tsx
@@ -404,3 +404,79 @@ export function IconCheck({ size = 16, className = 'svg-icon', strokeWidth = 2, 
   );
 }
 
+/** Open book — journal entries and photo essays. */
+export function IconBook({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
+      <path d="M12 7v14" />
+      <path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z" />
+    </svg>
+  );
+}
+
+export function IconEye({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
+      <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7z" />
+      <circle cx="12" cy="12" r="3" />
+    </svg>
+  );
+}
+
+/** Clock — reading time. */
+export function IconClock({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
+      <circle cx="12" cy="12" r="9" />
+      <path d="M12 7v5l3 2" />
+    </svg>
+  );
+}

--- a/app/admin/components/JournalStudio.tsx
+++ b/app/admin/components/JournalStudio.tsx
@@ -1,12 +1,9 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useRouter } from 'next/navigation';
 import type { JournalEntrySummary, ParsedJournal, JournalBlock } from '@/lib/journal';
-import {
-  parseJournalMarkdown,
-  serializeJournalMarkdown,
-  sanitizeSlug,
-} from '@/lib/journal';
+import { parseJournalMarkdown, serializeJournalMarkdown, sanitizeSlug } from '@/lib/journal';
 import {
   IconFileText,
   IconSparkles,
@@ -19,18 +16,29 @@ import {
   IconGear,
   IconLink,
   IconPlus,
+  IconBook,
+  IconEye,
+  IconClock,
+  IconCalendar,
+  IconLock,
+  IconCheck,
 } from './Icons';
 import AssetPicker from './AssetPicker';
+import { BlockBadge } from './BlockBadge';
 import { EssayView } from '@/app/[...path]/EssayView';
 import type { PhotoItem } from '@/app/[...path]/PhotoGrid';
-import { useScrollLock } from './useScrollLock';
 import './journal-studio.css';
 
-export function JournalStudio() {
+interface JournalStudioProps {
+  /** Entry to open, taken from the /admin/journal/[slug] route. */
+  slug?: string;
+}
+
+export function JournalStudio({ slug: activeSlug }: JournalStudioProps) {
+  const router = useRouter();
   const [entries, setEntries] = useState<JournalEntrySummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [activeSlug, setActiveSlug] = useState<string | null>(null);
 
   // New Entry Modal
   const [showCreateModal, setShowCreateModal] = useState(false);
@@ -83,7 +91,7 @@ export function JournalStudio() {
         setNewSlug('');
         await fetchEntries();
         if (data.entry?.slug) {
-          setActiveSlug(data.entry.slug);
+          router.push(`/admin/journal/${data.entry.slug}`);
         }
       } else {
         const data = await res.json();
@@ -105,7 +113,7 @@ export function JournalStudio() {
       });
       if (res.ok) {
         await fetchEntries();
-        if (activeSlug === slug) setActiveSlug(null);
+        if (activeSlug === slug) router.push('/admin/journal');
       } else {
         alert('Failed to delete journal entry');
       }
@@ -115,15 +123,7 @@ export function JournalStudio() {
   };
 
   if (activeSlug) {
-    return (
-      <JournalEditor
-        slug={activeSlug}
-        onBack={() => {
-          setActiveSlug(null);
-          fetchEntries();
-        }}
-      />
-    );
+    return <JournalEditor slug={activeSlug} onBack={() => router.push('/admin/journal')} />;
   }
 
   return (
@@ -131,7 +131,7 @@ export function JournalStudio() {
       <div className="journal-studio-header">
         <div>
           <h2>
-            <span>📖</span> Journal &amp; Photo Essays
+            <IconBook size={20} /> Journal &amp; Photo Essays
           </h2>
           <p style={{ margin: '4px 0 0', opacity: 0.7, fontSize: '0.9rem' }}>
             Author visual stories, field notes, and longform photo essays with live preview.
@@ -151,9 +151,7 @@ export function JournalStudio() {
           Loading journal entries...
         </div>
       ) : error ? (
-        <div style={{ padding: '3rem', textAlign: 'center', color: '#ef4444' }}>
-          {error}
-        </div>
+        <div style={{ padding: '3rem', textAlign: 'center', color: '#ef4444' }}>{error}</div>
       ) : entries.length === 0 ? (
         <div style={{ padding: '5rem 2rem', textAlign: 'center', opacity: 0.6 }}>
           <h3>No journal entries yet</h3>
@@ -180,7 +178,7 @@ export function JournalStudio() {
                     alt={entry.frontmatter.title || entry.slug}
                   />
                 ) : (
-                  <span style={{ fontSize: '2.5rem', opacity: 0.3 }}>📖</span>
+                  <IconBook size={36} className="svg-icon journal-card-cover-placeholder" />
                 )}
               </div>
               <div className="journal-admin-card-body">
@@ -190,21 +188,31 @@ export function JournalStudio() {
                 <div className="journal-admin-card-slug">/journal/{entry.slug}</div>
 
                 <div className="journal-admin-card-meta">
-                  {entry.frontmatter.date && <span>📅 {entry.frontmatter.date}</span>}
-                  <span>⏱️ {entry.readingTimeMinutes} min</span>
-                  {entry.frontmatter.draft ? (
-                    <span style={{ color: '#eab308', fontWeight: 600 }}>[Draft]</span>
-                  ) : (
-                    <span style={{ color: '#22c55e', fontWeight: 600 }}>[Published]</span>
+                  {entry.frontmatter.date && (
+                    <span>
+                      <IconCalendar size={12} /> {entry.frontmatter.date}
+                    </span>
                   )}
-                  {entry.frontmatter.password && <span>🔒 Password</span>}
+                  <span>
+                    <IconClock size={12} /> {entry.readingTimeMinutes} min
+                  </span>
+                  {entry.frontmatter.draft ? (
+                    <span className="journal-status-pill is-draft">Draft</span>
+                  ) : (
+                    <span className="journal-status-pill is-published">Published</span>
+                  )}
+                  {entry.frontmatter.password && (
+                    <span>
+                      <IconLock size={12} /> Password
+                    </span>
+                  )}
                 </div>
 
                 <div className="journal-admin-card-actions">
                   <button
                     type="button"
                     className="admin-btn admin-btn-sm admin-btn-primary"
-                    onClick={() => setActiveSlug(entry.slug)}
+                    onClick={() => router.push(`/admin/journal/${entry.slug}`)}
                   >
                     Edit in Studio
                   </button>
@@ -240,7 +248,14 @@ export function JournalStudio() {
             <h3 style={{ margin: '0 0 1rem' }}>Create New Journal Entry</h3>
             <form onSubmit={handleCreate}>
               <div style={{ marginBottom: '1rem' }}>
-                <label style={{ display: 'block', fontSize: '0.85rem', marginBottom: '4px', opacity: 0.8 }}>
+                <label
+                  style={{
+                    display: 'block',
+                    fontSize: '0.85rem',
+                    marginBottom: '4px',
+                    opacity: 0.8,
+                  }}
+                >
                   Title
                 </label>
                 <input
@@ -260,7 +275,14 @@ export function JournalStudio() {
               </div>
 
               <div style={{ marginBottom: '1.5rem' }}>
-                <label style={{ display: 'block', fontSize: '0.85rem', marginBottom: '4px', opacity: 0.8 }}>
+                <label
+                  style={{
+                    display: 'block',
+                    fontSize: '0.85rem',
+                    marginBottom: '4px',
+                    opacity: 0.8,
+                  }}
+                >
                   URL Slug
                 </label>
                 <input
@@ -271,7 +293,9 @@ export function JournalStudio() {
                   onChange={(e) => setNewSlug(sanitizeSlug(e.target.value))}
                   required
                 />
-                <span style={{ fontSize: '0.75rem', opacity: 0.6, marginTop: '2px', display: 'block' }}>
+                <span
+                  style={{ fontSize: '0.75rem', opacity: 0.6, marginTop: '2px', display: 'block' }}
+                >
                   Will be accessible at /journal/{newSlug || 'slug'}
                 </span>
               </div>
@@ -307,12 +331,84 @@ interface JournalEditorProps {
   onBack: () => void;
 }
 
+/**
+ * Photo blocks may carry a legacy positional reference ("1", "2") instead of an
+ * asset UUID. Those only ever resolved against a subpage's album; on a
+ * standalone journal page there is no album, so the photo silently disappears.
+ * Flag them in the editor so the author can re-pick before publishing.
+ */
+const ASSET_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isLegacyAssetRef(assetId: string): boolean {
+  return assetId.length > 0 && !ASSET_UUID.test(assetId);
+}
+
+/** Width of the authoring pane, in percent of the split view. */
+const SPLIT_STORAGE_KEY = 'folio-journal-split';
+const SPLIT_MIN = 25;
+const SPLIT_MAX = 70;
+const SPLIT_DEFAULT = 46;
+
 function JournalEditor({ slug, onBack }: JournalEditorProps) {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [dirty, setDirty] = useState(false);
   const [editorMode, setEditorMode] = useState<'blocks' | 'markdown'>('blocks');
   const [viewport, setViewport] = useState<'desktop' | 'mobile'>('desktop');
+
+  // Draggable divider between authoring pane and preview.
+  const splitRef = useRef<HTMLDivElement>(null);
+  const [splitPct, setSplitPct] = useState(SPLIT_DEFAULT);
+  const [dragging, setDragging] = useState(false);
+
+  // Restore the last width after mount (localStorage is unavailable on the server).
+  useEffect(() => {
+    const stored = Number(window.localStorage.getItem(SPLIT_STORAGE_KEY));
+    if (stored >= SPLIT_MIN && stored <= SPLIT_MAX) setSplitPct(stored);
+  }, []);
+
+  const applySplit = useCallback((clientX: number) => {
+    const rect = splitRef.current?.getBoundingClientRect();
+    if (!rect || rect.width === 0) return;
+    const pct = ((clientX - rect.left) / rect.width) * 100;
+    setSplitPct(Math.min(SPLIT_MAX, Math.max(SPLIT_MIN, pct)));
+  }, []);
+
+  useEffect(() => {
+    if (!dragging) return;
+    const onMove = (e: MouseEvent) => {
+      e.preventDefault();
+      applySplit(e.clientX);
+    };
+    const onUp = () => setDragging(false);
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+    return () => {
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+    };
+  }, [dragging, applySplit]);
+
+  // Persist once the drag ends, not on every pixel.
+  useEffect(() => {
+    if (dragging) return;
+    window.localStorage.setItem(SPLIT_STORAGE_KEY, String(Math.round(splitPct)));
+  }, [dragging, splitPct]);
+
+  // Keyboard access for the divider: arrows nudge, Home resets.
+  const handleSplitKeyDown = (e: React.KeyboardEvent) => {
+    const step = e.shiftKey ? 10 : 2;
+    if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      setSplitPct((p) => Math.max(SPLIT_MIN, p - step));
+    } else if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      setSplitPct((p) => Math.min(SPLIT_MAX, p + step));
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      setSplitPct(SPLIT_DEFAULT);
+    }
+  };
 
   const [rawMarkdown, setRawMarkdown] = useState('');
   const [parsed, setParsed] = useState<ParsedJournal>(() => ({
@@ -323,6 +419,9 @@ function JournalEditor({ slug, onBack }: JournalEditorProps) {
 
   // Settings / Metadata Modal
   const [showMetaModal, setShowMetaModal] = useState(false);
+
+  /** Real width/height ratios of the referenced photos, measured from thumbnails. */
+  const [assetRatios, setAssetRatios] = useState<Record<string, number>>({});
 
   // Asset Picker State
   const [assetPickerTarget, setAssetPickerTarget] = useState<{
@@ -372,8 +471,8 @@ function JournalEditor({ slug, onBack }: JournalEditorProps) {
             if (b.type === 'photo') return [b.assetId];
             if (b.type === 'photo-pair') return b.assetIds;
             return [];
-          })
-        )
+          }),
+        ),
       ),
     };
     const serialized = serializeJournalMarkdown(updated);
@@ -434,6 +533,40 @@ function JournalEditor({ slug, onBack }: JournalEditorProps) {
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [handleSave]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  /*
+   * The preview used to hard-code 3:2 for every photo, so the studio showed a
+   * cropped, uniform grid while the published page laid the photos out by their
+   * real proportions. There is no admin endpoint that reports asset dimensions,
+   * so the thumbnails are measured once as they load.
+   */
+  const measuredRef = useRef(new Set<string>());
+
+  useEffect(() => {
+    let cancelled = false;
+    for (const id of parsed.referencedAssetIds) {
+      if (!id || measuredRef.current.has(id)) continue;
+      measuredRef.current.add(id);
+
+      const probe = new window.Image();
+      probe.onload = () => {
+        if (cancelled || !probe.naturalHeight) return;
+        setAssetRatios((prev) => ({
+          ...prev,
+          [id]: probe.naturalWidth / probe.naturalHeight,
+        }));
+      };
+      probe.onerror = () => {
+        // Unresolvable reference — keep the fallback ratio, the block editor
+        // already flags it.
+        measuredRef.current.delete(id);
+      };
+      probe.src = `/api/admin/thumbnail/${id}`;
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, [parsed.referencedAssetIds]);
+
   // Block manipulation
   const handleAddBlock = (type: JournalBlock['type']) => {
     let newBlock: JournalBlock;
@@ -483,7 +616,8 @@ function JournalEditor({ slug, onBack }: JournalEditorProps) {
     thumbUrl: `/api/admin/thumbnail/${id}`,
     previewUrl: `/api/admin/thumbnail/${id}`,
     exifUrl: `/api/exif/${id}`,
-    aspectRatio: 1.5,
+    // Falls back to 3:2 only until the real ratio has been measured.
+    aspectRatio: assetRatios[id] ?? 1.5,
   }));
 
   if (loading) {
@@ -515,7 +649,15 @@ function JournalEditor({ slug, onBack }: JournalEditorProps) {
             onChange={(e) => handleFrontmatterChange({ title: e.target.value })}
           />
 
-          <div style={{ display: 'flex', gap: '4px', background: 'rgba(255,255,255,0.06)', borderRadius: '6px', padding: '2px' }}>
+          <div
+            style={{
+              display: 'flex',
+              gap: '4px',
+              background: 'rgba(255,255,255,0.06)',
+              borderRadius: '6px',
+              padding: '2px',
+            }}
+          >
             <button
               type="button"
               className={`admin-btn admin-btn-xs ${editorMode === 'blocks' ? 'admin-btn-primary' : ''}`}
@@ -557,13 +699,25 @@ function JournalEditor({ slug, onBack }: JournalEditorProps) {
             onClick={handleSave}
             disabled={saving}
           >
-            {saving ? 'Saving...' : dirty ? '💾 Save Changes' : '✅ Saved'}
+            {saving ? (
+              'Saving...'
+            ) : dirty ? (
+              'Save Changes'
+            ) : (
+              <>
+                <IconCheck size={14} /> Saved
+              </>
+            )}
           </button>
         </div>
       </div>
 
       {/* Split Screen */}
-      <div className="journal-editor-split">
+      <div
+        className={`journal-editor-split${dragging ? ' is-dragging' : ''}`}
+        ref={splitRef}
+        style={{ ['--journal-split-left' as string]: `${splitPct}%` }}
+      >
         {/* Left: Authoring Pane */}
         <div className="journal-editor-pane-left">
           {editorMode === 'markdown' ? (
@@ -577,7 +731,7 @@ function JournalEditor({ slug, onBack }: JournalEditorProps) {
             <div>
               {/* Add Block Toolbar */}
               <div className="essay-toolbar-sticky">
-                <span className="essay-toolbar-label">✨ Add Block:</span>
+                <span className="essay-toolbar-label">Add Block:</span>
                 <button
                   type="button"
                   className="admin-btn admin-btn-xs"
@@ -617,13 +771,13 @@ function JournalEditor({ slug, onBack }: JournalEditorProps) {
               </div>
 
               {/* Blocks List */}
-              <div style={{ marginTop: '1rem', display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+              <div
+                style={{ marginTop: '1rem', display: 'flex', flexDirection: 'column', gap: '1rem' }}
+              >
                 {parsed.blocks.map((block, idx) => (
                   <div key={idx} className="essay-block-card">
                     <div className="essay-block-card-header">
-                      <span className={`essay-block-badge badge-${block.type.startsWith('photo') ? 'photo' : block.type}`}>
-                        {block.type}
-                      </span>
+                      <BlockBadge type={block.type} />
                       <div className="essay-block-actions">
                         <button
                           type="button"
@@ -653,13 +807,13 @@ function JournalEditor({ slug, onBack }: JournalEditorProps) {
 
                     <div style={{ marginTop: '0.75rem' }}>
                       {block.type === 'heading' && (
-                        <div style={{ display: 'flex', gap: '8px' }}>
+                        <div className="journal-heading-row">
                           <select
+                            className="admin-input journal-level-select"
                             value={block.level}
                             onChange={(e) =>
                               handleUpdateBlock(idx, { ...block, level: Number(e.target.value) })
                             }
-                            style={{ width: '70px' }}
                           >
                             <option value={1}>H1</option>
                             <option value={2}>H2</option>
@@ -710,12 +864,20 @@ function JournalEditor({ slug, onBack }: JournalEditorProps) {
                         </div>
                       )}
 
+                      {block.type === 'photo' && isLegacyAssetRef(block.assetId) && (
+                        <p className="journal-block-warning">
+                          Reference &quot;{block.assetId}&quot; is a legacy album position, not a
+                          photo. It will not appear on the published page — pick a photo below.
+                        </p>
+                      )}
+
                       {block.type === 'photo' && (
                         <div style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
                           <div
                             style={{
-                              width: '100px',
-                              height: '70px',
+                              width: '140px',
+                              height: '96px',
+                              flexShrink: 0,
                               background: 'rgba(0,0,0,0.3)',
                               borderRadius: '6px',
                               overflow: 'hidden',
@@ -727,8 +889,7 @@ function JournalEditor({ slug, onBack }: JournalEditorProps) {
                             onClick={() =>
                               setAssetPickerTarget({
                                 title: 'Select Photo for Story',
-                                onSelect: (id) =>
-                                  handleUpdateBlock(idx, { ...block, assetId: id }),
+                                onSelect: (id) => handleUpdateBlock(idx, { ...block, assetId: id }),
                               })
                             }
                           >
@@ -744,9 +905,17 @@ function JournalEditor({ slug, onBack }: JournalEditorProps) {
                             )}
                           </div>
 
-                          <div style={{ flexGrow: 1, display: 'flex', flexDirection: 'column', gap: '6px' }}>
-                            <div style={{ display: 'flex', gap: '8px' }}>
+                          <div
+                            style={{
+                              flexGrow: 1,
+                              display: 'flex',
+                              flexDirection: 'column',
+                              gap: '6px',
+                            }}
+                          >
+                            <div className="journal-photo-layout-row">
                               <select
+                                className="admin-input"
                                 value={block.layout}
                                 onChange={(e) =>
                                   handleUpdateBlock(idx, {
@@ -786,9 +955,19 @@ function JournalEditor({ slug, onBack }: JournalEditorProps) {
                         </div>
                       )}
 
+                      {block.type === 'photo-pair' && block.assetIds.some(isLegacyAssetRef) && (
+                        <p className="journal-block-warning">
+                          References &quot;{block.assetIds.filter(isLegacyAssetRef).join('", "')}
+                          &quot; are legacy album positions, not photos. They will not appear on the
+                          published page — pick photos below.
+                        </p>
+                      )}
+
                       {block.type === 'photo-pair' && (
                         <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-                          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1rem' }}>
+                          <div
+                            style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1rem' }}
+                          >
                             {[0, 1].map((pIdx) => (
                               <div
                                 key={pIdx}
@@ -848,10 +1027,32 @@ function JournalEditor({ slug, onBack }: JournalEditorProps) {
           )}
         </div>
 
+        {/* Draggable divider */}
+        <div
+          className="journal-editor-resizer"
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize editor and preview"
+          aria-valuenow={Math.round(splitPct)}
+          aria-valuemin={SPLIT_MIN}
+          aria-valuemax={SPLIT_MAX}
+          tabIndex={0}
+          onMouseDown={(e) => {
+            e.preventDefault();
+            setDragging(true);
+          }}
+          onDoubleClick={() => setSplitPct(SPLIT_DEFAULT)}
+          onKeyDown={handleSplitKeyDown}
+        >
+          <span className="journal-editor-resizer-grip" aria-hidden="true" />
+        </div>
+
         {/* Right: Live Preview Pane */}
         <div className="journal-editor-pane-right">
           <div className="journal-preview-bar">
-            <span>👁️ Realtime Theme Preview</span>
+            <span className="journal-preview-bar-label">
+              <IconEye size={13} /> Realtime Theme Preview
+            </span>
             <div style={{ display: 'flex', gap: '4px' }}>
               <button
                 type="button"
@@ -889,7 +1090,14 @@ function JournalEditor({ slug, onBack }: JournalEditorProps) {
 
             <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
               <div>
-                <label style={{ display: 'block', fontSize: '0.8rem', opacity: 0.8, marginBottom: '4px' }}>
+                <label
+                  style={{
+                    display: 'block',
+                    fontSize: '0.8rem',
+                    opacity: 0.8,
+                    marginBottom: '4px',
+                  }}
+                >
                   Subtitle
                 </label>
                 <input
@@ -903,7 +1111,14 @@ function JournalEditor({ slug, onBack }: JournalEditorProps) {
 
               <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1rem' }}>
                 <div>
-                  <label style={{ display: 'block', fontSize: '0.8rem', opacity: 0.8, marginBottom: '4px' }}>
+                  <label
+                    style={{
+                      display: 'block',
+                      fontSize: '0.8rem',
+                      opacity: 0.8,
+                      marginBottom: '4px',
+                    }}
+                  >
                     Author
                   </label>
                   <input
@@ -915,7 +1130,14 @@ function JournalEditor({ slug, onBack }: JournalEditorProps) {
                   />
                 </div>
                 <div>
-                  <label style={{ display: 'block', fontSize: '0.8rem', opacity: 0.8, marginBottom: '4px' }}>
+                  <label
+                    style={{
+                      display: 'block',
+                      fontSize: '0.8rem',
+                      opacity: 0.8,
+                      marginBottom: '4px',
+                    }}
+                  >
                     Publish Date
                   </label>
                   <input
@@ -928,7 +1150,14 @@ function JournalEditor({ slug, onBack }: JournalEditorProps) {
               </div>
 
               <div>
-                <label style={{ display: 'block', fontSize: '0.8rem', opacity: 0.8, marginBottom: '4px' }}>
+                <label
+                  style={{
+                    display: 'block',
+                    fontSize: '0.8rem',
+                    opacity: 0.8,
+                    marginBottom: '4px',
+                  }}
+                >
                   Cover Photo
                 </label>
                 <div style={{ display: 'flex', gap: '10px', alignItems: 'center' }}>
@@ -980,7 +1209,14 @@ function JournalEditor({ slug, onBack }: JournalEditorProps) {
               </div>
 
               <div>
-                <label style={{ display: 'block', fontSize: '0.8rem', opacity: 0.8, marginBottom: '4px' }}>
+                <label
+                  style={{
+                    display: 'block',
+                    fontSize: '0.8rem',
+                    opacity: 0.8,
+                    marginBottom: '4px',
+                  }}
+                >
                   Password Protection (Optional)
                 </label>
                 <input

--- a/app/admin/components/SettingsEditor.tsx
+++ b/app/admin/components/SettingsEditor.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 import * as Icons from './Icons';
 import SaveBar from './SaveBar';
 
@@ -74,13 +75,37 @@ const PHOTO_FRAMES = ['none', 'passepartout', 'shadow'];
 const HERO_STYLES = ['split', 'fullbleed', 'minimal', 'stacked', 'typographic', 'mosaic'];
 const ASPECT_RATIOS = ['1', '3/2', '2/3', '16/9', 'auto'];
 
-const THEME_INFO: Record<string, { desc: string; label: string; accent: string; bg: string; tile: string }> = {
+/**
+ * Card metadata for the theme picker. `font`, `radius` and `frame` mirror the
+ * real preset definitions in lib/config/theme.ts so the mini mockups show what
+ * the preset actually does; `gap` is the visual density of its gallery grid.
+ */
+const THEME_INFO: Record<
+  string,
+  {
+    desc: string;
+    label: string;
+    accent: string;
+    bg: string;
+    tile: string;
+    font: string;
+    type: 'serif' | 'sans' | 'mono';
+    radius: number;
+    frame: 'none' | 'passepartout' | 'shadow';
+    gap: number;
+  }
+> = {
   studio: {
     label: 'Studio',
     desc: 'Clean, high-contrast grid with sans-serif type.',
     bg: '#141414',
     tile: '#242424',
     accent: '#e60012',
+    font: 'Playfair Display',
+    type: 'serif',
+    radius: 0,
+    frame: 'passepartout',
+    gap: 4,
   },
   'studio-modern': {
     label: 'Studio Modern',
@@ -88,6 +113,11 @@ const THEME_INFO: Record<string, { desc: string; label: string; accent: string; 
     bg: '#121212',
     tile: '#191919',
     accent: '#e60012',
+    font: 'Archivo',
+    type: 'sans',
+    radius: 0,
+    frame: 'none',
+    gap: 3,
   },
   minimal: {
     label: 'Minimal',
@@ -95,6 +125,11 @@ const THEME_INFO: Record<string, { desc: string; label: string; accent: string; 
     bg: '#ffffff',
     tile: '#f3f3f3',
     accent: '#111111',
+    font: 'Geist',
+    type: 'sans',
+    radius: 0,
+    frame: 'none',
+    gap: 2,
   },
   editorial: {
     label: 'Editorial',
@@ -102,6 +137,11 @@ const THEME_INFO: Record<string, { desc: string; label: string; accent: string; 
     bg: '#fbf9f4',
     tile: '#e5dfd4',
     accent: '#b89053',
+    font: 'Bodoni Moda',
+    type: 'serif',
+    radius: 0,
+    frame: 'shadow',
+    gap: 8,
   },
   classic: {
     label: 'Classic',
@@ -109,6 +149,11 @@ const THEME_INFO: Record<string, { desc: string; label: string; accent: string; 
     bg: '#f7f7f7',
     tile: '#ffffff',
     accent: '#444444',
+    font: 'Cinzel',
+    type: 'serif',
+    radius: 12,
+    frame: 'passepartout',
+    gap: 7,
   },
   noir: {
     label: 'Noir',
@@ -116,6 +161,11 @@ const THEME_INFO: Record<string, { desc: string; label: string; accent: string; 
     bg: '#000000',
     tile: '#151515',
     accent: '#ffffff',
+    font: 'Libre Baskerville',
+    type: 'serif',
+    radius: 0,
+    frame: 'passepartout',
+    gap: 6,
   },
   monograph: {
     label: 'Monograph',
@@ -123,17 +173,41 @@ const THEME_INFO: Record<string, { desc: string; label: string; accent: string; 
     bg: '#f4f4f6',
     tile: '#ffffff',
     accent: '#555555',
+    font: 'Instrument Serif',
+    type: 'mono',
+    radius: 0,
+    frame: 'none',
+    gap: 5,
   },
 };
 
-export default function SettingsEditor() {
+const SETTINGS_SECTIONS = [
+  { id: 'general', label: 'General' },
+  { id: 'theme', label: 'Theme' },
+  { id: 'grid', label: 'Grid' },
+  { id: 'footer', label: 'Footer' },
+  { id: 'legal', label: 'Legal' },
+  { id: 'seo', label: 'SEO' },
+  { id: 'security', label: 'Security & Protection' },
+];
+
+interface SettingsEditorProps {
+  /** Sub-section to show, taken from the /admin/settings/[section] route. */
+  section?: string;
+}
+
+export default function SettingsEditor({ section }: SettingsEditorProps) {
   const router = useRouter();
+  // An unknown section in the URL falls back to General instead of an empty panel.
+  const activeSection = SETTINGS_SECTIONS.some((sec) => sec.id === section)
+    ? (section as string)
+    : 'general';
   const [settings, setSettings] = useState<Settings>({});
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [dirty, setDirty] = useState(false);
   const [saveMessage, setSaveMessage] = useState('');
-  const [activeSection, setActiveSection] = useState('general');
+
   const [currentMode, setCurrentMode] = useState<'dark' | 'light'>('dark');
   const [faviconUploading, setFaviconUploading] = useState(false);
   const [faviconMessage, setFaviconMessage] = useState('');
@@ -278,16 +352,6 @@ export default function SettingsEditor() {
     );
   }
 
-  const sections = [
-    { id: 'general', label: 'General' },
-    { id: 'theme', label: 'Theme' },
-    { id: 'grid', label: 'Grid' },
-    { id: 'footer', label: 'Footer' },
-    { id: 'legal', label: 'Legal' },
-    { id: 'seo', label: 'SEO' },
-    { id: 'security', label: 'Security & Protection' },
-  ];
-
   return (
     <div className="settings-editor">
       <SaveBar
@@ -298,19 +362,21 @@ export default function SettingsEditor() {
         label="Save Settings"
       />
 
-      <p className="settings-live-sync-note">⚡ Live Sync (No Docker restart required)</p>
+      <p className="settings-live-sync-note">
+        <Icons.IconRefresh size={13} /> Live Sync (No Docker restart required)
+      </p>
 
       <div className="settings-layout">
         {/* Sidebar */}
         <nav className="settings-nav">
-          {sections.map((sec) => (
-            <button
+          {SETTINGS_SECTIONS.map((sec) => (
+            <Link
               key={sec.id}
+              href={`/admin/settings/${sec.id}`}
               className={`settings-nav-item ${activeSection === sec.id ? 'active' : ''}`}
-              onClick={() => setActiveSection(sec.id)}
             >
               {sec.label}
-            </button>
+            </Link>
           ))}
         </nav>
 
@@ -504,30 +570,52 @@ export default function SettingsEditor() {
                 <label>Preset</label>
                 <div className="preset-card-grid">
                   {PRESETS.map((p) => {
-                    const info = THEME_INFO[p] || { label: p, desc: '', bg: '#fff', tile: '#eee', accent: '#333' };
+                    const info = THEME_INFO[p] || {
+                      label: p,
+                      desc: '',
+                      bg: '#fff',
+                      tile: '#eee',
+                      accent: '#333',
+                      font: 'System',
+                      type: 'sans' as const,
+                      radius: 0,
+                      frame: 'none' as const,
+                      gap: 4,
+                    };
                     const isActive = (settings.theme?.preset || 'studio') === p;
                     return (
                       <button
                         key={p}
                         type="button"
-                        className={`preset-card ${isActive ? 'active' : ''}`}
+                        className={`preset-card theme-preset-card ${isActive ? 'active' : ''}`}
                         onClick={() => update('theme.preset', p)}
-                        style={{ '--preset-accent': info.accent } as React.CSSProperties}
+                        style={
+                          {
+                            '--preset-accent': info.accent,
+                            '--preset-bg': info.bg,
+                            '--preset-tile': info.tile,
+                            '--preset-radius': `${info.radius}px`,
+                            '--preset-gap': `${info.gap}px`,
+                          } as React.CSSProperties
+                        }
                       >
-                        <div className="preset-card-preview" style={{ backgroundColor: info.bg }}>
+                        <div className="preset-card-preview" data-frame={info.frame}>
                           <div className="mini-header">
-                            <span className="mini-dot" style={{ backgroundColor: info.accent }}></span>
-                            <span className="mini-line" style={{ backgroundColor: isActive ? info.accent : 'var(--admin-border)' }}></span>
+                            <span className={`mini-specimen type-${info.type}`}>Aa</span>
+                            <span className="mini-line" />
                           </div>
                           <div className="mini-grid">
-                            <div className="mini-tile" style={{ backgroundColor: info.tile }}></div>
-                            <div className="mini-tile" style={{ backgroundColor: info.tile }}></div>
-                            <div className="mini-tile" style={{ backgroundColor: info.tile }}></div>
+                            <div className="mini-tile" />
+                            <div className="mini-tile" />
+                            <div className="mini-tile" />
                           </div>
                         </div>
                         <div className="preset-card-info">
                           <span className="preset-card-name">{info.label}</span>
                           <span className="preset-card-desc">{info.desc}</span>
+                          <span className="preset-card-specs">
+                            {info.font} &middot; radius {info.radius} &middot; {info.frame}
+                          </span>
                         </div>
                       </button>
                     );
@@ -812,7 +900,7 @@ export default function SettingsEditor() {
                             )}
                             {l === 'showcase' && (
                               <div className="demo-showcase-grid">
-                                <div className="demo-tile hero-tile" />
+                                <div className="demo-tile demo-hero" />
                                 <div className="demo-col"><div className="demo-tile" /><div className="demo-tile" /></div>
                               </div>
                             )}

--- a/app/admin/components/journal-studio.css
+++ b/app/admin/components/journal-studio.css
@@ -1,5 +1,82 @@
 /* ── Journal Studio & Editor CSS ──────────────────────────────────── */
 
+/*
+ * The studio is a full-width workspace: it breaks out of the 1120px
+ * `.admin-main` column so the split view has room for editor *and* preview.
+ */
+.admin-main:has(> .journal-studio),
+.admin-main:has(> .journal-editor-container) {
+  max-width: none;
+  padding: 0;
+}
+
+/* ── Form controls ─────────────────────────────────────────────────
+ * Local field styling for the studio. Scoped so the generic class name
+ * cannot leak into the rest of the admin panel.
+ */
+.journal-studio .admin-input,
+.journal-editor-container .admin-input,
+.journal-modal-card .admin-input {
+  display: block;
+  width: 100%;
+  padding: 0.55rem 0.7rem;
+  background: var(--admin-bg-input, #161616);
+  border: 1px solid var(--admin-border, #2e2e2e);
+  border-radius: 8px;
+  color: var(--admin-text, #f0f0f0);
+  font-family: inherit;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  transition:
+    border-color 0.15s ease,
+    background 0.15s ease;
+}
+
+.journal-studio .admin-input:hover,
+.journal-editor-container .admin-input:hover,
+.journal-modal-card .admin-input:hover {
+  border-color: var(--admin-border-hover, #444);
+}
+
+.journal-studio .admin-input:focus,
+.journal-editor-container .admin-input:focus,
+.journal-modal-card .admin-input:focus {
+  outline: none;
+  border-color: var(--admin-border-focus, #6366f1);
+}
+
+.journal-studio .admin-input::placeholder,
+.journal-editor-container .admin-input::placeholder,
+.journal-modal-card .admin-input::placeholder {
+  color: var(--admin-text-secondary, #a0a0a0);
+  opacity: 0.7;
+}
+
+.journal-editor-container textarea.admin-input,
+.journal-modal-card textarea.admin-input {
+  resize: vertical;
+  min-height: 88px;
+}
+
+.journal-editor-container select.admin-input {
+  cursor: pointer;
+  appearance: none;
+  padding-right: 2rem;
+  background-image:
+    linear-gradient(45deg, transparent 50%, currentColor 50%),
+    linear-gradient(135deg, currentColor 50%, transparent 50%);
+  background-position:
+    calc(100% - 16px) calc(50% + 1px),
+    calc(100% - 11px) calc(50% + 1px);
+  background-size: 5px 5px;
+  background-repeat: no-repeat;
+}
+
+.journal-level-select {
+  width: 5.5rem;
+  flex-shrink: 0;
+}
+
 .journal-studio {
   display: flex;
   flex-direction: column;
@@ -38,7 +115,9 @@
   overflow: hidden;
   display: flex;
   flex-direction: column;
-  transition: border-color 0.2s ease, transform 0.2s ease;
+  transition:
+    border-color 0.2s ease,
+    transform 0.2s ease;
 }
 
 .journal-admin-card:hover {
@@ -153,18 +232,62 @@
 
 .journal-editor-split {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  /* Left width is driven by the draggable divider; the preview takes the rest. */
+  grid-template-columns: var(--journal-split-left, 46%) 7px minmax(0, 1fr);
   flex-grow: 1;
   overflow: hidden;
   height: 100%;
 }
 
+/* Kill text selection and pointer flicker while the divider is being dragged. */
+.journal-editor-split.is-dragging {
+  user-select: none;
+  cursor: col-resize;
+}
+
+.journal-editor-split.is-dragging .journal-editor-pane-right {
+  pointer-events: none;
+}
+
+.journal-editor-resizer {
+  position: relative;
+  cursor: col-resize;
+  background: var(--admin-border, rgba(255, 255, 255, 0.08));
+  transition: background 0.15s ease;
+  touch-action: none;
+}
+
+.journal-editor-resizer:hover,
+.journal-editor-resizer:focus-visible,
+.journal-editor-split.is-dragging .journal-editor-resizer {
+  background: var(--admin-accent, #6366f1);
+  outline: none;
+}
+
+/* Grip dots, and a widened invisible hit area so the divider is easy to grab. */
+.journal-editor-resizer-grip {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 15px;
+  height: 44px;
+  border-radius: 4px;
+  background: repeating-linear-gradient(to bottom, currentColor 0 2px, transparent 2px 5px);
+  color: rgba(255, 255, 255, 0.35);
+  background-clip: content-box;
+  padding: 0 6px;
+}
+
+.journal-editor-resizer:hover .journal-editor-resizer-grip {
+  color: #fff;
+}
+
 .journal-editor-pane-left {
   display: flex;
   flex-direction: column;
-  border-right: 1px solid var(--admin-border, rgba(255, 255, 255, 0.08));
   overflow-y: auto;
-  padding: 1.5rem;
+  padding: 1.5rem 2rem 4rem;
   background: var(--admin-bg, #09090b);
 }
 
@@ -191,11 +314,24 @@
 }
 
 .journal-preview-frame {
-  padding: 2rem 1.5rem;
-  max-width: 900px;
+  padding: 2.5rem 2rem;
+  max-width: 1080px;
   margin: 0 auto;
   width: 100%;
   transition: max-width 0.3s ease;
+}
+
+/*
+ * The essay's full-bleed and wide figures are sized against the viewport on the
+ * live site. Inside the preview pane that overshoots — the photo would bleed out
+ * of the pane and drift as the split is dragged — so they are re-anchored to the
+ * frame. 100% is the container's content box, so reaching the pane edges means
+ * adding back both horizontal paddings: 4rem for this frame plus 3rem for
+ * .essay-container. Keep in sync if either padding changes.
+ */
+.journal-preview-frame .essay-container {
+  --essay-bleed: calc(100% + 7rem);
+  --essay-wide: 100%;
 }
 
 .journal-preview-frame.mobile {
@@ -243,7 +379,107 @@
   border: 1px solid var(--admin-border, rgba(255, 255, 255, 0.1));
   border-radius: 12px;
   width: 90%;
-  max-width: 520px;
+  max-width: 620px;
+  max-height: 88vh;
+  overflow-y: auto;
   padding: 1.75rem;
   box-shadow: 0 20px 40px rgba(0, 0, 0, 0.5);
+}
+
+/* ── Card meta & status ───────────────────────────────────────────── */
+
+.journal-admin-card-meta span {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.journal-card-cover-placeholder {
+  opacity: 0.25;
+}
+
+.journal-status-pill {
+  padding: 0.15rem 0.5rem;
+  border-radius: 9999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  opacity: 1;
+}
+
+.journal-status-pill.is-draft {
+  background: rgba(234, 179, 8, 0.15);
+  color: #eab308;
+  border: 1px solid rgba(234, 179, 8, 0.3);
+}
+
+.journal-status-pill.is-published {
+  background: rgba(34, 197, 94, 0.15);
+  color: #22c55e;
+  border: 1px solid rgba(34, 197, 94, 0.3);
+}
+
+.journal-preview-bar-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+/* ── Block field rows ─────────────────────────────────────────────
+ * The generic `.admin-input { width: 100% }` would blow these rows apart,
+ * so the fixed-width controls are pinned here (higher specificity wins).
+ */
+.journal-heading-row,
+.journal-photo-layout-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.journal-editor-container .journal-heading-row .journal-level-select {
+  flex: 0 0 5.5rem;
+  width: 5.5rem;
+}
+
+.journal-editor-container .journal-heading-row input {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.journal-editor-container .journal-photo-layout-row select {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.journal-photo-layout-row .admin-btn {
+  flex-shrink: 0;
+}
+
+/* Stack the split view on narrow screens instead of squeezing both panes. */
+@media (max-width: 1100px) {
+  .journal-editor-split {
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(0, 1fr) minmax(0, 1fr);
+  }
+
+  .journal-editor-resizer {
+    display: none;
+  }
+
+  .journal-editor-pane-left {
+    border-bottom: 1px solid var(--admin-border, rgba(255, 255, 255, 0.08));
+  }
+}
+
+/* An unresolvable photo reference — shown in the block editor, not to visitors. */
+.journal-block-warning {
+  margin: 0 0 0.75rem;
+  padding: 0.55rem 0.7rem;
+  border-radius: 8px;
+  font-size: 0.78rem;
+  line-height: 1.45;
+  color: #fca5a5;
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.3);
 }

--- a/app/admin/journal/[slug]/page.tsx
+++ b/app/admin/journal/[slug]/page.tsx
@@ -1,0 +1,10 @@
+import { JournalStudio } from '../../components/JournalStudio';
+
+export default async function AdminJournalEntryPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  return <JournalStudio slug={slug} />;
+}

--- a/app/admin/journal/page.tsx
+++ b/app/admin/journal/page.tsx
@@ -1,0 +1,5 @@
+import { JournalStudio } from '../components/JournalStudio';
+
+export default function AdminJournalPage() {
+  return <JournalStudio />;
+}

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import AdminShell from './AdminShell';
 
 export const metadata: Metadata = {
   title: 'Immich Folio Admin',
@@ -16,5 +17,9 @@ export const metadata: Metadata = {
 export const dynamic = 'force-dynamic';
 
 export default function AdminLayout({ children }: { children: React.ReactNode }) {
-  return <div className="admin-layout">{children}</div>;
+  return (
+    <div className="admin-layout">
+      <AdminShell>{children}</AdminShell>
+    </div>
+  );
 }

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,54 +1,5 @@
-'use client';
+import PageBuilder from './components/PageBuilder';
 
-import { useState, useEffect } from 'react';
-import AdminLogin from './components/AdminLogin';
-import AdminDashboard from './components/AdminDashboard';
-import './admin.css';
-
-export default function AdminPage() {
-  const [authenticated, setAuthenticated] = useState<boolean | null>(null);
-  const [enabled, setEnabled] = useState(true);
-
-  useEffect(() => {
-    checkAuth();
-  }, []);
-
-  async function checkAuth() {
-    try {
-      const res = await fetch('/api/admin/auth');
-      const data = await res.json();
-      setAuthenticated(data.authenticated);
-      setEnabled(data.enabled);
-    } catch {
-      setAuthenticated(false);
-    }
-  }
-
-  if (authenticated === null) {
-    return (
-      <div className="admin-loading">
-        <div className="admin-spinner" />
-      </div>
-    );
-  }
-
-  if (!enabled) {
-    return (
-      <div className="admin-disabled">
-        <div className="admin-disabled-card">
-          <h1>Admin Panel</h1>
-          <p>
-            The admin panel is not enabled. Set <code>ADMIN_PASSWORD</code> in your environment
-            variables to activate it.
-          </p>
-        </div>
-      </div>
-    );
-  }
-
-  if (!authenticated) {
-    return <AdminLogin onSuccess={() => setAuthenticated(true)} />;
-  }
-
-  return <AdminDashboard onLogout={() => setAuthenticated(false)} />;
+export default function AdminHomePage() {
+  return <PageBuilder />;
 }

--- a/app/admin/pages/page.tsx
+++ b/app/admin/pages/page.tsx
@@ -1,0 +1,5 @@
+import PageBuilder from '../components/PageBuilder';
+
+export default function AdminPagesPage() {
+  return <PageBuilder />;
+}

--- a/app/admin/settings/[section]/page.tsx
+++ b/app/admin/settings/[section]/page.tsx
@@ -1,0 +1,10 @@
+import SettingsEditor from '../../components/SettingsEditor';
+
+export default async function AdminSettingsSectionPage({
+  params,
+}: {
+  params: Promise<{ section: string }>;
+}) {
+  const { section } = await params;
+  return <SettingsEditor section={section} />;
+}

--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -1,0 +1,5 @@
+import SettingsEditor from '../components/SettingsEditor';
+
+export default function AdminSettingsPage() {
+  return <SettingsEditor />;
+}


### PR DESCRIPTION
## URLs for the admin panel

The panel was a single client component switching tabs via `useState`. Consequences: no route per section, no deep link, no back button, and after every reload you landed on "Pages" again. The journal editor (`activeSlug` in state) had no URL either.

Seven routes now exist:

```
/admin  /admin/pages  /admin/journal  /admin/journal/<slug>
/admin/settings  /admin/settings/<section>  /admin/analytics
```

The shell with the auth check and header now lives in the **layout** and wraps `children`. The first draft had every route render its own shell — that would have triggered a fresh session check on each tab switch and flashed the spinner. This way it stays mounted across route changes and the pages render only their panel.

Tabs are `<Link>`s, the active one is derived from `usePathname`. Unknown sections (`/admin/settings/bogus`) fall back to General instead of an empty panel. After login you land on the route you requested, so deep links work from a logged-out state too.

## Journal Studio

Lives in the same files as the routing change, hence the same PR.

**Input fields:** the studio used the class `admin-input` in twelve places — a class defined in no CSS file. Every field fell back to browser defaults (white, monospace, fixed size). Now styled, and deliberately scoped to the studio so the generic class name cannot leak into the rest of the panel.

**Split view:** draggable divider — mouse, arrow keys (`Home` resets), double click, width persisted in `localStorage`, bounds 25–70 %. The studio also breaks out of `.admin-main`'s 1120px column so editor and preview have room side by side.

**The preview lied about the layout:** it hard-coded `aspectRatio: 1.5` for every photo, showing a uniform cropped grid while the published page lays photos out by their real proportions. There is no admin endpoint for asset dimensions, so the thumbnails are measured once as they load.

**Legacy photo references:** blocks with positional references (`![2, 3]`) cannot be resolved on a standalone journal page — there is no album for the indices to point into. They used to vanish silently; the block editor now flags them.

**Block type chips:** the only place in the panel with its own palette (iOS blue, purple, orange — 12 hard-coded values). Now a shared component for both the studio and the Pages builder, monochrome and told apart by icon — the same icon the "Add Block" toolbar uses. Labels are readable now instead of the raw type names from the data model.

**Emojis** replaced with SVG icons from `Icons.tsx` (`IconBook`, `IconEye`, `IconClock` added).

## Verification

`npm run build` lists all seven routes; `npx tsc --noEmit` and 363 unit tests pass in isolation on this branch. All eight URLs including `/admin/journal/foo` and an invalid section return 200.

Not verified: behaviour behind the login. I do not enter passwords, so what is tested is the logged-out state plus build and types.