### PR TITLE
security(admin): key the signing-key cache on its inputs, not a digest

### DIFF
--- a/lib/admin/auth.ts
+++ b/lib/admin/auth.ts
@@ -30,11 +30,18 @@ function getAdminPassword(): string {
  * Derived session signing key, kept for the process lifetime.
  *
  * scrypt is deliberately slow, and getSigningKey() runs on every admin request
- * — deriving per call would put ~100ms in front of each one. The cache is keyed
- * by a digest of the inputs, so a rotated password or secret misses the cache
- * and derives again, and no second plaintext copy of the password is retained.
+ * — deriving per call would put ~24ms in front of each one. The cache holds the
+ * inputs it was derived from, so a rotated password or secret misses the cache
+ * and derives again.
+ *
+ * Those inputs are compared directly rather than through a digest of them: a
+ * digest here would be a fast hash of the admin password sitting in memory for
+ * the life of the process, which is the very thing scrypt was introduced below
+ * to avoid. Holding the strings costs nothing extra — they are the same objects
+ * the env and install caches already hold, whereas building a digest input
+ * allocates a fresh copy of the password.
  */
-let cachedSigningKey: { fingerprint: string; key: Buffer } | null = null;
+let cachedSigningKey: { secret: string; password: string; key: Buffer } | null = null;
 
 function getSigningKey(): Buffer {
   // Bind the key to ADMIN_PASSWORD as well, so rotating the password
@@ -42,11 +49,9 @@ function getSigningKey(): Buffer {
   const secret = resolveAuthSecret();
   const password = getAdminPassword();
 
-  const fingerprint = crypto
-    .createHash('sha256')
-    .update(`${secret}\u0000${password}`)
-    .digest('base64');
-  if (cachedSigningKey?.fingerprint === fingerprint) return cachedSigningKey.key;
+  if (cachedSigningKey?.secret === secret && cachedSigningKey.password === password) {
+    return cachedSigningKey.key;
+  }
 
   /*
    * scrypt rather than a plain SHA-256 digest: the admin password is an input
@@ -56,7 +61,7 @@ function getSigningKey(): Buffer {
    * derived from AUTH_SECRET, which is deployment-specific.
    */
   const key = crypto.scryptSync(password, `folio-admin-session:${secret}`, 32);
-  cachedSigningKey = { fingerprint, key };
+  cachedSigningKey = { secret, password, key };
   return key;
 }
 


### PR DESCRIPTION
Cleaning up after #441, which caused this alert.

#441 removed the SHA-256 digest of the admin password from the key derivation — and introduced a new one three lines above it, as the cache key. Same rule, same file, reported immediately. That is the second time in this series I traded one instance of a finding for another (#439 → #440 did the same with a regex).

The comment justifying it was wrong as well. It claimed that no second plaintext copy of the password was retained, while building the digest input allocates exactly that in order to hash it.

## The change

The cache now holds the two input strings and compares them directly:

```ts
if (cachedSigningKey?.secret === secret && cachedSigningKey.password === password) {
  return cachedSigningKey.key;
}
```

They are the same string objects the env and install caches already hold, so nothing extra is retained — and unlike the digest, no fast hash of the password sits in memory for the life of the process. The comparison is not constant-time, which is fine: it is an internal cache check, not an authentication decision.

## Re-verified

Same checks as #441, run again after the change, in separate processes because `lib/env.ts` parses once at import:

| | |
|---|---|
| token from another process, same inputs | verifies |
| after password change | rejected |
| after `AUTH_SECRET` change | rejected |
| first derivation | 24 ms |
| cached calls | 0.001 ms |

409 unit tests pass, `npm run build` and `npx tsc --noEmit` clean.

## What is left in this file

scrypt is now the only place the password is hashed. The two HMACs further down operate on the derived key and on the token payload, not on the password. The constant-time comparison in `verifyAdminPassword` is the one already dismissed as won't fix — stored credentials go through scrypt, that branch only runs for a plaintext environment variable.

I am not predicting an alert count this time; the last two predictions were wrong.