### PR TITLE
fix(journal): contain file paths, fix frontmatter escaping, defuse two regexes

### DIFF
--- a/lib/__tests__/journal-service-paths.test.ts
+++ b/lib/__tests__/journal-service-paths.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import path from 'path';
+import { resolveJournalFilePath } from '../admin/journal-service';
+import { parseJournalMarkdown, serializeJournalMarkdown } from '../journal';
+
+describe('resolveJournalFilePath', () => {
+  it.each(['../../etc/passwd', 'foo/../../bar', '..', 'a/b', 'foo.md', '', '.'])(
+    'refuses %j',
+    (slug) => {
+      expect(resolveJournalFilePath(slug)).toBeNull();
+    },
+  );
+
+  it('keeps a valid slug inside content/', () => {
+    const resolved = resolveJournalFilePath('my-entry');
+    expect(resolved).not.toBeNull();
+    expect(resolved!.startsWith(path.join(process.cwd(), 'content') + path.sep)).toBe(true);
+    expect(path.basename(resolved!)).toBe('my-entry.md');
+  });
+});
+
+describe('frontmatter escaping', () => {
+  const roundTrip = (title: string) => {
+    const once = serializeJournalMarkdown({
+      frontmatter: { title },
+      blocks: [],
+      referencedAssetIds: [],
+    });
+    const parsedOnce = parseJournalMarkdown(once);
+    const twice = serializeJournalMarkdown(parsedOnce);
+    return { first: parsedOnce.frontmatter.title, stable: once === twice };
+  };
+
+  it.each([
+    ['plain', 'A normal title'],
+    ['quotes', 'A "quoted" title'],
+    ['backslash', String.raw`Path C:\Users`],
+    ['both', String.raw`C:\Users "quoted"`],
+    ['colon', 'Title: with a colon'],
+    ['apostrophe', "Author's title"],
+  ])('survives a title with %s', (_name, title) => {
+    const { first, stable } = roundTrip(title);
+    expect(first).toBe(title);
+    expect(stable).toBe(true);
+  });
+});
+
+describe('parser behaviour is unchanged by the regex rework', () => {
+  const parse = (body: string) => parseJournalMarkdown(`---\ntitle: "T"\n---\n\n${body}\n`).blocks;
+
+  it('parses headings at every level', () => {
+    expect(parse('### Third level')[0]).toEqual({
+      type: 'heading',
+      level: 3,
+      text: 'Third level',
+    });
+  });
+
+  it('splits a quote from its author on the first separator', () => {
+    expect(parse('> Something quotable -- Some Author')[0]).toEqual({
+      type: 'quote',
+      text: 'Something quotable',
+      author: 'Some Author',
+    });
+  });
+
+  it('leaves a quote without a separator whole', () => {
+    expect(parse('> Just a quote')[0]).toEqual({
+      type: 'quote',
+      text: 'Just a quote',
+      author: undefined,
+    });
+  });
+
+  it('still nests italic inside bold', () => {
+    expect(parse('Text with **bold *and italic* inside**.')[0]).toEqual({
+      type: 'paragraph',
+      html: 'Text with <strong>bold <em>and italic</em> inside</strong>.',
+    });
+  });
+});

--- a/lib/admin/journal-service.ts
+++ b/lib/admin/journal-service.ts
@@ -20,15 +20,36 @@ const LEGACY_ESSAYS_DIR = path.join(process.cwd(), 'content', 'essays');
 const MAX_BACKUPS = 10;
 let tmpCounter = 0;
 
+/**
+ * Join a filename onto a content directory, or return null if the result would
+ * escape it.
+ *
+ * isValidSlug() already rejects dots and separators, so nothing should ever get
+ * this far — this is the second lock on the door. It also gives the taint
+ * analysis in CI a barrier it can see: the slug check lives in another module,
+ * which CodeQL does not follow, so every path built from a slug was reported as
+ * path injection.
+ */
+function containedPath(dir: string, filename: string): string | null {
+  const base = path.resolve(dir);
+  const resolved = path.resolve(base, filename);
+  if (resolved !== base && !resolved.startsWith(base + path.sep)) return null;
+  return resolved;
+}
+
 /** Resolve file path for a journal slug (checks content/journal/ then content/essays/) */
 export function resolveJournalFilePath(slug: string): string | null {
   if (!isValidSlug(slug)) return null;
-  const filename = slug.endsWith('.md') ? slug : `${slug}.md`;
-  const primaryPath = path.join(JOURNAL_DIR, filename);
+  // Not `slug.endsWith('.md') ? slug : ...`: isValidSlug rejects dots, so that
+  // branch could never be taken.
+  const filename = `${slug}.md`;
+
+  const primaryPath = containedPath(JOURNAL_DIR, filename);
+  if (!primaryPath) return null;
   if (nodeFs.existsSync(primaryPath)) return primaryPath;
 
-  const legacyPath = path.join(LEGACY_ESSAYS_DIR, filename);
-  if (nodeFs.existsSync(legacyPath)) return legacyPath;
+  const legacyPath = containedPath(LEGACY_ESSAYS_DIR, filename);
+  if (legacyPath && nodeFs.existsSync(legacyPath)) return legacyPath;
 
   return primaryPath; // Target path for new writes
 }
