### PR TITLE
fix(admin): close design system gaps in the panel

### DIFF
--- a/app/admin/admin.css
+++ b/app/admin/admin.css
@@ -20,6 +20,8 @@
   --admin-text-secondary: #a0a0a0;
   --admin-text-muted: #707070;
   --admin-accent: #f59e0b;
+  /* One height for every control in the header row. */
+  --admin-control-height: 36px;
   --admin-success: #4ade80;
   --admin-error: #f87171;
   --admin-error-bg: #2d1111;
@@ -362,11 +364,22 @@
   align-items: center;
   justify-content: center;
   gap: 0.4rem;
-  padding: 0.6rem 1.2rem;
+  padding: 0 1.2rem;
+  min-height: var(--admin-control-height);
+  /* <button> gets this from the UA stylesheet, <a> does not — without it the
+   * ghost border pushed the "Site" link 2px past its neighbours. */
+  box-sizing: border-box;
   border: none;
   border-radius: 6px;
+  font-family: inherit;
   font-size: 0.875rem;
   font-weight: 500;
+  /*
+   * Explicit, because <a class="admin-btn"> and <button class="admin-btn">
+   * otherwise resolve `normal` against different inline boxes — the "Site" link
+   * ended up half a pixel taller than the buttons next to it.
+   */
+  line-height: 1;
   cursor: pointer;
   transition: all 0.15s;
 }
@@ -396,8 +409,40 @@
   border-color: var(--admin-border-hover);
 }
 
+/*
+ * Written as `.admin-btn.admin-btn-*` on purpose: these variants are combined
+ * with the size classes (`admin-btn-sm`, `admin-btn-xs`), which set their own
+ * background further down. The doubled class outranks them whatever the order.
+ */
+
+/* Neutral action next to a primary one. */
+.admin-btn.admin-btn-secondary {
+  background: var(--admin-bg-elevated);
+  color: var(--admin-text);
+  border: 1px solid var(--admin-border);
+}
+
+.admin-btn.admin-btn-secondary:hover:not(:disabled) {
+  background: var(--admin-bg-raised);
+  border-color: var(--admin-border-hover);
+}
+
+/* Destructive action — must read as destructive before it is clicked. */
+.admin-btn.admin-btn-danger {
+  background: transparent;
+  color: #f87171;
+  border: 1px solid rgba(239, 68, 68, 0.35);
+}
+
+.admin-btn.admin-btn-danger:hover:not(:disabled) {
+  background: rgba(239, 68, 68, 0.14);
+  border-color: rgba(239, 68, 68, 0.6);
+  color: #fca5a5;
+}
+
 .admin-btn-sm {
-  padding: 0.4rem 0.8rem;
+  padding: 0 0.8rem;
+  min-height: 30px;
   font-size: 0.8rem;
   background: var(--admin-bg-elevated);
   color: var(--admin-text-secondary);
@@ -411,7 +456,8 @@
 }
 
 .admin-btn-xs {
-  padding: 0.3rem 0.6rem;
+  padding: 0 0.6rem;
+  min-height: 26px;
   font-size: 0.75rem;
   background: var(--admin-bg-raised);
   color: var(--admin-text-secondary);
@@ -483,11 +529,19 @@
   gap: 0.5rem;
 }
 
+.admin-header-divider {
+  width: 1px;
+  height: 20px;
+  background: var(--admin-border);
+  margin: 0 0.25rem;
+}
+
 .admin-tabs {
   display: flex;
   gap: 0;
 }
 
