### PR TITLE
security(admin): derive the session signing key with scrypt

### DIFF
--- a/lib/admin/auth.ts
+++ b/lib/admin/auth.ts
@@ -26,11 +26,38 @@ function getAdminPassword(): string {
   return getInstallCredentials().adminPassword;
 }
 
+/**
+ * Derived session signing key, kept for the process lifetime.
+ *
+ * scrypt is deliberately slow, and getSigningKey() runs on every admin request
+ * — deriving per call would put ~100ms in front of each one. The cache is keyed
+ * by a digest of the inputs, so a rotated password or secret misses the cache
+ * and derives again, and no second plaintext copy of the password is retained.
+ */
+let cachedSigningKey: { fingerprint: string; key: Buffer } | null = null;
+
 function getSigningKey(): Buffer {
   // Bind the key to ADMIN_PASSWORD as well, so rotating the password
   // immediately invalidates every outstanding session token.
   const secret = resolveAuthSecret();
-  return crypto.createHash('sha256').update(`admin:${secret}:${getAdminPassword()}`).digest();
+  const password = getAdminPassword();
+
+  const fingerprint = crypto
+    .createHash('sha256')
+    .update(`${secret}\u0000${password}`)
+    .digest('base64');
+  if (cachedSigningKey?.fingerprint === fingerprint) return cachedSigningKey.key;
+
+  /*
+   * scrypt rather than a plain SHA-256 digest: the admin password is an input
+   * here, and a single fast hash would make it cheap to recover by brute force
+   * if the derived key ever leaked. The salt has to be stable — a random one
+   * would change the key on every call and invalidate every session — so it is
+   * derived from AUTH_SECRET, which is deployment-specific.
+   */
+  const key = crypto.scryptSync(password, `folio-admin-session:${secret}`, 32);
+  cachedSigningKey = { fingerprint, key };
+  return key;
 }
 
 /** Create a signed session token. */


### PR DESCRIPTION
`getSigningKey()` ran the admin password through a single SHA-256 digest. This is key derivation rather than password storage, so it was never a stored-hash problem — but if the derived key ever leaked, one fast hash makes recovering the password by brute force cheap. CodeQL flags it as `js/insufficient-password-hash` and, for this particular alert, has a point.

scrypt now. Two details that matter more than the swap itself:

**The salt has to be stable.** A random salt would produce a different key on every call and invalidate every session immediately. It is derived from `AUTH_SECRET`, which is deployment-specific. Verified across separate processes: the same inputs produce a token that still verifies, so a restart or redeploy does not log everyone out.

**The result is cached for the process lifetime.** scrypt is deliberately slow and `getSigningKey()` runs on every admin request — deriving per call would put ~24ms in front of each one. The cache key is a digest of secret plus password, so a rotation misses the cache and derives again, and no extra plaintext copy of the password is retained.

## Measured

| | |
|---|---|
| first derivation | 24 ms |
| subsequent calls (cached) | 0.12 ms |
| token from another process, same inputs | verifies |
| after password change | rejected |
| after `AUTH_SECRET` change | rejected |

The first two rows are the reason for the cache; the last three are the reason for the stable salt. All checked in separate processes, because mutating `process.env` at runtime does not work here — `lib/env.ts` parses once at import, which quietly invalidated my first attempt at testing rotation.

## One-time effect on deploy

The derivation changes, so existing admin sessions become invalid and everyone signs in once more. Worth a line in the release notes.

## Scope

This clears one of the five `js/insufficient-password-hash` alerts. The other four are comparison paths, not storage: stored credentials already go through scrypt, and those branches only run when the password is supplied as a plaintext environment variable — there is no stored hash to strengthen. Those are candidates for a documented dismissal rather than a change.

399 unit tests pass, `npm run build` and `npx tsc --noEmit` clean.