### PR TITLE
feat(admin): add scroll-to-top toggle and SVG arrow

### DIFF
--- a/app/admin/components/SettingsEditor.tsx
+++ b/app/admin/components/SettingsEditor.tsx
@@ -13,6 +13,7 @@ interface Settings {
   exifOnHover?: boolean;
   map?: boolean;
   transitions?: boolean;
+  scrollToTop?: boolean;
   analytics?: boolean;
   theme?: {
     preset?: string;
@@ -465,6 +466,20 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
                     <span className="toggle-card-desc">Enable subtle fade-in animations between page navigation</span>
                   </div>
                   <div className={`switch-toggle ${settings.transitions !== false ? 'on' : ''}`}>
+                    <span className="switch-slider" />
+                  </div>
+                </button>
+
+                <button
+                  type="button"
+                  className={`admin-toggle-card ${settings.scrollToTop !== false ? 'active' : ''}`}
+                  onClick={() => update('scrollToTop', settings.scrollToTop === false)}
+                >
+                  <div className="toggle-card-info">
+                    <span className="toggle-card-title"><Icons.IconArrowUp size={16} /> Scroll-to-Top Button</span>
+                    <span className="toggle-card-desc">Show a floating arrow that returns visitors to the top of long pages</span>
+                  </div>
+                  <div className={`switch-toggle ${settings.scrollToTop !== false ? 'on' : ''}`}>
                     <span className="switch-slider" />
                   </div>
                 </button>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1210,8 +1210,7 @@
   border: 1px solid var(--border-subtle);
   background: var(--bg-card);
   color: var(--text-secondary);
-  font-size: 1.1rem;
-  font-weight: 300;
+  padding: 0;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1225,6 +1224,26 @@
     background var(--transition-fast),
     border-color var(--transition-fast),
     color var(--transition-fast);
+}
+
+.scroll-to-top__icon {
+  width: 18px;
+  height: 18px;
+  transition: transform var(--transition-fast);
+}
+
+.scroll-to-top:hover .scroll-to-top__icon {
+  transform: translateY(-2px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scroll-to-top__icon {
+    transition: none;
+  }
+
+  .scroll-to-top:hover .scroll-to-top__icon {
+    transform: none;
+  }
 }
 
 .scroll-to-top--visible {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -164,7 +164,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
               {children}
             </main>
             <Footer />
-            <ScrollToTop />
+            {config.scrollToTop && <ScrollToTop />}
             <AssetProtection
               disableRightClick={config.protection?.disableRightClick}
               disableImageDrag={config.protection?.disableImageDrag}

--- a/components/ScrollToTop.tsx
+++ b/components/ScrollToTop.tsx
@@ -1,27 +1,40 @@
 /**
- * ScrollToTop — fixed ↑ button that appears after scrolling down.
- * Smooth-scrolls back to the top when clicked.
+ * ScrollToTop — fixed back-to-top button that fades in after scrolling down.
+ * Toggled site-wide via `scrollToTop` in settings.yaml.
  */
 
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
 const SHOW_THRESHOLD = 300;
 
 export function ScrollToTop() {
   const [visible, setVisible] = useState(false);
+  const frame = useRef<number | null>(null);
 
   useEffect(() => {
-    const onScroll = () => {
+    const measure = () => {
+      frame.current = null;
       setVisible(window.scrollY > SHOW_THRESHOLD);
     };
+
+    // rAF-throttled: one state update per frame, not one per scroll event.
+    const onScroll = () => {
+      if (frame.current === null) frame.current = requestAnimationFrame(measure);
+    };
+
+    measure();
     window.addEventListener('scroll', onScroll, { passive: true });
-    return () => window.removeEventListener('scroll', onScroll);
+    return () => {
+      window.removeEventListener('scroll', onScroll);
+      if (frame.current !== null) cancelAnimationFrame(frame.current);
+    };
   }, []);
 
   const scrollToTop = () => {
-    window.scrollTo({ top: 0, behavior: 'smooth' });
+    const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    window.scrollTo({ top: 0, behavior: reduced ? 'auto' : 'smooth' });
   };
 
   return (
@@ -34,7 +47,20 @@ export function ScrollToTop() {
       tabIndex={visible ? 0 : -1}
       aria-hidden={!visible}
     >
-      ↑
+      <svg
+        className="scroll-to-top__icon"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <path d="M12 18.75V6.25" />
+        <path d="m6.5 11.75 5.5-5.5 5.5 5.5" />
+      </svg>
     </button>
   );
 }

--- a/content/settings.yaml.example
+++ b/content/settings.yaml.example
@@ -24,6 +24,9 @@ map: true
 # Enable smooth page transitions between routes
 transitions: true
 
+# Show the floating back-to-top arrow on long pages
+scrollToTop: true
+
 # Client proofing & favorite photo selections
 # proofing:
 #   enabled: true

--- a/docs/admin-panel.md
+++ b/docs/admin-panel.md
@@ -66,7 +66,7 @@ The **Settings** tab lets you configure global site behavior:
 
 | Section   | Controls                                                         |
 | --------- | ---------------------------------------------------------------- |
-| General   | Site title, subtitle, language, EXIF on hover, map, transitions  |
+| General   | Site title, subtitle, language, EXIF on hover, map, transitions, scroll-to-top |
 | Theme     | Preset, accent color, photo frame, hero style, grain, header dot |
 | Grid      | Layout mode, columns, gap, aspect ratio                          |
 | Footer    | Name, Instagram, email, website                                  |

--- a/lib/config/index.ts
+++ b/lib/config/index.ts
@@ -307,6 +307,7 @@ export function getConfig(): AppConfig {
       legal: { enabled: false, name: '', address: '', zipCity: '', country: '' },
       map: false,
       transitions: false,
+      scrollToTop: false,
       analytics: true,
       proofing: { enabled: false, allowMailto: false },
       albumOverrides: {},
@@ -397,6 +398,7 @@ export function getConfig(): AppConfig {
     },
     map: settings.map === true,
     transitions: settings.transitions !== false,
+    scrollToTop: settings.scrollToTop !== false,
     analytics: settings.analytics !== false,
     proofing: {
       enabled: settings.proofing?.enabled !== false,

--- a/lib/config/schema.ts
+++ b/lib/config/schema.ts
@@ -104,6 +104,8 @@ export interface AppConfig {
   legal: LegalConfig;
   map: boolean;
   transitions: boolean;
+  /** Floating back-to-top arrow in the frontend. */
+  scrollToTop: boolean;
   analytics: boolean;
   proofing: {
     enabled: boolean;
@@ -195,6 +197,7 @@ export interface SettingsYaml {
   exifOnHover?: boolean;
   map?: boolean;
   transitions?: boolean;
+  scrollToTop?: boolean;
   analytics?: boolean;
   proofing?: {
     enabled?: boolean;


### PR DESCRIPTION
## Summary

The frontend already had a back-to-top button, but it was always on with no way to turn it off, and it drew its arrow with the `↑` text character — which renders at the mercy of whatever font the preset loads.

This adds a `scrollToTop` setting and replaces the glyph with a proper SVG.

- **New toggle** in the admin panel under **Settings → General**, as the fourth card between "Smooth Page Transitions" and "Analytics Tracking". Backed by `scrollToTop` in `settings.yaml`.
- **Defaults to on** (`settings.scrollToTop !== false`), so existing installations see no change in behaviour.
- **SVG arrow** — stroked, 1.5px, rounded caps, inheriting `currentColor` so it picks up each preset's accent and hover colours.
- Scroll handling is now rAF-throttled (one state update per frame instead of one per scroll event).
- `prefers-reduced-motion` disables both the hover lift and the smooth scroll.

The button geometry is deliberately untouched: `classic.css` and `studio-modern.css` override `border-radius` (12px and 0), so anything assuming a circle — a circular progress ring, for instance — would break on those presets.

## Type of change

- [x] ✨ New feature
- [x] 🎨 Style / visual

## Checklist

- [x] Targets the `dev` branch (see [CONTRIBUTING.md](../CONTRIBUTING.md#branches))
- [x] `npm run build` passes locally
- [x] `npx tsc --noEmit` passes (0 type errors)
- [x] `npx vitest run` passes (363 tests green)
- [x] No secrets / API keys in diff
- [x] Documentation updated if needed (`docs/`, `README.md`)
- [ ] Screenshots attached if there are visual changes

## Notes for the reviewer

**No screenshots.** I could not run the app end-to-end: this worktree has no `.env.local` and no `content/gallery.yaml`, so the dev server only reaches the setup screen. The change is verified by build, type-check and unit tests; the button itself was checked against the real CSS rules in an isolated harness across all three border-radius variants. Worth a manual look before merging.

**Branch history.** `dev` and `main` have diverged — this work started from `main` (d4d8c8b, the Sentinel commit), which `dev` does not contain. Rebasing would have dragged the entire `main` lead along and conflicted in five files, so the single commit was cherry-picked onto `dev` instead.

**Icon reuse.** `dev` already gained an `IconArrowUp` via #435, geometrically identical to the one this branch originally added. The duplicate was dropped; the toggle uses the existing icon.

## Lint

`app/admin/components/SettingsEditor.tsx` fails `npm run lint` on `dev` already (prettier formatting, repo-wide). The new toggle card is written in the same style as the five cards around it rather than reformatted, to keep the diff readable — it inherits the same two prettier complaints every other card in that file has.