@@ -133,8 +154,11 @@ export async function writeJournalEntry(slug: string, rawMarkdown: string): Prom
   }
 
   await fs.mkdir(JOURNAL_DIR, { recursive: true });
-  const filename = slug.endsWith('.md') ? slug : `${slug}.md`;
-  const filePath = path.join(JOURNAL_DIR, filename);
+  const filename = `${slug}.md`;
+  const filePath = containedPath(JOURNAL_DIR, filename);
+  if (!filePath) {
+    throw new Error(`Invalid journal slug: "${slug}"`);
+  }
 
   // Create rolling backup if file already exists
   try {

--- a/lib/journal.ts
+++ b/lib/journal.ts
@@ -110,6 +110,13 @@ export function renderInlineMarkdown(text: string): string {
   // build themselves, and a URL cannot break out of its href attribute.
   let html = sanitizeHtml(text);
   // Bold: **text** or __text__
+  //
+  // CodeQL flags the lazy group here as polynomial backtracking. It is left as
+  // is on purpose: rewriting it with a negated class (`\*\*([^*]+)\*\*`) removes
+  // the backtracking but also breaks nesting — `**bold *and italic* here**`
+  // then renders as `*<em>bold </em>and italic<em> here</em>*`. The input is
+  // Markdown written by an authenticated admin, never visitor input, so the
+  // worst case is an author slowing down their own page.
   html = html.replace(/(\*\*|__)(.*?)\1/g, '<strong>$2</strong>');
   // Italic: *text* or _text_
   html = html.replace(/(\*|_)(.*?)\1/g, '<em>$2</em>');
@@ -144,7 +151,12 @@ export function parseFrontmatter(content: string): {
 
     const key = trimmed.slice(0, colonIdx).trim();
     let val = trimmed.slice(colonIdx + 1).trim();
-    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+    if (val.length >= 2 && val.startsWith('"') && val.endsWith('"')) {
+      // Undo the escaping serializeJournalMarkdown applies. Without this a title
+      // containing a quote or a backslash gained one more backslash on every
+      // save/load cycle.
+      val = val.slice(1, -1).replace(/\\([\\"])/g, '$1');
+    } else if (val.length >= 2 && val.startsWith("'") && val.endsWith("'")) {
       val = val.slice(1, -1);
     }
 
@@ -179,7 +191,9 @@ export function parseJournalMarkdown(rawContent: string): ParsedJournal {
 
   for (const chunk of chunks) {
     // 1. Headings (# H1, ## H2, ### H3)
-    const headingMatch = chunk.match(/^(#{1,6})\s+(.+)$/);
+    // `[ \t]+` rather than `\s+`: next to `(.+)` the two overlap, and the
+    // engine has to try every split of the whitespace run before failing.
+    const headingMatch = chunk.match(/^(#{1,6})[ \t]+(\S.*)$/);
     if (headingMatch) {
       blocks.push({
         type: 'heading',
@@ -197,14 +211,22 @@ export function parseJournalMarkdown(rawContent: string): ParsedJournal {
         .join(' ')
         .trim();
 
-      const authorMatch = quoteText.match(/^(.*?)(?:\s+--\s+(.+))?$/);
-      if (authorMatch) {
-        blocks.push({
-          type: 'quote',
-          text: renderInlineMarkdown(authorMatch[1]),
-          author: authorMatch[2] ? authorMatch[2].trim() : undefined,
-        });
-      }
+      // Split on the first ` -- ` by index instead of matching the whole line.
+      // `/^(.*?)(?:\s+--\s+(.+))?$/` made the engine re-try every prefix
+      // against an optional tail — quadratic on a line that has no separator.
+      const separator = quoteText.match(/\s+--\s+/);
+      const quoteBody =
+        separator?.index === undefined ? quoteText : quoteText.slice(0, separator.index);
+      const quoteAuthor =
+        separator?.index === undefined
+          ? undefined
+          : quoteText.slice(separator.index + separator[0].length).trim();
+
+      blocks.push({
+        type: 'quote',
+        text: renderInlineMarkdown(quoteBody),
+        author: quoteAuthor || undefined,
+      });
       continue;
     }
 
@@ -284,7 +306,8 @@ export function serializeJournalMarkdown(journal: ParsedJournal): string {
         if (typeof val === 'boolean') {
           lines.push(`${key}: ${val}`);
         } else {
-          lines.push(`${key}: "${String(val).replace(/"/g, '\\"')}"`);
+          const escaped = String(val).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+          lines.push(`${key}: "${escaped}"`);
         }
       }
     }


### PR DESCRIPTION
Follow-up to the CodeQL findings on release PR #432. I went through all 23 alerts individually. This addresses the ones worth addressing and documents the ones that are not, rather than chasing a green checkmark.

| rule | count | verdict |
|---|---|---|
| `js/path-injection` | 12 | False positive — hardened anyway |
| `js/insufficient-password-hash` | 5 | Correct in general, not applicable here — left alone |
| `js/polynomial-redos` | 3 | Two fixed, one deliberately kept |
| `js/incomplete-*-sanitization` | 3 | One real bug fixed, two are not sanitizers |

## Path containment — 12 alerts, all false positives

Every path built from a slug already goes through `isValidSlug()`, a strict `/^[a-zA-Z0-9_-]+$/` allowlist. Verified rather than assumed:

```
blockt | "../../etc/passwd"    blockt | "foo/../../bar"
blockt | "..%2f..%2fetc"       blockt | "a/b"
blockt | "foo.md"              blockt | ".."
```

CodeQL cannot see this because the check lives in another module and its taint analysis does not follow it. Added a `containedPath()` helper that resolves the path and refuses anything landing outside the content directory — a second lock on a door that was already locked, and a barrier the analysis can follow.

Also removed the dead `slug.endsWith('.md') ? slug : …` branches in two places: `isValidSlug` rejects dots, so they could never be taken.

## Frontmatter escaping — a real bug

The serializer escaped `"` but not `\`, and the parser never unescaped anything at all. A title containing either character gained a backslash on every save/load cycle:

```
Path C:\Users "quoted"   ->   title: "Path C:\\Users \"quoted\""   ->   Path C:\\Users \"quoted\"
```

Escaping now covers the backslash first, and the parser undoes both. Round trip tests cover quotes, backslashes, colons and apostrophes — asserting both that the value survives and that a second serialize produces identical bytes.

## Two of three ReDoS regexes

- **Heading**: `/^(#{1,6})\s+(.+)$/` — `\s+` and `(.+)` overlap, so the engine tries every split of the whitespace run before failing. Now `[ \t]+` and `(\S.*)`.
- **Quote author**: `/^(.*?)(?:\s+--\s+(.+))?$/` — a lazy group wrapped around an optional group, the textbook quadratic case. Now an index split on the first separator, preserving the original first-match semantics.

**The third one stays**, and that is a deliberate trade-off rather than an oversight. Rewriting the bold/italic pass with a negated class removes the backtracking but breaks nesting:

```
input:     **bold *and italic* here**
current:   <strong>bold <em>and italic</em> here</strong>
rewritten: *<em>bold </em>and italic<em> here</em>*     ← broken
```

The input is Markdown written by an authenticated admin, never visitor input, so the worst case is an author slowing down their own page. A comment in the code records the reasoning so the next person does not "fix" it.

## Not addressed: 5 password-hash alerts

They ask for a slow KDF where the code uses SHA-256/HMAC. Correct as a general rule, but the admin password comes from an environment variable and is never stored — a stronger KDF protects nothing that is not already sitting in plaintext in the environment. The per-page passwords already use scrypt. These are candidates for a documented dismissal in the code scanning UI.

## Verification

399 unit tests pass (18 new), `npm run build` and `npx tsc --noEmit` clean. Parser behaviour spot-checked against headings at several levels, quotes with and without an author, and nested bold/italic — all unchanged.