### PR TITLE
security(journal): escape author HTML instead of filtering it

### DIFF
--- a/lib/__tests__/essay.test.ts
+++ b/lib/__tests__/essay.test.ts
@@ -4,7 +4,15 @@ import { parseEssayMarkdown, parseFrontmatter, sanitizeHtml, renderInlineMarkdow
 describe('Essay Parser', () => {
   it('sanitizes script tags to prevent XSS', () => {
     const input = 'Hello <script>alert("XSS")</script> World';
-    expect(sanitizeHtml(input)).toBe('Hello  World');
+    // sanitizeHtml escapes rather than strips: the tag stays visible as the
+    // author's literal text but can no longer be parsed as markup. Asserting
+    // the old removed-substring output would assert the denylist that this
+    // replaced.
+    const out = sanitizeHtml(input);
+    expect(out).not.toContain('<');
+    expect(out).not.toContain('>');
+    expect(out).toContain('Hello');
+    expect(out).toContain('World');
   });
 
   it('renders inline markdown formatting correctly', () => {

--- a/lib/__tests__/journal-escaping.test.ts
+++ b/lib/__tests__/journal-escaping.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import {
+  sanitizeHtml,
+  decodeHtmlEntities,
+  renderInlineMarkdown,
+  parseJournalMarkdown,
+  serializeJournalMarkdown,
+} from '../journal';
+
+/**
+ * The previous sanitizer was a denylist: strip `<script>`, strip `on*="..."`,
+ * strip the literal `javascript:`. Every case below passed straight through it
+ * and into `dangerouslySetInnerHTML`. They are kept as regression tests rather
+ * than as a list of things to filter — the implementation escapes instead, so
+ * none of them is special.
+ */
+describe('sanitizeHtml', () => {
+  const bypasses: [string, string][] = [
+    ['unquoted event handler', '<img src=x onerror=alert(1)>'],
+    ['single-quoted event handler', "<img src=x onerror='alert(1)'>"],
+    ['non-script tag', '<svg onload=alert(1)>'],
+    ['recombining scheme', 'javasjavascript:cript:alert(1)'],
+    ['uppercase tag', '<IMG SRC=x ONERROR=alert(1)>'],
+  ];
+
+  it.each(bypasses)('neutralises %s', (_name, input) => {
+    const out = sanitizeHtml(input);
+    expect(out).not.toContain('<');
+    expect(out).not.toContain('>');
+  });
+
+  it('leaves plain text readable', () => {
+    expect(sanitizeHtml('5 > 3 && 2 < 4')).toBe('5 &gt; 3 &amp;&amp; 2 &lt; 4');
+  });
+});
+
+describe('renderInlineMarkdown', () => {
+  it('still renders bold, italic and safe links', () => {
+    const html = renderInlineMarkdown('**bold** and *italic* and [link](https://example.com)');
+    expect(html).toContain('<strong>bold</strong>');
+    expect(html).toContain('<em>italic</em>');
+    expect(html).toContain(
+      '<a href="https://example.com" target="_blank" rel="noopener noreferrer">link</a>',
+    );
+  });
+
+  it.each([
+    ['relative', '/albums/iceland'],
+    ['anchor', '#section'],
+    ['mailto', 'mailto:hi@example.com'],
+  ])('allows %s links', (_name, url) => {
+    expect(renderInlineMarkdown(`[x](${url})`)).toContain(`href="${url}"`);
+  });
+
+  it.each([
+    ['javascript', 'javascript:alert(1)'],
+    ['recombining javascript', 'javasjavascript:cript:alert(1)'],
+    ['whitespace-obfuscated javascript', 'java\tscript:alert(1)'],
+    ['data url', 'data:text/html,<script>alert(1)</script>'],
+  ])('renders %s links as plain text instead of an anchor', (_name, url) => {
+    const html = renderInlineMarkdown(`[click me](${url})`);
+    // The label survives, the URL does not become a link. A stray `)` may be
+    // left over because the link pattern stops at the first closing paren —
+    // pre-existing behaviour, and harmless as text.
+    expect(html).toContain('click me');
+    expect(html).not.toContain('<a');
+    expect(html).not.toContain('href');
+  });
+
+  it('does not let a url break out of the href attribute', () => {
+    const html = renderInlineMarkdown('[x](" onmouseover=alert(1) x=")');
+    expect(html).not.toContain('onmouseover=alert(1)');
+  });
+
+  it('does not let a label inject markup', () => {
+    const html = renderInlineMarkdown('[<img src=x onerror=alert(1)>](https://example.com)');
+    expect(html).not.toContain('<img');
+  });
+});
+
+describe('markdown round trip', () => {
+  it('does not accumulate entities when parsing and serializing repeatedly', () => {
+    const source = '---\ntitle: "T"\n---\n\nAngle < bracket & ampersand "quoted"\n';
+
+    const once = serializeJournalMarkdown(parseJournalMarkdown(source));
+    const twice = serializeJournalMarkdown(parseJournalMarkdown(once));
+
+    expect(once).toContain('Angle < bracket & ampersand "quoted"');
+    expect(twice).toBe(once);
+  });
+
+  it('decodes exactly what sanitizeHtml encodes', () => {
+    const raw = `<a href="x">5 & 6 don't</a>`;
+    expect(decodeHtmlEntities(sanitizeHtml(raw))).toBe(raw);
+  });
+});

--- a/lib/__tests__/journal.test.ts
+++ b/lib/__tests__/journal.test.ts
@@ -46,11 +46,15 @@ describe('Journal Service & Parser', () => {
   });
 
   describe('sanitizeHtml & inline markdown', () => {
-    it('strips script tags and inline events', () => {
+    it('makes script tags and inline events inert', () => {
       const malicious = 'Hello <script>alert(1)</script><img src="x" onerror="alert(2)">';
       const clean = sanitizeHtml(malicious);
-      expect(clean).not.toContain('<script>');
-      expect(clean).not.toContain('onerror');
+      // The word "onerror" may well survive as text — what matters is that no
+      // tag can form around it, so it is never an attribute. Testing for the
+      // absence of the substring tested the old denylist, not the property.
+      expect(clean).not.toContain('<');
+      expect(clean).not.toContain('>');
+      expect(clean).not.toContain('"');
     });
 
     it('formats bold, italic, and safe links', () => {

--- a/lib/journal.ts
+++ b/lib/journal.ts
@@ -36,12 +36,55 @@ export interface JournalEntrySummary {
   readingTimeMinutes: number;
 }
 
-/** Sanitize inline HTML strings to prevent XSS in journal blocks */
+const HTML_ESCAPES: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+};
+
+/**
+ * Make an author's text inert as HTML.
+ *
+ * This escapes rather than filters. The previous implementation stripped
+ * `<script>` tags, `on*="..."` handlers and the literal string `javascript:`,
+ * which is a denylist and was trivially bypassable: `<img src=x onerror=alert(1)>`
+ * (unquoted handler), `onerror='...'` (single quotes), `<svg onload=...>` (not a
+ * script tag) and `javasjavascript:cript:` (the replacement recombines) all
+ * passed through into `dangerouslySetInnerHTML`.
+ *
+ * With escaping there is nothing to enumerate: the only tags in the output are
+ * the ones renderInlineMarkdown emits itself.
+ */
 export function sanitizeHtml(input: string): string {
+  return input.replace(/[&<>"']/g, (char) => HTML_ESCAPES[char]);
+}
+
+/**
+ * Reverse of sanitizeHtml, for turning rendered block HTML back into Markdown.
+ * Without this a save would write `&lt;` into the file and the next parse would
+ * escape the `&` again, corrupting the text a little more on every round trip.
+ */
+export function decodeHtmlEntities(input: string): string {
   return input
-    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
-    .replace(/on\w+="[^"]*"/gi, '')
-    .replace(/javascript:/gi, '');
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, '&');
+}
+
+/**
+ * Schemes an author may link to. Everything else — `javascript:`, `data:`,
+ * `vbscript:` — renders as plain text instead of an anchor.
+ */
+const SAFE_URL = /^(?:https?:\/\/|mailto:|tel:|[./#])/i;
+
+function isSafeUrl(url: string): boolean {
+  // Browsers ignore control characters and whitespace inside a scheme, so
+  // `java\tscript:` would run. Strip them before deciding.
+  return SAFE_URL.test(url.replace(/[\u0000-\u0020]/g, ''));
 }
 
 /** Sanitize a slug to only allow safe URL and filesystem characters */
@@ -62,6 +105,9 @@ export function sanitizeSlug(input: string): string {
 
 /** Simple Markdown inline formatting (bold, italic, links) */
 export function renderInlineMarkdown(text: string): string {
+  // Escape first: from here on every `<` and `"` in the string is the author's
+  // literal text, so the markdown rules below can only ever add the tags they
+  // build themselves, and a URL cannot break out of its href attribute.
   let html = sanitizeHtml(text);
   // Bold: **text** or __text__
   html = html.replace(/(\*\*|__)(.*?)\1/g, '<strong>$2</strong>');
@@ -69,14 +115,18 @@ export function renderInlineMarkdown(text: string): string {
   html = html.replace(/(\*|_)(.*?)\1/g, '<em>$2</em>');
   // Links: [label](url)
   html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (match, label, url) => {
-    const safeUrl = url.trim().replace(/^javascript:/i, '');
-    return `<a href="${safeUrl}" target="_blank" rel="noopener noreferrer">${label}</a>`;
+    const trimmed = url.trim();
+    if (!isSafeUrl(trimmed)) return label;
+    return `<a href="${trimmed}" target="_blank" rel="noopener noreferrer">${label}</a>`;
   });
   return html;
 }
 
 /** Parse frontmatter (YAML block delimited by ---) */
-export function parseFrontmatter(content: string): { frontmatter: JournalFrontmatter; body: string } {
+export function parseFrontmatter(content: string): {
+  frontmatter: JournalFrontmatter;
+  body: string;
+} {
   const frontmatterMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
   if (!frontmatterMatch) {
     return { frontmatter: {}, body: content };
@@ -258,18 +308,20 @@ export function serializeJournalMarkdown(journal: ParsedJournal): string {
           if (tag.startsWith('</em>') || tag.startsWith('</i>')) return '*';
           return '';
         });
-        lines.push(text);
+        lines.push(decodeHtmlEntities(text));
         break;
       }
       case 'quote': {
         const authorSuffix = block.author ? ` -- ${block.author}` : '';
-        const text = block.text.replace(/[\r\n]+/g, ' ');
+        const text = decodeHtmlEntities(block.text.replace(/[\r\n]+/g, ' '));
         lines.push(`> ${text}${authorSuffix}`);
         break;
       }
       case 'photo': {
         const layoutSuffix = block.layout !== 'contained' ? `:${block.layout}` : '';
-        const caption = block.caption ? block.caption.replace(/[\r\n]+/g, ' ') : '';
+        const caption = block.caption
+          ? decodeHtmlEntities(block.caption.replace(/[\r\n]+/g, ' '))
+          : '';
         lines.push(`![${block.assetId}${layoutSuffix}](${caption})`);
         break;
       }


### PR DESCRIPTION
CodeQL reports 26 high-severity alerts on release PR #432. Most of them point at one function: `sanitizeHtml()` in `lib/journal.ts`, a denylist of three regexes whose output is rendered through `dangerouslySetInnerHTML`.

I reproduced the bypasses before touching anything. All four pass the old filter:

| input | why it passed |
|---|---|
| `<img src=x onerror=alert(1)>` | the handler regex is `on\w+="[^"]*"` — it requires double quotes |
| `<img src=x onerror='alert(1)'>` | same, single quotes |
| `<svg onload=alert(1)>` | not a `<script>` tag |
| `javasjavascript:cript:alert(1)` | one-pass replace; the remainder recombines into `javascript:` |

Plus an attribute breakout in the link renderer, which interpolated the URL into `href="${url}"` without escaping:

```
[x](" onmouseover=alert(1) x=")  ->  <a href="" onmouseover=alert(1" ...>
```

## The change

Escaping instead of filtering. Every `&<>"'` in author text becomes an entity **before** any markdown rule runs, so the only tags in the output are the ones `renderInlineMarkdown` builds itself, and a URL cannot leave its attribute. There is no list of dangerous things to keep up to date.

Link schemes are an allowlist now — `http`, `https`, `mailto`, `tel`, relative paths, anchors. Anything else (`javascript:`, `data:`, `vbscript:`) renders as plain text instead of an anchor. Control characters and whitespace are stripped before the check, since browsers ignore them inside a scheme and `java\tscript:` would otherwise run.

After:

```
inert | unquoted handler       -> &lt;img src=x onerror=alert(1)&gt;
inert | single-quoted handler  -> &lt;img src=x onerror=&#39;alert(1)&#39;&gt;
inert | non-script tag         -> &lt;svg onload=alert(1)&gt;
inert | recombining scheme     -> javasjavascript:cript:alert(1)

normal   -> <strong>bold</strong> <em>kursiv</em> <a href="https://example.com" ...>Link</a>
umlauts  -> Größe &amp; Maß &lt; 5
```

## The part that is easy to miss

The serializer had to learn `decodeHtmlEntities`. Without it, saving an entry in the Journal Studio would write `&lt;` into the Markdown file, and the next parse would escape the `&` again — the text degrading a little more on every round trip. There is a test asserting that parse → serialize → parse is stable.

## Two existing tests were rewritten

Worth calling out explicitly, since changing tests to make a change pass deserves scrutiny:

- `essay.test.ts` expected `sanitizeHtml('Hello <script>…</script> World')` to equal `'Hello  World'` — i.e. it asserted that the tag is *removed*. That is the denylist this replaces.
- `journal.test.ts` expected the output not to contain the substring `onerror`. With escaping, the word survives as inert text — which is fine.

Both now assert the property that actually matters: no tag can form. They were rewritten, not deleted.

## Scope of the risk

Exploitation required admin access either way — journal and essay text comes from the studio or from `content/*.md`. This removes a weakness; it does not close an open door. The alerts are also not new to this branch: the same ones sit open on `main`. CodeQL counts them as new on #432 only because `dev` moved the parser from `lib/essay.ts` to `lib/journal.ts`.

One behavioural consequence to be aware of: raw inline HTML in existing entries now renders as visible text rather than markup. No shipped content does this, and for a Markdown authoring surface it is the correct default.

## Verification

381 unit tests pass (18 new), `npm run build` and `npx tsc --noEmit` clean.