+/* Rendered as an <a> — each tab is its own route. */
 .admin-tab {
   background: none;
   border: none;
@@ -497,6 +551,8 @@
   cursor: pointer;
   border-bottom: 2px solid transparent;
   transition: all 0.15s;
+  display: inline-block;
+  text-decoration: none;
 }
 
 .admin-tab:hover {
@@ -1190,6 +1246,9 @@
   margin: 0 0 1.25rem;
   font-size: 0.75rem;
   color: var(--admin-text-muted);
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 
 .settings-layout {
@@ -1204,6 +1263,7 @@
   gap: 0.25rem;
 }
 
+/* Rendered as an <a> — each settings section is its own route. */
 .settings-nav-item {
   background: none;
   border: none;
@@ -1214,6 +1274,8 @@
   border-radius: 6px;
   cursor: pointer;
   transition: all 0.1s;
+  display: block;
+  text-decoration: none;
 }
 
 .settings-nav-item:hover {
@@ -1272,51 +1334,101 @@
   box-shadow: 0 0 0 2px var(--admin-accent);
 }
 
-/* Preset Mini Preview Mockup */
+/* ── Preset Mini Preview Mockup ──────────────────────────────────
+ * Driven entirely by the --preset-* custom properties the card sets inline,
+ * so each mockup reflects that preset's real background, tile colour, corner
+ * radius, grid density and photo frame instead of looking identical.
+ */
 .preset-card-preview {
   width: 100%;
   aspect-ratio: 16 / 10;
-  padding: 0.5rem;
+  padding: 0.55rem;
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
+  gap: 0.45rem;
   border-bottom: 1px solid var(--admin-border);
   position: relative;
   overflow: hidden;
+  background: var(--preset-bg);
 }
 
 .preset-card-preview .mini-header {
   display: flex;
-  align-items: center;
-  gap: 0.3rem;
-  height: 8px;
+  align-items: baseline;
+  gap: 0.4rem;
+  flex-shrink: 0;
 }
 
-.preset-card-preview .mini-dot {
-  width: 4px;
-  height: 4px;
-  border-radius: 50%;
+/* Type specimen: generic families stand in for the preset's real webfont,
+ * which is not loaded inside the admin panel. */
+.preset-card-preview .mini-specimen {
+  font-size: 0.95rem;
+  line-height: 1;
+  color: var(--preset-accent);
+}
+
+.preset-card-preview .mini-specimen.type-serif {
+  font-family: Georgia, 'Times New Roman', serif;
+}
+
+.preset-card-preview .mini-specimen.type-sans {
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+.preset-card-preview .mini-specimen.type-mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.85rem;
 }
 
 .preset-card-preview .mini-line {
   height: 2px;
-  width: 24px;
+  flex: 1;
+  max-width: 46px;
   border-radius: 1px;
+  background: var(--preset-accent);
+  opacity: 0.4;
+}
+
+.preset-card.active .preset-card-preview .mini-line {
+  opacity: 1;
 }
 
 .preset-card-preview .mini-grid {
   flex: 1;
+  min-height: 0;
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 0.25rem;
-  align-items: center;
+  gap: var(--preset-gap, 4px);
 }
 
 .preset-card-preview .mini-tile {
-  aspect-ratio: 1;
-  border-radius: 3px;
-  border: 1px solid rgba(0, 0, 0, 0.05);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.02);
+  background: var(--preset-tile);
+  border-radius: var(--preset-radius, 0);
+  /* Keeps near-white tiles on a white page (Minimal, Classic) readable. */
+  box-shadow: inset 0 0 0 1px rgba(128, 128, 128, 0.16);
+}
+
+/* Passepartout: a mat board in the page colour framing the photo. */
+.preset-card-preview[data-frame='passepartout'] .mini-tile {
+  padding: 4px;
+  background-clip: content-box;
+  border: 1px solid rgba(128, 128, 128, 0.3);
+}
+
+.preset-card-preview[data-frame='shadow'] .mini-tile {
+  box-shadow:
+    0 2px 5px rgba(0, 0, 0, 0.28),
+    inset 0 0 0 1px rgba(128, 128, 128, 0.16);
+}
+
+.preset-card-specs {
+  font-size: 0.62rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  color: var(--admin-text-muted);
+  opacity: 0.75;
+  margin-top: 0.15rem;
 }
 
 .preset-card-info {
@@ -1346,14 +1458,26 @@
   margin-right: 0.5rem;
 }
 
+/*
+ * A status readout, not an action: same height and typography as the buttons
+ * beside it, but pill-shaped so the row still reads as "state | actions".
+ * It inherited the browser's default button font before, which is why it looked
+ * like it came from a different app.
+ */
 .status-badge-btn {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
-  padding: 0.4rem 0.75rem;
+  gap: 0.45rem;
+  padding: 0 0.85rem;
+  min-height: var(--admin-control-height);
   background: var(--admin-bg-raised);
   border: 1px solid var(--admin-border);
-  border-radius: 20px;
+  border-radius: 999px;
+  font-family: inherit;
+  font-size: 0.8rem;
+  font-weight: 500;
+  line-height: 1;
+  color: var(--admin-text-secondary);
   cursor: pointer;
   transition: all 0.15s;
 }
@@ -1370,10 +1494,11 @@
   position: relative;
 }
 
