### PR TITLE
fix(journal): split the quote author by scanning, not by pattern

### DIFF
--- a/lib/__tests__/journal-service-paths.test.ts
+++ b/lib/__tests__/journal-service-paths.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import path from 'path';
 import { resolveJournalFilePath } from '../admin/journal-service';
-import { parseJournalMarkdown, serializeJournalMarkdown } from '../journal';
+import { parseJournalMarkdown, serializeJournalMarkdown, splitQuoteAuthor } from '../journal';
 
 describe('resolveJournalFilePath', () => {
   it.each(['../../etc/passwd', 'foo/../../bar', '..', 'a/b', 'foo.md', '', '.'])(
@@ -77,5 +77,32 @@ describe('parser behaviour is unchanged by the regex rework', () => {
       type: 'paragraph',
       html: 'Text with <strong>bold <em>and italic</em> inside</strong>.',
     });
+  });
+});
+
+describe('splitQuoteAuthor', () => {
+  it.each([
+    ['separator', 'Quote -- Author', { body: 'Quote', author: 'Author' }],
+    ['no separator', 'Just a quote', { body: 'Just a quote', author: undefined }],
+    [
+      'first of several',
+      'Quote -- Author -- Second',
+      { body: 'Quote', author: 'Author -- Second' },
+    ],
+    ['tabs', 'Quote\t--\tAuthor', { body: 'Quote', author: 'Author' }],
+    ['wide gap', 'Quote   --   Author', { body: 'Quote', author: 'Author' }],
+    // Whitespace on both sides is required, so these are not separators.
+    ['no surrounding space', 'no--separator', { body: 'no--separator', author: undefined }],
+    ['leading', '-- author only', { body: '-- author only', author: undefined }],
+    ['trailing', 'Quote --', { body: 'Quote --', author: undefined }],
+    ['empty', '', { body: '', author: undefined }],
+  ])('handles %s', (_name, input, expected) => {
+    expect(splitQuoteAuthor(input as string)).toEqual(expected);
+  });
+
+  it('stays linear on a long run of whitespace with no separator', () => {
+    const started = performance.now();
+    splitQuoteAuthor(' '.repeat(50_000) + 'x');
+    expect(performance.now() - started).toBeLessThan(100);
   });
 });

--- a/lib/journal.ts
+++ b/lib/journal.ts
@@ -129,6 +129,37 @@ export function renderInlineMarkdown(text: string): string {
   return html;
 }
 
+const isWhitespace = (char: string) => char.trim() === '';
+
+/**
+ * Split `Quote -- Author` at the first separator surrounded by whitespace.
+ *
+ * A plain scan rather than a pattern. The original `/^(.*?)(?:\s+--\s+(.+))?$/`
+ * wrapped a lazy group around an optional one — the quadratic case — and its
+ * first replacement, `/\s+--\s+/`, was reported as polynomial backtracking in
+ * turn. This is linear and needs no reasoning about the engine at all.
+ */
+export function splitQuoteAuthor(text: string): { body: string; author?: string } {
+  for (
+    let hyphens = text.indexOf('--');
+    hyphens !== -1;
+    hyphens = text.indexOf('--', hyphens + 2)
+  ) {
+    let start = hyphens;
+    while (start > 0 && isWhitespace(text[start - 1])) start--;
+
+    let end = hyphens + 2;
+    while (end < text.length && isWhitespace(text[end])) end++;
+
+    // Whitespace is required on both sides, so `a--b` is not a separator.
+    if (start === hyphens || end === hyphens + 2) continue;
+
+    return { body: text.slice(0, start), author: text.slice(end).trim() || undefined };
+  }
+
+  return { body: text };
+}
+
 /** Parse frontmatter (YAML block delimited by ---) */
 export function parseFrontmatter(content: string): {
   frontmatter: JournalFrontmatter;
@@ -211,21 +242,12 @@ export function parseJournalMarkdown(rawContent: string): ParsedJournal {
         .join(' ')
         .trim();
 
-      // Split on the first ` -- ` by index instead of matching the whole line.
-      // `/^(.*?)(?:\s+--\s+(.+))?$/` made the engine re-try every prefix
-      // against an optional tail — quadratic on a line that has no separator.
-      const separator = quoteText.match(/\s+--\s+/);
-      const quoteBody =
-        separator?.index === undefined ? quoteText : quoteText.slice(0, separator.index);
-      const quoteAuthor =
-        separator?.index === undefined
-          ? undefined
-          : quoteText.slice(separator.index + separator[0].length).trim();
+      const { body: quoteBody, author: quoteAuthor } = splitQuoteAuthor(quoteText);
 
       blocks.push({
         type: 'quote',
         text: renderInlineMarkdown(quoteBody),
-        author: quoteAuthor || undefined,
+        author: quoteAuthor,
       });
       continue;
     }


### PR DESCRIPTION
Cleaning up after myself.

#439 replaced the quote author regex `/^(.*?)(?:\s+--\s+(.+))?$/` — a lazy group wrapped around an optional one, the textbook quadratic case — with `/\s+--\s+/`. CodeQL promptly flagged the replacement for the same reason. One reported pattern traded for another, so the alert count moved from 3 to 2 instead of to 1.

`splitQuoteAuthor()` scans for the first `--` that has whitespace on both sides. Linear, and it requires no reasoning about the regex engine at all.

## Behaviour is unchanged

Checked case by case against the original regex before writing the tests:

| input | body | author |
|---|---|---|
| `Quote -- Author` | `Quote` | `Author` |
| `Just a quote` | `Just a quote` | — |
| `Quote -- Author -- Second` | `Quote` | `Author -- Second` |
| `Quote\t--\tAuthor` | `Quote` | `Author` |
| `Quote   --   Author` | `Quote` | `Author` |
| `no--separator` | `no--separator` | — |
| `-- author only` | `-- author only` | — |
| `Quote --` | `Quote --` | — |
| `` (empty) | `` | — |

All nine are tests now, plus one asserting the scan stays fast on a 50,000 character whitespace run.

## Where this leaves the CodeQL findings on #432

This removes one alert. What remains is, by my reading, not worth code changes:

- **12× path injection** — false positives. Every path goes through a strict `/^[a-zA-Z0-9_-]+$/` allowlist. The `containedPath()` helper added in #439 did *not* satisfy the analysis, contrary to what that PR claimed: CodeQL wants the guard at the sink, not behind a function return, and the derived backup and `.tmp` paths are separate flows the guard never touched. The hardening is still correct as defence in depth; the claim that it would clear the alerts was wrong.
- **5× insufficient password hash** — the admin password comes from an environment variable and is never stored.
- **2× incomplete sanitization** — tag stripping for text extraction, not sanitizers.
- **1× polynomial redos** — the bold/italic pass, kept deliberately because the non-backtracking rewrite breaks nested formatting.

Clearing those means either duplicating containment assertions in front of six filesystem calls, or dismissing them in the code scanning UI with a justification. I would dismiss.

Worth knowing for the release: what actually blocks #432 is not the failing check but the ruleset's `required_review_thread_resolution` — the advanced-security bot opens a review thread per alert, and 15 are unresolved.

## Verification

409 unit tests pass (10 new), `npm run build` and `npx tsc --noEmit` clean.