### PR TITLE
chore(journal): ship the sample story as a template, not a live entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,10 +62,18 @@ docker-compose.override.yml
 content/settings.yaml
 content/gallery.yaml
 content/about.md
+# Journal entries reference Immich asset UUIDs, which are specific to one
+# server — committing an entry would publish ids from the author's instance.
+# The .example alongside them stays tracked as a starting point.
+content/journal/*.md
+content/essays/*.md
 # Von der App zur Laufzeit geschrieben: yaml-service legt bis zu 10 Backups je
 # Datei ab, und die Backups von gallery.yaml/settings.yaml wuerden genau den
 # Inhalt ins Repo tragen, den die drei Zeilen darueber heraushalten sollen.
 content/.backups/
+# yaml-service writes next to the file it backs up, so the journal directory
+# gets its own .backups/ — the top-level pattern above does not reach it.
+content/**/.backups/
 content/analytics.json
 content/*.screenshot-bak
 # Credentials written by the /install wizard (never committed)

--- a/content/journal/sample-story.md.example
+++ b/content/journal/sample-story.md.example
@@ -5,19 +5,26 @@ author: "Portfolio Photographer"
 date: "2026-08-05"
 ---
 
+Copy this file to `content/journal/<your-slug>.md` to start an entry by hand, or
+create one under Journal in the admin panel — the studio writes this same
+format. Delete this paragraph and the next one when you are done.
+
+Photos are referenced by their Immich asset id, and those ids are specific to
+your server, so this template ships without any. Add them in the studio via
+Add Block → Photo, where the picker fills the id in for you. Written by hand it
+is `![<asset-id>:fullbleed](Caption)` for a single photo — `:wide` or no suffix
+give the narrower widths — and `![<asset-id>, <asset-id>](Caption)` for a
+side-by-side pair.
+
 # Into the Wilderness
 
 The journey began at dawn along the F-roads winding deep into the interior. As civil infrastructure faded behind us, the landscape shifted dramatically into vast fields of black volcanic ash framed by vivid neon-green moss.
 
 > Silence in the highlands isn't just the absence of sound — it is a physical weight that fills every horizon.
 
-![1:fullbleed](Crossing the icy glacial melt rivers of Landmannalaugar at early morning)
-
 ## Landmannalaugar & Beyond
 
 Walking through the rhyolite mountains, the earth fumes with geothermal vents. The color spectrum ranges from deep ochre and sulfur yellow to dark basalt gray.
-
-![2, 3](Side-by-side: Thermal vent details and volcanic obsidian formations)
 
 ### Reflection & Light
 


### PR DESCRIPTION
`content/essays/sample-story.md` was tracked as a *live* entry, and the journal service scans that directory. So every deployment published a story its owner never wrote — and the photo blocks used positional references (`![1]`, `![2, 3]`), which only ever resolved against a subpage album. A standalone journal page has none, so the entry rendered text and no photos, for everyone.

It is now `content/journal/sample-story.md.example`, matching the convention the repo already uses:

```
content/about.md.example        tracked  →  content/about.md        ignored
content/gallery.yaml.example    tracked  →  content/gallery.yaml    ignored
content/settings.yaml.example   tracked  →  content/settings.yaml   ignored
content/journal/sample-story.md.example   ← now the same shape
```

Nobody gets a published entry they did not create, and whoever wants a starting point copies it deliberately.

## The template itself

The prose is unchanged. The two unresolvable photo references are replaced by a short note explaining that asset ids are specific to an Immich server, that the studio's picker writes them, and what the written form looks like (`![<asset-id>:fullbleed](Caption)`, `![<id>, <id>](Caption)`).

A template genuinely cannot ship working photos — the ids are per-instance — so the honest options were a note or nothing. The note also documents the syntax, which was previously only discoverable by reading the parser.

## Two gitignore gaps closed

- `content/journal/*.md`, `content/essays/*.md` — entries embed Immich asset UUIDs, so committing one publishes ids from the author's instance.
- `content/**/.backups/` — yaml-service writes backups next to the file it backs up, so the journal directory has its own `.backups/` that the existing top-level `content/.backups/` never reached.

The second one was not theoretical: staging this change pulled in four `.bak` files containing exactly the asset id the rules above are meant to keep out. They are excluded now.

## Verification

Fresh deployments end up with no journal entries, which the index already handles — `app/journal/page.tsx` renders "No journal entries published yet." 409 unit tests pass, `npm run build` clean.