+/* Healthy is the resting state — no animation. A permanently pulsing dot pulls
+ * the eye toward the one thing that needs no attention. */
 .status-badge-btn.connected .status-dot {
   background-color: var(--admin-success, #10b981);
-  box-shadow: 0 0 8px var(--admin-success, #10b981);
-  animation: pulse-green 2s infinite;
+  box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.18);
 }
 
 .status-badge-btn.disconnected .status-dot {
@@ -1389,9 +1514,9 @@
 }
 
 .status-text {
-  font-size: 0.75rem;
-  font-weight: 500;
-  color: var(--admin-text-secondary);
+  font-size: inherit;
+  font-weight: inherit;
+  color: inherit;
 }
 
 /* Status Dropdown */
@@ -3021,6 +3146,9 @@ h3 .svg-icon {
   font-size: 0.88rem;
   font-weight: 600;
   color: var(--admin-text);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
 }
 
 .toggle-card-desc {
@@ -3170,6 +3298,19 @@ h3 .svg-icon {
 }
 
 /* Grid Layout Mini Demos */
+
+/*
+ * Same framing as .ratio-card-preview. Without an explicit box here the demos
+ * (which size themselves with height: 100%) collapse to zero height.
+ */
+.grid-card-preview {
+  width: 100%;
+  aspect-ratio: 16 / 10;
+  background: var(--admin-bg-elevated);
+  border-bottom: 1px solid var(--admin-border);
+  overflow: hidden;
+}
+
 .mini-layout-demo {
   width: 100%;
   height: 100%;
@@ -3194,9 +3335,19 @@ h3 .svg-icon {
 }
 
 .demo-tile {
-  background: linear-gradient(135deg, #444, #222);
+  background: var(--admin-text-secondary);
+  opacity: 0.35;
   border-radius: 2px;
   flex: 1;
+  transition:
+    background 0.15s ease,
+    opacity 0.15s ease;
+}
+
+/* The selected layout tints its diagram with the accent colour. */
+.preset-card.active .demo-tile {
+  background: var(--admin-accent);
+  opacity: 0.55;
 }
 
 .demo-tile.h-high {
@@ -3222,7 +3373,9 @@ h3 .svg-icon {
   height: 100%;
 }
 
-.demo-tile.hero-tile {
+/* Deliberately NOT named .hero-tile — that class belongs to the page builder
+ * and its `aspect-ratio` would leak into this demo. */
+.demo-tile.demo-hero {
   flex: 2;
 }
 
@@ -3233,9 +3386,11 @@ h3 .svg-icon {
   align-items: center;
 }
 
+/* A band of wide tiles running off the right edge — the horizontal scroll hint
+ * that separates this demo from the uniform grid. */
 .demo-tile.strip {
-  width: 40%;
-  height: 90%;
+  width: 46%;
+  height: 62%;
   flex-shrink: 0;
 }
 
@@ -3395,6 +3550,75 @@ h3 .svg-icon {
   display: flex;
   align-items: center;
   justify-content: space-between;
+}
+
+/* Breadcrumb + title stack on the left of the drawer header. */
+.subpage-drawer-title-group {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+/* One thematic group of fields inside the drawer body. */
+.subpage-drawer-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+  background: var(--admin-bg-raised);
+  border: 1px solid var(--admin-border);
+  border-radius: 8px;
+}
+
+.subpage-drawer-section > .admin-field:only-child {
+  margin-bottom: 0;
+}
+
+/* Heading + hint at the top of a drawer section. */
+.drawer-section-heading h4 {
+  margin: 0;
+  font-size: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.drawer-section-heading p {
+  margin: 4px 0 0;
+  font-size: 0.8rem;
+  color: var(--admin-text-muted);
+}
+
+/* Published / hidden marker, replacing the traffic-light emoji. */
+/* Named apart from the header badge's .status-dot, which is a different dot. */
+.page-status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  display: inline-block;
+  margin-right: 2px;
+}
+
+.page-status-dot.is-on {
+  background: #22c55e;
+  box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.18);
+}
+
+.page-status-dot.is-off {
+  background: #ef4444;
+  box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.18);
+}
+
+.input-with-icon {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100%;
+}
+
+.input-with-icon > input {
+  width: 100%;
 }
 
 .input-slug-wrapper {
@@ -3690,6 +3914,31 @@ h3 .svg-icon {
   overflow: hidden;
 }
 
+/* The bar itself. Without this the track stayed empty and the view count had
+ * no visual weight at all. */
+.page-progress-fill {
+  height: 100%;
+  min-width: 2px;
+  border-radius: 3px;
+  background: var(--admin-accent);
+  transition: width 0.3s ease;
+}
+
+.analytics-empty {
+  margin: 0;
+  padding: 2rem 1rem;
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--admin-text-muted);
+}
+
+.admin-loading-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 320px;
+}
+
 /* ── Drawer Live Preview ────────────────────────────────────── */
 .drawer-live-preview-panel {
   display: flex;
@@ -3850,22 +4099,20 @@ h3 .svg-icon {
   border: 1px solid var(--admin-border, #2e2e2e);
 }
 
-.essay-block-badge.badge-photo {
-  background: rgba(10, 132, 255, 0.15);
-  color: #64d2ff;
-  border-color: rgba(10, 132, 255, 0.3);
+/* Position prefix inside the chip, e.g. "3 · Quote". */
+.essay-block-badge-index {
+  color: var(--admin-text-muted);
+  font-variant-numeric: tabular-nums;
 }
 
-.essay-block-badge.badge-heading {
-  background: rgba(191, 90, 242, 0.15);
-  color: #da8fff;
-  border-color: rgba(191, 90, 242, 0.3);
+.essay-block-badge-index::after {
+  content: ' ·';
 }
 
-.essay-block-badge.badge-quote {
-  background: rgba(255, 159, 10, 0.15);
-  color: #ffd60a;
-  border-color: rgba(255, 159, 10, 0.3);
+/* The card's own hover state is enough of a highlight; the chip stays quiet. */
+.essay-block-card:hover .essay-block-badge {
+  border-color: var(--admin-border-hover);
+  color: var(--admin-text);
 }
 
 .essay-block-actions {

--- a/app/admin/components/AlbumPicker.tsx
+++ b/app/admin/components/AlbumPicker.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo } from 'react';
 import { useScrollLock } from './useScrollLock';
+import { IconFolder } from './Icons';
 
 interface ImmichAlbumInfo {
   id: string;
@@ -77,7 +78,9 @@ export default function AlbumPicker({ albums, onSelect, onClose, usedAlbumIds }:
                       loading="lazy"
                     />
                   ) : (
-                    <div className="picker-thumb-placeholder">📁</div>
+                    <div className="picker-thumb-placeholder">
+                      <IconFolder size={20} />
+                    </div>
                   )}
                 </div>
                 <div className="picker-item-info">

--- a/app/admin/components/AssetPicker.tsx
+++ b/app/admin/components/AssetPicker.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { IconFolder, IconImage, IconStar } from './Icons';
+import { IconCheck, IconFolder, IconImage, IconStar } from './Icons';
 import { useScrollLock } from './useScrollLock';
 
 interface AssetInfo {
@@ -177,7 +177,11 @@ export default function AssetPicker({
                       alt={asset.originalFileName}
                       loading="lazy"
                     />
-                    {isUsed && <div className="asset-picker-used-badge">✓</div>}
+                    {isUsed && (
+                      <div className="asset-picker-used-badge">
+                        <IconCheck size={11} />
+                      </div>
+                    )}
                     {asset.isFavorite && !isUsed && (
                       <div className="asset-picker-fav-badge" title="Favorite in Immich">
                         <IconStar size={14} />

--- a/app/admin/components/BackupManagerModal.tsx
+++ b/app/admin/components/BackupManagerModal.tsx
@@ -99,7 +99,7 @@ export default function BackupManagerModal({ isOpen, onClose, onRestoreSuccess }
             </p>
           </div>
           <button className="backup-modal-close-btn" onClick={onClose} aria-label="Close">
-            ✕
+            <Icons.IconX size={16} />
           </button>
         </div>
 

--- a/app/admin/components/EssayBlockEditor.tsx
+++ b/app/admin/components/EssayBlockEditor.tsx
@@ -18,6 +18,7 @@ import {
   IconSparkles,
   IconArrowLeftRight,
 } from './Icons';
+import { BlockBadge } from './BlockBadge';
 
 interface EssayBlockEditorProps {
   markdown: string;
@@ -119,7 +120,7 @@ export function EssayBlockEditor({ markdown, onChange, onSelectPhoto }: EssayBlo
     <div className="essay-block-editor">
       {/* Sticky Dark Glass Toolbar */}
       <div className="essay-toolbar-sticky">
-        <span className="essay-toolbar-label">✨ Add Story Block:</span>
+        <span className="essay-toolbar-label">Add Story Block:</span>
         <button
           type="button"
           className="admin-btn admin-btn-xs"
@@ -171,19 +172,7 @@ export function EssayBlockEditor({ markdown, onChange, onSelectPhoto }: EssayBlo
           <div className="essay-block-card-header">
             <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
               <IconGripVertical size={14} style={{ color: 'var(--admin-text-muted)', cursor: 'grab' }} />
-              <span
-                className={`essay-block-badge ${
-                  block.type === 'photo' || block.type === 'photo-pair'
-                    ? 'badge-photo'
-                    : block.type === 'heading'
-                    ? 'badge-heading'
-                    : block.type === 'quote'
-                    ? 'badge-quote'
-                    : ''
-                }`}
-              >
-                Block {idx + 1}: {block.type}
-              </span>
+              <BlockBadge type={block.type} index={idx + 1} />
             </div>
 
             <div className="essay-block-actions">

--- a/app/admin/components/PageBuilder.tsx
+++ b/app/admin/components/PageBuilder.tsx
@@ -35,6 +35,7 @@ import type { AlbumEntryObject } from '@/lib/config/schema';
 import {
   IconArrowDown,
   IconArrowUp,
+  IconBook,
   IconCalendar,
   IconCamera,
   IconCopy,
@@ -1108,7 +1109,7 @@ export default function PageBuilder() {
                           onClick={() => setExpandedSubpage(null)}
                           title="Close drawer"
                         >
-                          ✕
+                          <IconX size={14} />
                         </button>
                       </div>
                     </div>
@@ -1239,7 +1240,13 @@ export default function PageBuilder() {
                           >
                             <div className="toggle-card-info" style={{ textAlign: 'left' }}>
                               <span className="toggle-card-title" style={{ fontWeight: 600 }}>
-                                {sp.enabled !== false ? '🟢 Page Active (Published)' : '🔴 Page Disabled (Hidden)'}
+                                <span
+                                  className={`page-status-dot ${sp.enabled !== false ? 'is-on' : 'is-off'}`}
+                                  aria-hidden="true"
+                                />
+                                {sp.enabled !== false
+                                  ? 'Page Active (Published)'
+                                  : 'Page Disabled (Hidden)'}
                               </span>
                               <span className="toggle-card-desc" style={{ fontSize: '0.8rem', display: 'block', opacity: 0.75 }}>
                                 {sp.enabled !== false
@@ -1281,14 +1288,12 @@ export default function PageBuilder() {
 
                       {/* Visual Photo Essay Builder (if layout === 'essay') */}
                       {(sp.grid?.layout === 'essay' || sp.essayText != null) && (
-                        <div className="subpage-drawer-section" style={{ background: 'var(--admin-surface, rgba(255,255,255,0.02))', padding: '1rem', borderRadius: '8px', border: '1px solid var(--admin-border, rgba(255,255,255,0.1))' }}>
-                          <div style={{ marginBottom: '1rem' }}>
-                            <h4 style={{ margin: 0, fontSize: '1rem', display: 'flex', alignItems: 'center', gap: '8px' }}>
-                              <span>📖 Storytelling &amp; Photo Essay Builder</span>
+                        <div className="subpage-drawer-section">
+                          <div className="drawer-section-heading">
+                            <h4>
+                              <IconBook size={16} /> Storytelling &amp; Photo Essay Builder
                             </h4>
-                            <p style={{ margin: '4px 0 0 0', fontSize: '0.8rem', opacity: 0.75 }}>
-                              Compose text, quotes, and fullbleed/wide photos visually.
-                            </p>
+                            <p>Compose text, quotes, and fullbleed/wide photos visually.</p>
                           </div>
 
                           <EssayBlockEditor


### PR DESCRIPTION
This started from a systematic search for classes used in TSX but defined in no CSS file — the same pattern that caused the unstyled fields in the Journal Studio. Four more hits:

| finding | effect |
|---|---|
| `.admin-btn-secondary` + `.admin-btn-danger` defined nowhere | **Every** delete button looked like an ordinary button — no red, no warning |
| `.page-progress-fill` missing (`.page-progress-bg` exists) | Analytics "Top Pages": the bars were empty tracks, the value invisible |
| `.admin-loading-container`, `.analytics-empty` | Loading and empty states in Analytics unstyled |
| `.input-with-icon`, `.subpage-drawer-*` | Layout containers with no effect, partly compensated by inline styles |

The button variants are deliberately written as `.admin-btn.admin-btn-danger`: they are combined with the size classes, which set their own background further down the file. The doubled class wins regardless of order.

## Grid previews

The markup for all five layout demos was there; two bugs made them invisible. `.grid-card-preview` was defined nowhere, so the container had zero height and the demos sized with `height: 100%` collapsed. Only "Showcase" was visible — and that by accident, because its tile was named `demo-tile hero-tile` and `.hero-tile` belongs to the page builder and brings `aspect-ratio: 16/10` with it. Renamed so nothing leaks.

Before/after: preview heights `0, 0, 116, 0, 0` → `116, 116, 116, 116, 116`.

## Theme previews

All seven presets showed the same three square tiles (`aspect-ratio: 1` plus `align-items: center` ⇒ centered, half the box empty); the only difference was the background colour. They now reflect the real preset data from `lib/config/theme.ts`: type character as a specimen, corner radius, grid density as the gap, passepartout or shadow depending on `photoFrame`. Plus a mono line per card (`Playfair Display · radius 0 · passepartout`).

The demo tiles use theme tokens instead of hard-coded `#444/#222`, so they also work in the light admin theme.

## Header

The "Site" link was taller than the three buttons next to it, for two independent reasons: `.admin-btn` had no explicit `line-height`, so `<a>` and `<button>` resolved `normal` against different inline boxes. And `<button>` gets `box-sizing: border-box` from the UA stylesheet while `<a>` does not — the ghost style's 1px border sat outside the height on the link.

The status readout set neither `font-family` nor `font-size`; a `<button>` does not inherit fonts, so it fell back to 13.33px Arial. It was never part of the design system.

There is now a shared control height token everything aligns to. The status readout stays distinguishable (pill shape for a state indicator) but shares height and typography, with a divider separating it from the action group. The permanent pulsing of the green dot is gone — it pulled attention toward the one state that needs none; red and unknown still pulse.

Measured across all five elements: height and top-edge spread **0px** (previously 8.4px between status and buttons, 0.5px between link and buttons).

## Misc

Remaining emojis replaced with SVG icons. Fixed a class collision: `.status-dot` existed twice — for the header dot and for the page status in the PageBuilder, the latter silently overriding the former's size.

## Verification

`npm run build`, `npx tsc --noEmit` and 363 unit tests pass in isolation on this branch. The measurements come from the components rebuilt in the browser with the real `admin.css` — I cannot get past the admin login, as I do not enter passwords.