### PR TITLE
style: run prettier across the tree

### DIFF
--- a/app/[...path]/AlbumDetailView.tsx
+++ b/app/[...path]/AlbumDetailView.tsx
@@ -70,7 +70,9 @@ export function AlbumDetailView({
             priority
             sizes="100vw"
             style={{ objectFit: 'cover' }}
-            {...(heroBlurDataURL ? { placeholder: 'blur' as const, blurDataURL: heroBlurDataURL } : {})}
+            {...(heroBlurDataURL
+              ? { placeholder: 'blur' as const, blurDataURL: heroBlurDataURL }
+              : {})}
           />
           <div className="album-hero__overlay" />
         </div>
@@ -90,12 +92,8 @@ export function AlbumDetailView({
           <span className="album-header__meta-count">
             {images.length} {images.length === 1 ? 'photo' : 'photos'}
           </span>
-          {metaDetail.date && (
-            <span className="album-header__meta-date"> · {metaDetail.date}</span>
-          )}
-          {metaDetail.gear && (
-            <span className="album-header__meta-gear">{metaDetail.gear}</span>
-          )}
+          {metaDetail.date && <span className="album-header__meta-date"> · {metaDetail.date}</span>}
+          {metaDetail.gear && <span className="album-header__meta-gear">{metaDetail.gear}</span>}
         </p>
       </div>
       <PhotoGrid assets={images} layout={layout} gridStyle={gridStyle} watermark={watermark} />

--- a/app/[...path]/PhotoGrid.tsx
+++ b/app/[...path]/PhotoGrid.tsx
@@ -35,13 +35,7 @@ export interface PhotoItem {
 interface PhotoGridProps {
   assets: PhotoItem[];
   layout?:
-    | 'masonry'
-    | 'uniform'
-    | 'showcase'
-    | 'filmstrip'
-    | 'editorial-flow'
-    | 'essay'
-    | 'justified';
+    'masonry' | 'uniform' | 'showcase' | 'filmstrip' | 'editorial-flow' | 'essay' | 'justified';
   gridStyle?: React.CSSProperties;
   watermark?: LightboxWatermark;
 }
@@ -120,7 +114,9 @@ function PhotoGridInner({ assets, layout = 'masonry', gridStyle, watermark }: Ph
   }, [displayedAssets.length]);
 
   const goPrev = useCallback(() => {
-    setLightboxIndex((prev) => (prev !== null ? (prev - 1 + displayedAssets.length) % displayedAssets.length : null));
+    setLightboxIndex((prev) =>
+      prev !== null ? (prev - 1 + displayedAssets.length) % displayedAssets.length : null,
+    );
   }, [displayedAssets.length]);
 
   // Keyboard navigation and the scroll lock live in <Lightbox/>.
@@ -268,7 +264,9 @@ function PhotoGridInner({ assets, layout = 'masonry', gridStyle, watermark }: Ph
             type="button"
             onClick={() => proofing.setIsFilterActive((prev) => !prev)}
             style={{
-              background: proofing.isFilterActive ? 'var(--accent, #e60012)' : 'rgba(255,255,255,0.15)',
+              background: proofing.isFilterActive
+                ? 'var(--accent, #e60012)'
+                : 'rgba(255,255,255,0.15)',
               color: '#fff',
               border: 'none',
               padding: '6px 14px',

--- a/app/[...path]/SubpageGridView.tsx
+++ b/app/[...path]/SubpageGridView.tsx
@@ -61,7 +61,9 @@ function AlbumGrid({
                   fill
                   sizes="(max-width: 600px) 100vw, (max-width: 1000px) 50vw, 33vw"
                   loading="lazy"
-                  {...(album.coverPosition ? { style: { objectPosition: album.coverPosition } } : {})}
+                  {...(album.coverPosition
+                    ? { style: { objectPosition: album.coverPosition } }
+                    : {})}
                   {...(ph ? { placeholder: 'blur' as const, blurDataURL: ph.blurDataURL } : {})}
                 />
               ) : (

--- a/app/[...path]/page.tsx
+++ b/app/[...path]/page.tsx
@@ -282,12 +282,12 @@ export default async function PathPage({ params, searchParams }: PathPageProps) 
       let essayParsed = result.subpage.essayText
         ? parseEssayMarkdown(result.subpage.essayText)
         : result.subpage.essayFile
-        ? loadEssayFromFile(result.subpage.essayFile)
-        : null;
+          ? loadEssayFromFile(result.subpage.essayFile)
+          : null;
 
       // Fetch assets from all subpage albums
       const allAlbums = await Promise.all(
-        albums.map((a) => immich.getAlbumBySlug(a.slug, slug, forceFresh))
+        albums.map((a) => immich.getAlbumBySlug(a.slug, slug, forceFresh)),
       );
       const allAssets = allAlbums.flatMap((a) => (a ? a.assets : []));
       const images = toPhotoItems(allAssets, config.exifOnHover);

--- a/app/admin/components/AnalyticsView.tsx
+++ b/app/admin/components/AnalyticsView.tsx
@@ -56,7 +56,9 @@ export default function AnalyticsView() {
   if (error || !data) {
     return (
       <div className="admin-panel" style={{ padding: '2rem', textAlign: 'center' }}>
-        <p style={{ color: 'var(--admin-text-muted)', marginBottom: '1rem' }}>{error || 'No analytics data'}</p>
+        <p style={{ color: 'var(--admin-text-muted)', marginBottom: '1rem' }}>
+          {error || 'No analytics data'}
+        </p>
         <button className="admin-btn admin-btn-primary" onClick={fetchAnalytics}>
           <Icons.IconRefresh size={14} /> Retry
         </button>
@@ -71,17 +73,22 @@ export default function AnalyticsView() {
     .slice(-14); // Last 14 days
   const maxDayViews = Math.max(...daysList.map(([, d]) => d.pageviews || 0), 1);
 
-  const desktopRatio = data.devices.desktop + data.devices.mobile > 0
-    ? Math.round((data.devices.desktop / (data.devices.desktop + data.devices.mobile)) * 100)
-    : 50;
+  const desktopRatio =
+    data.devices.desktop + data.devices.mobile > 0
+      ? Math.round((data.devices.desktop / (data.devices.desktop + data.devices.mobile)) * 100)
+      : 50;
 
   return (
     <div className="analytics-view">
       {/* Header */}
       <div className="analytics-header">
         <div>
-          <h2><Icons.IconSparkles size={20} /> Visitor Insights &amp; Analytics</h2>
-          <p className="analytics-subtitle">Privacy-first aggregate traffic stats. No personal data collected.</p>
+          <h2>
+            <Icons.IconSparkles size={20} /> Visitor Insights &amp; Analytics
+          </h2>
+          <p className="analytics-subtitle">
+            Privacy-first aggregate traffic stats. No personal data collected.
+          </p>
         </div>
         <button className="admin-btn admin-btn-ghost admin-btn-sm" onClick={fetchAnalytics}>
           <Icons.IconRefresh size={14} /> Refresh
@@ -89,10 +96,15 @@ export default function AnalyticsView() {
       </div>
 
       {data.trackingEnabled === false && (
-        <div className="backup-status-alert error" style={{ margin: 0, display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+        <div
+          className="backup-status-alert error"
+          style={{ margin: 0, display: 'flex', alignItems: 'center', gap: '0.5rem' }}
+        >
           <Icons.IconLock size={16} />
           <span>
-            <strong>Analytics Tracking is Currently Disabled.</strong> No new visitor views are being recorded. You can re-enable tracking anytime under <em>Settings &rarr; General</em>.
+            <strong>Analytics Tracking is Currently Disabled.</strong> No new visitor views are
+            being recorded. You can re-enable tracking anytime under{' '}
+            <em>Settings &rarr; General</em>.
           </span>
         </div>
       )}
@@ -111,7 +123,9 @@ export default function AnalyticsView() {
         </div>
         <div className="metric-card">
           <span className="metric-label">Desktop vs Mobile</span>
-          <span className="metric-value">{desktopRatio}% / {100 - desktopRatio}%</span>
+          <span className="metric-value">
+            {desktopRatio}% / {100 - desktopRatio}%
+          </span>
           <span className="metric-sub">Device distribution</span>
         </div>
       </div>
@@ -119,17 +133,25 @@ export default function AnalyticsView() {
       {/* Daily Trends Chart */}
       <div className="analytics-panel">
         <div className="analytics-section-title">
-          <h3><Icons.IconGrid size={16} /> Daily Traffic Trend (Last 14 Days)</h3>
+          <h3>
+            <Icons.IconGrid size={16} /> Daily Traffic Trend (Last 14 Days)
+          </h3>
         </div>
         {daysList.length === 0 ? (
-          <p className="analytics-empty">No pageviews recorded yet. Visit portfolio pages to start tracking!</p>
+          <p className="analytics-empty">
+            No pageviews recorded yet. Visit portfolio pages to start tracking!
+          </p>
         ) : (
           <div className="analytics-bar-chart">
             {daysList.map(([dateStr, dayData]) => {
               const heightPct = Math.round((dayData.pageviews / maxDayViews) * 100);
               const formattedDate = dateStr.slice(5); // MM-DD
               return (
-                <div key={dateStr} className="bar-col" title={`${dateStr}: ${dayData.pageviews} views`}>
+                <div
+                  key={dateStr}
+                  className="bar-col"
+                  title={`${dateStr}: ${dayData.pageviews} views`}
+                >
                   <div className="bar-wrapper">
                     <div className="bar-fill" style={{ height: `${Math.max(heightPct, 8)}%` }}>
                       <span className="bar-val">{dayData.pageviews}</span>
@@ -146,7 +168,9 @@ export default function AnalyticsView() {
       {/* Top Pages List */}
       <div className="analytics-panel">
         <div className="analytics-section-title">
-          <h3><Icons.IconTarget size={16} /> Top Visited Pages &amp; Subpages</h3>
+          <h3>
+            <Icons.IconTarget size={16} /> Top Visited Pages &amp; Subpages
+          </h3>
         </div>
         {data.topPages.length === 0 ? (
           <p className="analytics-empty">No pages recorded yet.</p>

--- a/app/admin/components/BackupManagerModal.tsx
+++ b/app/admin/components/BackupManagerModal.tsx
@@ -137,8 +137,8 @@ export default function BackupManagerModal({ isOpen, onClose, onRestoreSuccess }
             <div className="backup-confirm-content">
               <strong>Confirm Restoration</strong>
               <p>
-                Are you sure you want to restore <code>{confirmFilename}</code>?
-                A safety snapshot of your current state will be created automatically before reverting.
+                Are you sure you want to restore <code>{confirmFilename}</code>? A safety snapshot
+                of your current state will be created automatically before reverting.
               </p>
               <div className="backup-confirm-actions">
                 <button
@@ -170,12 +170,13 @@ export default function BackupManagerModal({ isOpen, onClose, onRestoreSuccess }
             <div className="backup-list">
               {visibleList.map((item) => {
                 const dateObj = item.timestamp ? new Date(item.timestamp) : null;
-                const formattedDate = dateObj && !isNaN(dateObj.getTime())
-                  ? dateObj.toLocaleString('de-DE', {
-                      dateStyle: 'medium',
-                      timeStyle: 'medium',
-                    })
-                  : item.filename;
+                const formattedDate =
+                  dateObj && !isNaN(dateObj.getTime())
+                    ? dateObj.toLocaleString('de-DE', {
+                        dateStyle: 'medium',
+                        timeStyle: 'medium',
+                      })
+                    : item.filename;
 
                 return (
                   <div key={item.filename} className="backup-item">
@@ -183,7 +184,10 @@ export default function BackupManagerModal({ isOpen, onClose, onRestoreSuccess }
                       <div className="backup-item-title">
                         <span className="backup-filename">{formattedDate}</span>
                         {item.isPreRestore && (
-                          <span className="backup-badge pre-restore" title="Safety snapshot taken before a restore">
+                          <span
+                            className="backup-badge pre-restore"
+                            title="Safety snapshot taken before a restore"
+                          >
                             Pre-Restore Snapshot
                           </span>
                         )}
@@ -208,7 +212,13 @@ export default function BackupManagerModal({ isOpen, onClose, onRestoreSuccess }
                   className="backup-toggle-btn"
                   onClick={() => setShowAllBackups(!showAllBackups)}
                 >
-                  <Icons.IconChevronDown size={14} style={{ transform: showAllBackups ? 'rotate(180deg)' : 'none', transition: 'transform 0.2s ease' }} />
+                  <Icons.IconChevronDown
+                    size={14}
+                    style={{
+                      transform: showAllBackups ? 'rotate(180deg)' : 'none',
+                      transition: 'transform 0.2s ease',
+                    }}
+                  />
                   {showAllBackups
                     ? 'Ältere Einträge einklappen'
                     : `Ältere Einträge anzeigen (${hiddenCount} weitere)`}

--- a/app/admin/components/EssayBlockEditor.tsx
+++ b/app/admin/components/EssayBlockEditor.tsx
@@ -28,7 +28,7 @@ interface EssayBlockEditorProps {
 
 export function EssayBlockEditor({ markdown, onChange, onSelectPhoto }: EssayBlockEditorProps) {
   const [essay, setEssay] = useState<ParsedEssay>(() =>
-    parseEssayMarkdown(markdown || '# Title\n\nWrite your story here...')
+    parseEssayMarkdown(markdown || '# Title\n\nWrite your story here...'),
   );
 
   // Sync internal state when prop changes from outside (e.g. initial load)
@@ -50,15 +50,15 @@ export function EssayBlockEditor({ markdown, onChange, onSelectPhoto }: EssayBlo
               if (b.type === 'photo') return [b.assetId];
               if (b.type === 'photo-pair') return b.assetIds;
               return [];
-            })
-          )
+            }),
+          ),
         ),
       };
 
       setEssay(updatedEssay);
       onChange(serializeEssayMarkdown(updatedEssay));
     },
-    [essay, onChange]
+    [essay, onChange],
   );
 
   // Block manipulation helpers
@@ -171,7 +171,10 @@ export function EssayBlockEditor({ markdown, onChange, onSelectPhoto }: EssayBlo
           {/* Card Header */}
           <div className="essay-block-card-header">
             <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-              <IconGripVertical size={14} style={{ color: 'var(--admin-text-muted)', cursor: 'grab' }} />
+              <IconGripVertical
+                size={14}
+                style={{ color: 'var(--admin-text-muted)', cursor: 'grab' }}
+              />
               <BlockBadge type={block.type} index={idx + 1} />
             </div>
 
@@ -227,7 +230,10 @@ export function EssayBlockEditor({ markdown, onChange, onSelectPhoto }: EssayBlo
                 value={block.text}
                 onChange={(e) => handleUpdateBlock(idx, { ...block, text: e.target.value })}
                 placeholder="Section heading..."
-                style={{ flex: 1, fontWeight: block.level === 1 ? 700 : block.level === 2 ? 600 : 500 }}
+                style={{
+                  flex: 1,
+                  fontWeight: block.level === 1 ? 700 : block.level === 2 ? 600 : 500,
+                }}
               />
             </div>
           )}
@@ -237,7 +243,7 @@ export function EssayBlockEditor({ markdown, onChange, onSelectPhoto }: EssayBlo
             <textarea
               rows={3}
               value={block.html.replace(/<[^>]+>/g, (t) =>
-                t.startsWith('<strong>') ? '**' : t.startsWith('</strong>') ? '**' : ''
+                t.startsWith('<strong>') ? '**' : t.startsWith('</strong>') ? '**' : '',
               )}
               onChange={(e) => handleUpdateBlock(idx, { ...block, html: e.target.value })}
               placeholder="Write text paragraph... (**bold**, *italic* markdown supported)"
@@ -246,7 +252,15 @@ export function EssayBlockEditor({ markdown, onChange, onSelectPhoto }: EssayBlo
 
           {/* 3. PULLQUOTE BLOCK */}
           {block.type === 'quote' && (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', borderLeft: '3px solid var(--admin-accent)', paddingLeft: '10px' }}>
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                gap: '8px',
+                borderLeft: '3px solid var(--admin-accent)',
+                paddingLeft: '10px',
+              }}
+            >
               <textarea
                 rows={2}
                 value={block.text}
@@ -293,7 +307,7 @@ export function EssayBlockEditor({ markdown, onChange, onSelectPhoto }: EssayBlo
                         className="admin-btn admin-btn-sm admin-btn-primary"
                         onClick={() =>
                           onSelectPhoto((pickedId) =>
-                            handleUpdateBlock(idx, { ...block, assetId: pickedId })
+                            handleUpdateBlock(idx, { ...block, assetId: pickedId }),
                           )
                         }
                       >
@@ -354,7 +368,13 @@ export function EssayBlockEditor({ markdown, onChange, onSelectPhoto }: EssayBlo
               <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1rem' }}>
                 {/* Photo 1 */}
                 <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-                  <span style={{ fontSize: '0.75rem', fontWeight: 600, color: 'var(--admin-text-secondary)' }}>
+                  <span
+                    style={{
+                      fontSize: '0.75rem',
+                      fontWeight: 600,
+                      color: 'var(--admin-text-secondary)',
+                    }}
+                  >
                     Photo 1
                   </span>
                   <div className="essay-photo-preview-container">
@@ -380,7 +400,7 @@ export function EssayBlockEditor({ markdown, onChange, onSelectPhoto }: EssayBlo
                               handleUpdateBlock(idx, {
                                 ...block,
                                 assetIds: [pickedId, block.assetIds[1]],
-                              })
+                              }),
                             )
                           }
                         >
@@ -405,8 +425,20 @@ export function EssayBlockEditor({ markdown, onChange, onSelectPhoto }: EssayBlo
 
                 {/* Photo 2 */}
                 <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                    <span style={{ fontSize: '0.75rem', fontWeight: 600, color: 'var(--admin-text-secondary)' }}>
+                  <div
+                    style={{
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      alignItems: 'center',
+                    }}
+                  >
+                    <span
+                      style={{
+                        fontSize: '0.75rem',
+                        fontWeight: 600,
+                        color: 'var(--admin-text-secondary)',
+                      }}
+                    >
                       Photo 2
                     </span>
                     <button
@@ -447,7 +479,7 @@ export function EssayBlockEditor({ markdown, onChange, onSelectPhoto }: EssayBlo
                               handleUpdateBlock(idx, {
                                 ...block,
                                 assetIds: [block.assetIds[0], pickedId],
-                              })
+                              }),
                             )
                           }
                         >

--- a/app/admin/components/PageBuilder.tsx
+++ b/app/admin/components/PageBuilder.tsx
@@ -321,7 +321,10 @@ function SortableSubpageTile({
   const totalAlbums =
     sp.albums.length + (sp.sections?.reduce((sum, sec) => sum + sec.albums.length, 0) || 0);
   const firstThumb = getFirstThumb(sp);
-  const slug = sp.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+  const slug = sp.name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
 
   return (
     <div
@@ -336,13 +339,20 @@ function SortableSubpageTile({
       </div>
 
       {sp.enabled === false && (
-        <span className="subpage-badge-protected" style={{ background: '#e60012', color: '#fff' }} title="Page is disabled">
+        <span
+          className="subpage-badge-protected"
+          style={{ background: '#e60012', color: '#fff' }}
+          title="Page is disabled"
+        >
           Disabled
         </span>
       )}
 
       {sp.hidden === true && sp.enabled !== false && (
-        <span className="subpage-badge-protected" title="Hidden from navigation, reachable by direct link">
+        <span
+          className="subpage-badge-protected"
+          title="Hidden from navigation, reachable by direct link"
+        >
           Unlisted
         </span>
       )}
@@ -362,7 +372,9 @@ function SortableSubpageTile({
           </div>
         )}
         <div className="subpage-hover-overlay">
-          <span className="hover-action-btn"><IconPencil size={14} /> Edit Page</span>
+          <span className="hover-action-btn">
+            <IconPencil size={14} /> Edit Page
+          </span>
         </div>
       </div>
       <div className="subpage-tile-info">
@@ -407,7 +419,9 @@ export default function PageBuilder() {
     onSave: (assetOrder: string[]) => void;
   } | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
-  const [editingAlbumAddress, setEditingAlbumAddress] = useState<ActiveEditAlbumAddress | null>(null);
+  const [editingAlbumAddress, setEditingAlbumAddress] = useState<ActiveEditAlbumAddress | null>(
+    null,
+  );
 
   // Keep the builder still behind either drawer. One combined lock rather than
   // one per drawer: the album drawer opens from inside the subpage drawer, and
@@ -899,7 +913,12 @@ export default function PageBuilder() {
     const description = (album.description || '').toLowerCase();
     const overrideTitle = (album.title || '').toLowerCase();
     const query = searchQuery.toLowerCase();
-    return name.includes(query) || description.includes(query) || overrideTitle.includes(query) || album.id.toLowerCase().includes(query);
+    return (
+      name.includes(query) ||
+      description.includes(query) ||
+      overrideTitle.includes(query) ||
+      album.id.toLowerCase().includes(query)
+    );
   });
 
   // Filter subpages
@@ -911,17 +930,22 @@ export default function PageBuilder() {
       const name = sp.name.toLowerCase();
       const title = (sp.title || '').toLowerCase();
       const subtitle = (sp.subtitle || '').toLowerCase();
-      
+
       if (name.includes(query) || title.includes(query) || subtitle.includes(query)) return true;
-      
+
       const albums = sp.albums || [];
       const hasMatchingAlbum = albums.some((a) => {
         const aName = getAlbumName(a.id).toLowerCase();
         const aTitle = (a.title || '').toLowerCase();
         const aDesc = (a.description || '').toLowerCase();
-        return aName.includes(query) || aTitle.includes(query) || aDesc.includes(query) || a.id.toLowerCase().includes(query);
+        return (
+          aName.includes(query) ||
+          aTitle.includes(query) ||
+          aDesc.includes(query) ||
+          a.id.toLowerCase().includes(query)
+        );
       });
-      
+
       return hasMatchingAlbum;
     });
 
@@ -939,7 +963,9 @@ export default function PageBuilder() {
       {/* Search Bar */}
       <div className="builder-search-container">
         <div className="builder-search-wrapper">
-          <span className="builder-search-icon"><IconSearch size={14} /></span>
+          <span className="builder-search-icon">
+            <IconSearch size={14} />
+          </span>
           <input
             type="text"
             className="builder-search-input"
@@ -948,7 +974,11 @@ export default function PageBuilder() {
             onChange={(e) => setSearchQuery(e.target.value)}
           />
           {searchQuery && (
-            <button className="builder-search-clear" onClick={() => setSearchQuery('')} title="Clear search">
+            <button
+              className="builder-search-clear"
+              onClick={() => setSearchQuery('')}
+              title="Clear search"
+            >
               ×
             </button>
           )}
@@ -958,7 +988,9 @@ export default function PageBuilder() {
       {/* Hero Section */}
       <section className="builder-section">
         <div className="builder-section-header">
-          <h2><IconHome /> Homepage Hero</h2>
+          <h2>
+            <IconHome /> Homepage Hero
+          </h2>
           <button
             className="admin-btn admin-btn-sm"
             onClick={() =>
@@ -1029,7 +1061,9 @@ export default function PageBuilder() {
             <div className="album-list">
               {filteredAlbums.length === 0 && (
                 <p className="empty-hint">
-                  {searchQuery ? 'No matching standalone albums found.' : 'No standalone albums. These show directly on the homepage.'}
+                  {searchQuery
+                    ? 'No matching standalone albums found.'
+                    : 'No standalone albums. These show directly on the homepage.'}
                 </p>
               )}
               {filteredAlbums.map((album) => {
@@ -1043,7 +1077,9 @@ export default function PageBuilder() {
                     count={getAlbumCount(album.id)}
                     thumbnailId={getAlbumThumbnailId(album.id)}
                     onRemove={() => removeStandaloneAlbum(originalIndex)}
-                    onEdit={() => setEditingAlbumAddress({ type: 'standalone', albumIndex: originalIndex })}
+                    onEdit={() =>
+                      setEditingAlbumAddress({ type: 'standalone', albumIndex: originalIndex })
+                    }
                   />
                 );
               })}
@@ -1071,9 +1107,7 @@ export default function PageBuilder() {
         )}
 
         {gallery.subpages.length > 0 && filteredSubpages.length === 0 && (
-          <p className="empty-hint">
-            No matching subpages found.
-          </p>
+          <p className="empty-hint">No matching subpages found.</p>
         )}
 
         {/* Collapsed overview grid with DnD */}
@@ -1113,7 +1147,9 @@ export default function PageBuilder() {
                     <div className="subpage-drawer-header">
                       <div className="subpage-drawer-title-group">
                         <span className="subpage-drawer-breadcrumb">Pages / Subpages</span>
-                        <h3 className="subpage-drawer-title">{sp.title || sp.name || 'Untitled Page'}</h3>
+                        <h3 className="subpage-drawer-title">
+                          {sp.title || sp.name || 'Untitled Page'}
+                        </h3>
                       </div>
                       <div className="subpage-drawer-header-actions">
                         <div className="segmented-control" style={{ padding: '2px' }}>
@@ -1158,15 +1194,21 @@ export default function PageBuilder() {
                       {drawerMode === 'preview' ? (
                         <div className="drawer-live-preview-panel">
                           <div className="preview-hero-banner">
-                            <h2 className="preview-hero-title">{sp.title || sp.name || 'Untitled Page'}</h2>
+                            <h2 className="preview-hero-title">
+                              {sp.title || sp.name || 'Untitled Page'}
+                            </h2>
                             {sp.subtitle && <p className="preview-hero-sub">{sp.subtitle}</p>}
                           </div>
 
                           {sp.sections && sp.sections.length > 0 ? (
                             sp.sections.map((sec, sIdx) => (
                               <div key={sIdx} className="preview-section-group">
-                                <h3 className="preview-section-title">{sec.title || 'Untitled Section'}</h3>
-                                {sec.description && <p className="preview-section-desc">{sec.description}</p>}
+                                <h3 className="preview-section-title">
+                                  {sec.title || 'Untitled Section'}
+                                </h3>
+                                {sec.description && (
+                                  <p className="preview-section-desc">{sec.description}</p>
+                                )}
                                 <div className="preview-albums-grid">
                                   {sec.albums.map((alb, aIdx) => {
                                     const immichAlb = immichAlbums.find((a) => a.id === alb.id);
@@ -1178,7 +1220,9 @@ export default function PageBuilder() {
                                           {thumb ? (
                                             <img src={`/api/admin/thumbnail/${thumb}`} alt="" />
                                           ) : (
-                                            <div className="subpage-tile-placeholder"><IconFolder /></div>
+                                            <div className="subpage-tile-placeholder">
+                                              <IconFolder />
+                                            </div>
                                           )}
                                         </div>
                                         <span className="preview-album-title">
@@ -1202,7 +1246,9 @@ export default function PageBuilder() {
                                       {thumb ? (
                                         <img src={`/api/admin/thumbnail/${thumb}`} alt="" />
                                       ) : (
-                                        <div className="subpage-tile-placeholder"><IconFolder /></div>
+                                        <div className="subpage-tile-placeholder">
+                                          <IconFolder />
+                                        </div>
                                       )}
                                     </div>
                                     <span className="preview-album-title">
@@ -1216,306 +1262,377 @@ export default function PageBuilder() {
                         </div>
                       ) : (
                         <div className="admin-sheet-columns admin-sheet-columns--settings-aside">
-                        <div className="admin-sheet-col">
-                      <div className="subpage-drawer-section">
-                        <div className="admin-field">
-                          <label>Page Name (URL Identifier)</label>
-                          <div className="input-slug-wrapper">
-                            <input
-                              className="subpage-name-input"
-                              value={sp.name}
-                              onChange={(e) => updateSubpage(spIndex, { name: e.target.value })}
-                              placeholder="e.g. dubai, travel, weddings"
-                            />
-                            <span className="input-slug-preview">/{slugify(sp.name)}</span>
-                          </div>
-                        </div>
-                      </div>
+                          <div className="admin-sheet-col">
+                            <div className="subpage-drawer-section">
+                              <div className="admin-field">
+                                <label>Page Name (URL Identifier)</label>
+                                <div className="input-slug-wrapper">
+                                  <input
+                                    className="subpage-name-input"
+                                    value={sp.name}
+                                    onChange={(e) =>
+                                      updateSubpage(spIndex, { name: e.target.value })
+                                    }
+                                    placeholder="e.g. dubai, travel, weddings"
+                                  />
+                                  <span className="input-slug-preview">/{slugify(sp.name)}</span>
+                                </div>
+                              </div>
+                            </div>
 
-                      {/* Subpage metadata */}
-                      <div className="subpage-drawer-section">
-                        <div className="admin-field-row">
-                          <div className="admin-field">
-                            <label>Display Title (optional)</label>
-                            <input
-                              value={sp.title || ''}
-                              onChange={(e) =>
-                                updateSubpage(spIndex, { title: e.target.value || undefined })
-                              }
-                              placeholder="Display title (defaults to name)"
-                            />
-                          </div>
-                          <div className="admin-field">
-                            <label>Subtitle</label>
-                            <input
-                              value={sp.subtitle || ''}
-                              onChange={(e) =>
-                                updateSubpage(spIndex, { subtitle: e.target.value || undefined })
-                              }
-                              placeholder="Subtitle text"
-                            />
-                          </div>
-                        </div>
-                        <div className="admin-field" style={{ marginTop: '1rem' }}>
-                          <label>Visibility &amp; Access</label>
-                          {/*
+                            {/* Subpage metadata */}
+                            <div className="subpage-drawer-section">
+                              <div className="admin-field-row">
+                                <div className="admin-field">
+                                  <label>Display Title (optional)</label>
+                                  <input
+                                    value={sp.title || ''}
+                                    onChange={(e) =>
+                                      updateSubpage(spIndex, { title: e.target.value || undefined })
+                                    }
+                                    placeholder="Display title (defaults to name)"
+                                  />
+                                </div>
+                                <div className="admin-field">
+                                  <label>Subtitle</label>
+                                  <input
+                                    value={sp.subtitle || ''}
+                                    onChange={(e) =>
+                                      updateSubpage(spIndex, {
+                                        subtitle: e.target.value || undefined,
+                                      })
+                                    }
+                                    placeholder="Subtitle text"
+                                  />
+                                </div>
+                              </div>
+                              <div className="admin-field" style={{ marginTop: '1rem' }}>
+                                <label>Visibility &amp; Access</label>
+                                {/*
                             One field, three states — enabled/hidden are two YAML flags,
                             but for the owner it is a single question: how visible is
                             this page? Splitting it across two toggles produced
                             contradictory copy ("Disabled (Hidden)" vs "Unlisted").
                           */}
-                          {(
-                            [
-                              {
-                                key: 'published',
-                                active: sp.enabled !== false && sp.hidden !== true,
-                                icon: <IconGlobe size={15} />,
-                                iconColor: '#4ade80',
-                                title: 'Published',
-                                desc: 'Shown in the header menu and homepage lists, reachable via URL',
-                                patch: { enabled: true, hidden: false },
-                              },
-                              {
-                                key: 'unlisted',
-                                active: sp.enabled !== false && sp.hidden === true,
-                                icon: <IconEyeOff size={15} />,
-                                iconColor: '#fbbf24',
-                                title: 'Unlisted (Experimental)',
-                                desc: 'Not shown in menus or on the homepage, but reachable via direct link',
-                                patch: { enabled: true, hidden: true },
-                              },
-                              {
-                                key: 'disabled',
-                                active: sp.enabled === false,
-                                icon: <IconBan size={15} />,
-                                iconColor: '#f87171',
-                                title: 'Disabled',
-                                desc: 'Completely offline — returns 404 even when accessed directly',
-                                patch: { enabled: false, hidden: false },
-                              },
-                            ] as const
-                          ).map((opt) => (
-                            <button
-                              key={opt.key}
-                              type="button"
-                              className={`admin-toggle-card ${opt.active ? 'active' : ''}`}
-                              onClick={() => updateSubpage(spIndex, opt.patch)}
-                              aria-pressed={opt.active}
-                              style={{ padding: '10px 14px', width: '100%', display: 'flex', alignItems: 'center', justifyContent: 'space-between', borderRadius: '8px', cursor: 'pointer', marginBottom: '6px' }}
-                            >
-                              <div className="toggle-card-info" style={{ textAlign: 'left' }}>
-                                <span className="toggle-card-title" style={{ fontWeight: 600, display: 'inline-flex', alignItems: 'center', gap: '8px' }}>
-                                  <span style={{ color: opt.iconColor, display: 'inline-flex' }} aria-hidden="true">
-                                    {opt.icon}
-                                  </span>
-                                  {opt.title}
-                                </span>
-                                <span className="toggle-card-desc" style={{ fontSize: '0.8rem', display: 'block', opacity: 0.75 }}>
-                                  {opt.desc}
-                                </span>
-                              </div>
-                              <div className={`switch-toggle ${opt.active ? 'on' : ''}`}>
-                                <span className="switch-slider" />
-                              </div>
-                            </button>
-                          ))}
+                                {(
+                                  [
+                                    {
+                                      key: 'published',
+                                      active: sp.enabled !== false && sp.hidden !== true,
+                                      icon: <IconGlobe size={15} />,
+                                      iconColor: '#4ade80',
+                                      title: 'Published',
+                                      desc: 'Shown in the header menu and homepage lists, reachable via URL',
+                                      patch: { enabled: true, hidden: false },
+                                    },
+                                    {
+                                      key: 'unlisted',
+                                      active: sp.enabled !== false && sp.hidden === true,
+                                      icon: <IconEyeOff size={15} />,
+                                      iconColor: '#fbbf24',
+                                      title: 'Unlisted (Experimental)',
+                                      desc: 'Not shown in menus or on the homepage, but reachable via direct link',
+                                      patch: { enabled: true, hidden: true },
+                                    },
+                                    {
+                                      key: 'disabled',
+                                      active: sp.enabled === false,
+                                      icon: <IconBan size={15} />,
+                                      iconColor: '#f87171',
+                                      title: 'Disabled',
+                                      desc: 'Completely offline — returns 404 even when accessed directly',
+                                      patch: { enabled: false, hidden: false },
+                                    },
+                                  ] as const
+                                ).map((opt) => (
+                                  <button
+                                    key={opt.key}
+                                    type="button"
+                                    className={`admin-toggle-card ${opt.active ? 'active' : ''}`}
+                                    onClick={() => updateSubpage(spIndex, opt.patch)}
+                                    aria-pressed={opt.active}
+                                    style={{
+                                      padding: '10px 14px',
+                                      width: '100%',
+                                      display: 'flex',
+                                      alignItems: 'center',
+                                      justifyContent: 'space-between',
+                                      borderRadius: '8px',
+                                      cursor: 'pointer',
+                                      marginBottom: '6px',
+                                    }}
+                                  >
+                                    <div className="toggle-card-info" style={{ textAlign: 'left' }}>
+                                      <span
+                                        className="toggle-card-title"
+                                        style={{
+                                          fontWeight: 600,
+                                          display: 'inline-flex',
+                                          alignItems: 'center',
+                                          gap: '8px',
+                                        }}
+                                      >
+                                        <span
+                                          style={{ color: opt.iconColor, display: 'inline-flex' }}
+                                          aria-hidden="true"
+                                        >
+                                          {opt.icon}
+                                        </span>
+                                        {opt.title}
+                                      </span>
+                                      <span
+                                        className="toggle-card-desc"
+                                        style={{
+                                          fontSize: '0.8rem',
+                                          display: 'block',
+                                          opacity: 0.75,
+                                        }}
+                                      >
+                                        {opt.desc}
+                                      </span>
+                                    </div>
+                                    <div className={`switch-toggle ${opt.active ? 'on' : ''}`}>
+                                      <span className="switch-slider" />
+                                    </div>
+                                  </button>
+                                ))}
 
-                          {/* Password lives in the same group: it is the access half
+                                {/* Password lives in the same group: it is the access half
                               of "who gets to see this page". Applies to Published and
                               Unlisted; a Disabled page 404s before the gate. */}
-                          <div className="password-input-wrapper" style={{ marginTop: '6px' }}>
-                            <span className="password-icon"><IconLock size={12} /></span>
-                            <input
-                              type="password"
-                              value={sp.password || ''}
-                              onChange={(e) =>
-                                updateSubpage(spIndex, { password: e.target.value || undefined })
-                              }
-                              placeholder="Password protection (optional) — leave empty for public access"
-                              disabled={sp.enabled === false}
-                            />
-                          </div>
-                        </div>
-                        <div className="admin-field" style={{ marginTop: '1rem' }}>
-                          <label>Page Layout Style</label>
-                          <select
-                            value={sp.grid?.layout || 'masonry'}
-                            onChange={(e) => {
-                              const newLayout = e.target.value;
-                              updateSubpage(spIndex, {
-                                grid: { ...(sp.grid || {}), layout: newLayout },
-                              });
-                            }}
-                            style={{ padding: '8px 12px', borderRadius: '6px', width: '100%', fontSize: '0.9rem' }}
-                          >
-                            {/*
+                                <div
+                                  className="password-input-wrapper"
+                                  style={{ marginTop: '6px' }}
+                                >
+                                  <span className="password-icon">
+                                    <IconLock size={12} />
+                                  </span>
+                                  <input
+                                    type="password"
+                                    value={sp.password || ''}
+                                    onChange={(e) =>
+                                      updateSubpage(spIndex, {
+                                        password: e.target.value || undefined,
+                                      })
+                                    }
+                                    placeholder="Password protection (optional) — leave empty for public access"
+                                    disabled={sp.enabled === false}
+                                  />
+                                </div>
+                              </div>
+                              <div className="admin-field" style={{ marginTop: '1rem' }}>
+                                <label>Page Layout Style</label>
+                                <select
+                                  value={sp.grid?.layout || 'masonry'}
+                                  onChange={(e) => {
+                                    const newLayout = e.target.value;
+                                    updateSubpage(spIndex, {
+                                      grid: { ...(sp.grid || {}), layout: newLayout },
+                                    });
+                                  }}
+                                  style={{
+                                    padding: '8px 12px',
+                                    borderRadius: '6px',
+                                    width: '100%',
+                                    fontSize: '0.9rem',
+                                  }}
+                                >
+                                  {/*
                               Plain text, no emoji: an <option> cannot contain markup, so the
                               SVG icon set is not available here — and a decorative emoji is
                               not a substitute for it.
                             */}
-                            <option value="masonry">Masonry Grid (Dynamic Height)</option>
-                            <option value="uniform">Uniform Grid (Square Tiles)</option>
-                            <option value="showcase">Showcase (Featured First Asset)</option>
-                            <option value="filmstrip">Filmstrip (Horizontal Scroll)</option>
-                            <option value="editorial-flow">Editorial Flow</option>
-                            <option value="essay">Photo Essay Mode (Storytelling Editor)</option>
-                          </select>
-                        </div>
-                      </div>
-
-                      {/* Visual Photo Essay Builder (if layout === 'essay') */}
-                      {(sp.grid?.layout === 'essay' || sp.essayText != null) && (
-                        <div className="subpage-drawer-section">
-                          <div className="drawer-section-heading">
-                            <h4>
-                              <IconBook size={16} /> Storytelling &amp; Photo Essay Builder
-                            </h4>
-                            <p>Compose text, quotes, and fullbleed/wide photos visually.</p>
-                          </div>
-
-                          <EssayBlockEditor
-                            markdown={sp.essayText || ''}
-                            onChange={(newMarkdown) => updateSubpage(spIndex, { essayText: newMarkdown })}
-                            onSelectPhoto={(callback) => {
-                              setHeroPickerTarget({
-                                albumId: undefined,
-                                title: 'Select Photo for Photo Essay',
-                                onSelect: (assetId) => {
-                                  callback(assetId);
-                                  setHeroPickerTarget(null);
-                                },
-                              });
-                            }}
-                          />
-                        </div>
-                      )}
-
-                        </div>
-
-                        <div className="admin-sheet-col admin-sheet-col--divided">
-                      {/* Albums (if no sections) with DnD */}
-                      {(!sp.sections || sp.sections.length === 0) && (
-                        <div className="subpage-albums">
-                          <div className="subpage-albums-header">
-                            <span>Albums in this Page</span>
-                            <button
-                              className="admin-btn admin-btn-xs admin-btn-primary"
-                              onClick={() =>
-                                setPickerTarget({ type: 'subpage', subpageIndex: spIndex })
-                              }
-                            >
-                              + Add Album
-                            </button>
-                          </div>
-                          <DndContext
-                            sensors={sensors}
-                            collisionDetection={closestCenter}
-                            onDragEnd={handleSubpageAlbumDragEnd(spIndex)}
-                          >
-                            <SortableContext
-                              items={sp.albums.map((a, i) => `album-${a.id}-${i}`)}
-                              strategy={verticalListSortingStrategy}
-                            >
-                              <div className="album-list">
-                                {sp.albums.length === 0 && (
-                                  <p className="empty-hint">No albums added yet. Click + Add Album to pick from Immich.</p>
-                                )}
-                                {sp.albums.map((album, aIndex) => (
-                                  <SortableAlbumCard
-                                    key={`${album.id}-${aIndex}`}
-                                    album={album}
-                                    index={aIndex}
-                                    name={getAlbumName(album.id)}
-                                    count={getAlbumCount(album.id)}
-                                    thumbnailId={getAlbumThumbnailId(album.id)}
-                                    onRemove={() => removeSubpageAlbum(spIndex, aIndex)}
-                                    onEdit={() => setEditingAlbumAddress({ type: 'subpage', subpageIndex: spIndex, albumIndex: aIndex })}
-                                  />
-                                ))}
+                                  <option value="masonry">Masonry Grid (Dynamic Height)</option>
+                                  <option value="uniform">Uniform Grid (Square Tiles)</option>
+                                  <option value="showcase">Showcase (Featured First Asset)</option>
+                                  <option value="filmstrip">Filmstrip (Horizontal Scroll)</option>
+                                  <option value="editorial-flow">Editorial Flow</option>
+                                  <option value="essay">
+                                    Photo Essay Mode (Storytelling Editor)
+                                  </option>
+                                </select>
                               </div>
-                            </SortableContext>
-                          </DndContext>
-                        </div>
-                      )}
-
-                      {/* Sections */}
-                      {sp.sections && sp.sections.length > 0 && (
-                        <div className="subpage-sections">
-                          {sp.sections.map((sec, secIndex) => (
-                            <div key={secIndex} className="section-card">
-                              <div className="section-header">
-                                <input
-                                  className="section-title-input"
-                                  value={sec.title}
-                                  onChange={(e) =>
-                                    updateSection(spIndex, secIndex, { title: e.target.value })
-                                  }
-                                  placeholder="Section title"
-                                />
-                                <button
-                                  className="admin-btn-icon"
-                                  onClick={() => removeSection(spIndex, secIndex)}
-                                  title="Remove section"
-                                >
-                                  <IconX size={14} />
-                                </button>
-                              </div>
-                              <div className="admin-field">
-                                <input
-                                  value={sec.description || ''}
-                                  onChange={(e) =>
-                                    updateSection(spIndex, secIndex, {
-                                      description: e.target.value || undefined,
-                                    })
-                                  }
-                                  placeholder="Section description (optional)"
-                                  className="section-desc-input"
-                                />
-                              </div>
-                              <div className="album-list">
-                                {sec.albums.map((album, aIndex) => (
-                                  <AlbumCard
-                                    key={`${album.id}-${aIndex}`}
-                                    album={album}
-                                    name={getAlbumName(album.id)}
-                                    count={getAlbumCount(album.id)}
-                                    thumbnailId={getAlbumThumbnailId(album.id)}
-                                    onRemove={() => removeSectionAlbum(spIndex, secIndex, aIndex)}
-                                    onEdit={() => setEditingAlbumAddress({ type: 'section', subpageIndex: spIndex, sectionIndex: secIndex, albumIndex: aIndex })}
-                                  />
-                                ))}
-                              </div>
-                              <button
-                                className="admin-btn admin-btn-xs"
-                                onClick={() =>
-                                  setPickerTarget({
-                                    type: 'section',
-                                    subpageIndex: spIndex,
-                                    sectionIndex: secIndex,
-                                  })
-                                }
-                              >
-                                + Add Album
-                              </button>
                             </div>
-                          ))}
-                        </div>
-                      )}
 
-                      <div className="subpage-actions" style={{ marginTop: '1rem' }}>
-                        <button className="admin-btn admin-btn-xs admin-btn-secondary" onClick={() => addSection(spIndex)}>
-                          + Add Section
-                        </button>
-                        {sp.sections && sp.sections.length > 0 && (
-                          <button
-                            className="admin-btn admin-btn-xs admin-btn-secondary"
-                            onClick={() => setPickerTarget({ type: 'subpage', subpageIndex: spIndex })}
-                          >
-                            + Add Loose Album
-                          </button>
-                        )}
-                      </div>
-                        </div>
+                            {/* Visual Photo Essay Builder (if layout === 'essay') */}
+                            {(sp.grid?.layout === 'essay' || sp.essayText != null) && (
+                              <div className="subpage-drawer-section">
+                                <div className="drawer-section-heading">
+                                  <h4>
+                                    <IconBook size={16} /> Storytelling &amp; Photo Essay Builder
+                                  </h4>
+                                  <p>Compose text, quotes, and fullbleed/wide photos visually.</p>
+                                </div>
+
+                                <EssayBlockEditor
+                                  markdown={sp.essayText || ''}
+                                  onChange={(newMarkdown) =>
+                                    updateSubpage(spIndex, { essayText: newMarkdown })
+                                  }
+                                  onSelectPhoto={(callback) => {
+                                    setHeroPickerTarget({
+                                      albumId: undefined,
+                                      title: 'Select Photo for Photo Essay',
+                                      onSelect: (assetId) => {
+                                        callback(assetId);
+                                        setHeroPickerTarget(null);
+                                      },
+                                    });
+                                  }}
+                                />
+                              </div>
+                            )}
+                          </div>
+
+                          <div className="admin-sheet-col admin-sheet-col--divided">
+                            {/* Albums (if no sections) with DnD */}
+                            {(!sp.sections || sp.sections.length === 0) && (
+                              <div className="subpage-albums">
+                                <div className="subpage-albums-header">
+                                  <span>Albums in this Page</span>
+                                  <button
+                                    className="admin-btn admin-btn-xs admin-btn-primary"
+                                    onClick={() =>
+                                      setPickerTarget({ type: 'subpage', subpageIndex: spIndex })
+                                    }
+                                  >
+                                    + Add Album
+                                  </button>
+                                </div>
+                                <DndContext
+                                  sensors={sensors}
+                                  collisionDetection={closestCenter}
+                                  onDragEnd={handleSubpageAlbumDragEnd(spIndex)}
+                                >
+                                  <SortableContext
+                                    items={sp.albums.map((a, i) => `album-${a.id}-${i}`)}
+                                    strategy={verticalListSortingStrategy}
+                                  >
+                                    <div className="album-list">
+                                      {sp.albums.length === 0 && (
+                                        <p className="empty-hint">
+                                          No albums added yet. Click + Add Album to pick from
+                                          Immich.
+                                        </p>
+                                      )}
+                                      {sp.albums.map((album, aIndex) => (
+                                        <SortableAlbumCard
+                                          key={`${album.id}-${aIndex}`}
+                                          album={album}
+                                          index={aIndex}
+                                          name={getAlbumName(album.id)}
+                                          count={getAlbumCount(album.id)}
+                                          thumbnailId={getAlbumThumbnailId(album.id)}
+                                          onRemove={() => removeSubpageAlbum(spIndex, aIndex)}
+                                          onEdit={() =>
+                                            setEditingAlbumAddress({
+                                              type: 'subpage',
+                                              subpageIndex: spIndex,
+                                              albumIndex: aIndex,
+                                            })
+                                          }
+                                        />
+                                      ))}
+                                    </div>
+                                  </SortableContext>
+                                </DndContext>
+                              </div>
+                            )}
+
+                            {/* Sections */}
+                            {sp.sections && sp.sections.length > 0 && (
+                              <div className="subpage-sections">
+                                {sp.sections.map((sec, secIndex) => (
+                                  <div key={secIndex} className="section-card">
+                                    <div className="section-header">
+                                      <input
+                                        className="section-title-input"
+                                        value={sec.title}
+                                        onChange={(e) =>
+                                          updateSection(spIndex, secIndex, {
+                                            title: e.target.value,
+                                          })
+                                        }
+                                        placeholder="Section title"
+                                      />
+                                      <button
+                                        className="admin-btn-icon"
+                                        onClick={() => removeSection(spIndex, secIndex)}
+                                        title="Remove section"
+                                      >
+                                        <IconX size={14} />
+                                      </button>
+                                    </div>
+                                    <div className="admin-field">
+                                      <input
+                                        value={sec.description || ''}
+                                        onChange={(e) =>
+                                          updateSection(spIndex, secIndex, {
+                                            description: e.target.value || undefined,
+                                          })
+                                        }
+                                        placeholder="Section description (optional)"
+                                        className="section-desc-input"
+                                      />
+                                    </div>
+                                    <div className="album-list">
+                                      {sec.albums.map((album, aIndex) => (
+                                        <AlbumCard
+                                          key={`${album.id}-${aIndex}`}
+                                          album={album}
+                                          name={getAlbumName(album.id)}
+                                          count={getAlbumCount(album.id)}
+                                          thumbnailId={getAlbumThumbnailId(album.id)}
+                                          onRemove={() =>
+                                            removeSectionAlbum(spIndex, secIndex, aIndex)
+                                          }
+                                          onEdit={() =>
+                                            setEditingAlbumAddress({
+                                              type: 'section',
+                                              subpageIndex: spIndex,
+                                              sectionIndex: secIndex,
+                                              albumIndex: aIndex,
+                                            })
+                                          }
+                                        />
+                                      ))}
+                                    </div>
+                                    <button
+                                      className="admin-btn admin-btn-xs"
+                                      onClick={() =>
+                                        setPickerTarget({
+                                          type: 'section',
+                                          subpageIndex: spIndex,
+                                          sectionIndex: secIndex,
+                                        })
+                                      }
+                                    >
+                                      + Add Album
+                                    </button>
+                                  </div>
+                                ))}
+                              </div>
+                            )}
+
+                            <div className="subpage-actions" style={{ marginTop: '1rem' }}>
+                              <button
+                                className="admin-btn admin-btn-xs admin-btn-secondary"
+                                onClick={() => addSection(spIndex)}
+                              >
+                                + Add Section
+                              </button>
+                              {sp.sections && sp.sections.length > 0 && (
+                                <button
+                                  className="admin-btn admin-btn-xs admin-btn-secondary"
+                                  onClick={() =>
+                                    setPickerTarget({ type: 'subpage', subpageIndex: spIndex })
+                                  }
+                                >
+                                  + Add Loose Album
+                                </button>
+                              )}
+                            </div>
+                          </div>
                         </div>
                       )}
                     </div>
@@ -1583,166 +1700,168 @@ export default function PageBuilder() {
                   repeated as a read-only stat. */}
               <div className="album-drawer-body">
                 <div className="admin-sheet-columns">
-                <div className="admin-sheet-col">
-                <div className="modal-cover-container">
-                  {heroThumb ? (
-                    <img src={`/api/admin/thumbnail/${heroThumb}`} alt="" loading="lazy" />
-                  ) : (
-                    <div className="modal-cover-placeholder">
-                      <IconCamera />
+                  <div className="admin-sheet-col">
+                    <div className="modal-cover-container">
+                      {heroThumb ? (
+                        <img src={`/api/admin/thumbnail/${heroThumb}`} alt="" loading="lazy" />
+                      ) : (
+                        <div className="modal-cover-placeholder">
+                          <IconCamera />
+                        </div>
+                      )}
                     </div>
-                  )}
-                </div>
-                <div className="modal-meta-box">
-                  <span className="modal-album-title">{album.title || name}</span>
-                  <span className="modal-album-subtitle">
-                    {count} {count === 1 ? 'photo' : 'photos'}
-                    {album.title ? ` · Original: ${name}` : ''}
-                  </span>
-                </div>
+                    <div className="modal-meta-box">
+                      <span className="modal-album-title">{album.title || name}</span>
+                      <span className="modal-album-subtitle">
+                        {count} {count === 1 ? 'photo' : 'photos'}
+                        {album.title ? ` · Original: ${name}` : ''}
+                      </span>
+                    </div>
 
-                <div className="admin-field">
-                  <label>Title override</label>
-                  <input
-                    value={album.title || ''}
-                    onChange={(e) => onUpdate({ title: e.target.value || undefined })}
-                    placeholder={name}
-                  />
-                </div>
+                    <div className="admin-field">
+                      <label>Title override</label>
+                      <input
+                        value={album.title || ''}
+                        onChange={(e) => onUpdate({ title: e.target.value || undefined })}
+                        placeholder={name}
+                      />
+                    </div>
 
-                <div className="admin-field">
-                  <label>Description</label>
-                  <textarea
-                    value={album.description || ''}
-                    onChange={(e) => onUpdate({ description: e.target.value || undefined })}
-                    placeholder="Optional description for visitors"
-                    rows={4}
-                  />
-                </div>
+                    <div className="admin-field">
+                      <label>Description</label>
+                      <textarea
+                        value={album.description || ''}
+                        onChange={(e) => onUpdate({ description: e.target.value || undefined })}
+                        placeholder="Optional description for visitors"
+                        rows={4}
+                      />
+                    </div>
 
-                <div className="admin-field">
-                  <label>Password protection</label>
-                  <div className="input-with-icon">
-                    <input
-                      type="password"
-                      value={album.password || ''}
-                      onChange={(e) => onUpdate({ password: e.target.value || undefined })}
-                      placeholder="Leave empty for public access"
-                    />
+                    <div className="admin-field">
+                      <label>Password protection</label>
+                      <div className="input-with-icon">
+                        <input
+                          type="password"
+                          value={album.password || ''}
+                          onChange={(e) => onUpdate({ password: e.target.value || undefined })}
+                          placeholder="Leave empty for public access"
+                        />
+                      </div>
+                    </div>
                   </div>
-                </div>
 
-                </div>
+                  <div className="admin-sheet-col admin-sheet-col--divided">
+                    <div className="admin-field">
+                      <label>Layout override (Experimental)</label>
+                      <select
+                        value={album.grid?.layout || ''}
+                        onChange={(e) => {
+                          const layout = e.target.value || undefined;
+                          // Only the layout is exposed here; drop the grid object
+                          // entirely when it goes back to "inherit" so the YAML
+                          // stays clean.
+                          onUpdate({
+                            grid: layout ? { ...(album.grid || {}), layout } : undefined,
+                          });
+                        }}
+                      >
+                        <option value="">Inherit from page / global settings</option>
+                        <option value="masonry">Masonry</option>
+                        <option value="uniform">Uniform Grid</option>
+                        <option value="showcase">Showcase</option>
+                        <option value="filmstrip">Filmstrip</option>
+                        <option value="editorial-flow">Editorial Flow</option>
+                        <option value="justified">Justified (Experimental)</option>
+                      </select>
+                    </div>
 
-                <div className="admin-sheet-col admin-sheet-col--divided">
-                <div className="admin-field">
-                  <label>Layout override (Experimental)</label>
-                  <select
-                    value={album.grid?.layout || ''}
-                    onChange={(e) => {
-                      const layout = e.target.value || undefined;
-                      // Only the layout is exposed here; drop the grid object
-                      // entirely when it goes back to "inherit" so the YAML
-                      // stays clean.
-                      onUpdate({ grid: layout ? { ...(album.grid || {}), layout } : undefined });
-                    }}
-                  >
-                    <option value="">Inherit from page / global settings</option>
-                    <option value="masonry">Masonry</option>
-                    <option value="uniform">Uniform Grid</option>
-                    <option value="showcase">Showcase</option>
-                    <option value="filmstrip">Filmstrip</option>
-                    <option value="editorial-flow">Editorial Flow</option>
-                    <option value="justified">Justified (Experimental)</option>
-                  </select>
-                </div>
+                    <div className="admin-field">
+                      <label>Cover focal point (Experimental)</label>
+                      <input
+                        value={album.coverPosition || ''}
+                        onChange={(e) => onUpdate({ coverPosition: e.target.value || undefined })}
+                        placeholder={'e.g. "50% 25%" or "top" — where the cover crop should anchor'}
+                      />
+                    </div>
 
-                <div className="admin-field">
-                  <label>Cover focal point (Experimental)</label>
-                  <input
-                    value={album.coverPosition || ''}
-                    onChange={(e) => onUpdate({ coverPosition: e.target.value || undefined })}
-                    placeholder={'e.g. "50% 25%" or "top" — where the cover crop should anchor'}
-                  />
-                </div>
-
-                {/* Hero Image Selection */}
-                <div className="admin-field">
-                  <label>Custom Hero Image</label>
-                  <div className="album-hero-field">
-                    {album.heroImage ? (
-                      <div className="album-hero-preview">
-                        <img src={`/api/admin/thumbnail/${album.heroImage}`} alt="Hero" />
+                    {/* Hero Image Selection */}
+                    <div className="admin-field">
+                      <label>Custom Hero Image</label>
+                      <div className="album-hero-field">
+                        {album.heroImage ? (
+                          <div className="album-hero-preview">
+                            <img src={`/api/admin/thumbnail/${album.heroImage}`} alt="Hero" />
+                            <button
+                              className="album-hero-remove"
+                              onClick={() => onUpdate({ heroImage: undefined })}
+                              title="Remove custom hero image"
+                            >
+                              <IconX size={14} />
+                            </button>
+                          </div>
+                        ) : (
+                          <span className="album-hero-empty">Using default album cover</span>
+                        )}
                         <button
-                          className="album-hero-remove"
-                          onClick={() => onUpdate({ heroImage: undefined })}
-                          title="Remove custom hero image"
+                          className="admin-btn admin-btn-sm"
+                          onClick={() =>
+                            setHeroPickerTarget({
+                              albumId: album.id,
+                              onSelect: (assetId) => {
+                                onUpdate({ heroImage: assetId });
+                                setHeroPickerTarget(null);
+                              },
+                              currentAssetIds: album.heroImage ? [album.heroImage] : [],
+                              title: `Pick Hero Image for ${name}`,
+                            })
+                          }
                         >
-                          <IconX size={14} />
+                          <IconImage size={12} />{' '}
+                          {album.heroImage ? 'Change Image' : 'Pick Hero Image'}
                         </button>
                       </div>
-                    ) : (
-                      <span className="album-hero-empty">Using default album cover</span>
-                    )}
-                    <button
-                      className="admin-btn admin-btn-sm"
-                      onClick={() =>
-                        setHeroPickerTarget({
-                          albumId: album.id,
-                          onSelect: (assetId) => {
-                            onUpdate({ heroImage: assetId });
-                            setHeroPickerTarget(null);
-                          },
-                          currentAssetIds: album.heroImage ? [album.heroImage] : [],
-                          title: `Pick Hero Image for ${name}`,
-                        })
-                      }
-                    >
-                      <IconImage size={12} /> {album.heroImage ? 'Change Image' : 'Pick Hero Image'}
-                    </button>
-                  </div>
-                </div>
-
-                {/* Photo order */}
-                <div className="admin-field">
-                  <label id="album-sort-label">Photo order</label>
-                  <Listbox
-                    labelledBy="album-sort-label"
-                    value={album.sort || DEFAULT_ALBUM_SORT}
-                    options={SORT_OPTIONS}
-                    onChange={(mode) => onUpdate({ sort: mode })}
-                  />
-                  <span className="admin-field-hint">
-                    {album.sort === 'manual'
-                      ? 'Pinned photos come first, in the order you set. Everything else follows in the album’s Immich order.'
-                      : 'Immich order follows the album’s own sort setting in Immich.'}
-                  </span>
-
-                  {album.sort === 'manual' && (
-                    <div style={{ marginTop: '0.75rem' }}>
-                      <button
-                        className="admin-btn admin-btn-sm"
-                        onClick={() =>
-                          setOrderEditorTarget({
-                            albumId: album.id,
-                            albumName: album.title || name,
-                            assetOrder: album.assetOrder || [],
-                            onSave: (assetOrder) => {
-                              onUpdate({ assetOrder });
-                              setOrderEditorTarget(null);
-                            },
-                          })
-                        }
-                      >
-                        <IconGripVertical size={18} className="svg-icon svg-drag" />{' '}
-                        {album.assetOrder?.length
-                          ? `Reorder photos (${album.assetOrder.length} pinned)`
-                          : 'Reorder photos'}
-                      </button>
                     </div>
-                  )}
-                </div>
-                </div>
+
+                    {/* Photo order */}
+                    <div className="admin-field">
+                      <label id="album-sort-label">Photo order</label>
+                      <Listbox
+                        labelledBy="album-sort-label"
+                        value={album.sort || DEFAULT_ALBUM_SORT}
+                        options={SORT_OPTIONS}
+                        onChange={(mode) => onUpdate({ sort: mode })}
+                      />
+                      <span className="admin-field-hint">
+                        {album.sort === 'manual'
+                          ? 'Pinned photos come first, in the order you set. Everything else follows in the album’s Immich order.'
+                          : 'Immich order follows the album’s own sort setting in Immich.'}
+                      </span>
+
+                      {album.sort === 'manual' && (
+                        <div style={{ marginTop: '0.75rem' }}>
+                          <button
+                            className="admin-btn admin-btn-sm"
+                            onClick={() =>
+                              setOrderEditorTarget({
+                                albumId: album.id,
+                                albumName: album.title || name,
+                                assetOrder: album.assetOrder || [],
+                                onSave: (assetOrder) => {
+                                  onUpdate({ assetOrder });
+                                  setOrderEditorTarget(null);
+                                },
+                              })
+                            }
+                          >
+                            <IconGripVertical size={18} className="svg-icon svg-drag" />{' '}
+                            {album.assetOrder?.length
+                              ? `Reorder photos (${album.assetOrder.length} pinned)`
+                              : 'Reorder photos'}
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                  </div>
                 </div>
               </div>
               <div className="album-drawer-footer">
@@ -1938,11 +2057,7 @@ function AlbumCard({
           </div>
         )}
         <div className="album-tile-overlay">
-          <button
-            className="album-tile-btn"
-            onClick={onEdit}
-            title="Edit details"
-          >
+          <button className="album-tile-btn" onClick={onEdit} title="Edit details">
             <IconPencil size={14} />
           </button>
           <button
@@ -1956,7 +2071,10 @@ function AlbumCard({
       </div>
       <div className="album-tile-info">
         <div className="album-tile-title-row">
-          <span className={`album-tile-name ${hasTitleOverride ? 'custom-title' : ''}`} title={album.title || name}>
+          <span
+            className={`album-tile-name ${hasTitleOverride ? 'custom-title' : ''}`}
+            title={album.title || name}
+          >
             {album.title || name}
           </span>
           <div className="album-tile-badges">
@@ -1972,7 +2090,11 @@ function AlbumCard({
             )}
             {album.sort && album.sort !== DEFAULT_ALBUM_SORT && (
               <span className="badge badge-sort" title={`Photo order: ${SORT_LABELS[album.sort]}`}>
-                {album.sort === 'manual' ? <IconGripVertical size={18} className="svg-icon svg-drag" /> : album.sort}
+                {album.sort === 'manual' ? (
+                  <IconGripVertical size={18} className="svg-icon svg-drag" />
+                ) : (
+                  album.sort
+                )}
               </span>
             )}
           </div>

--- a/app/admin/components/SettingsEditor.tsx
+++ b/app/admin/components/SettingsEditor.tsx
@@ -234,7 +234,8 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
   useEffect(() => {
     loadSettings();
     if (typeof window !== 'undefined') {
-      const mode = (document.documentElement.getAttribute('data-theme') as 'dark' | 'light') || 'dark';
+      const mode =
+        (document.documentElement.getAttribute('data-theme') as 'dark' | 'light') || 'dark';
       setCurrentMode(mode);
     }
   }, []);
@@ -497,8 +498,12 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
           {activeSection === 'general' && (
             <div className="settings-panel">
               <div className="settings-section-header">
-                <h3><Icons.IconGear size={18} /> General Site Settings</h3>
-                <p className="settings-section-sub">Configure basic site identity, language, and core feature toggles.</p>
+                <h3>
+                  <Icons.IconGear size={18} /> General Site Settings
+                </h3>
+                <p className="settings-section-sub">
+                  Configure basic site identity, language, and core feature toggles.
+                </p>
               </div>
 
               <div className="admin-field">
@@ -534,8 +539,12 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
               <div className="settings-section-divider" />
 
               <div className="settings-section-header">
-                <h3><Icons.IconSparkles size={18} /> Portfolio Features &amp; Modules</h3>
-                <p className="settings-section-sub">Enable or disable optional portfolio modules, privacy analytics, and map widgets.</p>
+                <h3>
+                  <Icons.IconSparkles size={18} /> Portfolio Features &amp; Modules
+                </h3>
+                <p className="settings-section-sub">
+                  Enable or disable optional portfolio modules, privacy analytics, and map widgets.
+                </p>
               </div>
 
               <div className="admin-toggle-cards-grid">
@@ -545,8 +554,12 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
                   onClick={() => update('exifOnHover', settings.exifOnHover === false)}
                 >
                   <div className="toggle-card-info">
-                    <span className="toggle-card-title"><Icons.IconCamera size={16} /> EXIF Data on Hover</span>
-                    <span className="toggle-card-desc">Display camera gear, lens, aperture &amp; shutter speed on hover</span>
+                    <span className="toggle-card-title">
+                      <Icons.IconCamera size={16} /> EXIF Data on Hover
+                    </span>
+                    <span className="toggle-card-desc">
+                      Display camera gear, lens, aperture &amp; shutter speed on hover
+                    </span>
                   </div>
                   <div className={`switch-toggle ${settings.exifOnHover !== false ? 'on' : ''}`}>
                     <span className="switch-slider" />
@@ -559,8 +572,12 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
                   onClick={() => update('map', !settings.map)}
                 >
                   <div className="toggle-card-info">
-                    <span className="toggle-card-title"><Icons.IconMap size={16} /> Interactive GPS Map</span>
-                    <span className="toggle-card-desc">Enable /map view showing photo locations on a world map</span>
+                    <span className="toggle-card-title">
+                      <Icons.IconMap size={16} /> Interactive GPS Map
+                    </span>
+                    <span className="toggle-card-desc">
+                      Enable /map view showing photo locations on a world map
+                    </span>
                   </div>
                   <div className={`switch-toggle ${settings.map === true ? 'on' : ''}`}>
                     <span className="switch-slider" />
@@ -573,8 +590,12 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
                   onClick={() => update('transitions', settings.transitions === false)}
                 >
                   <div className="toggle-card-info">
-                    <span className="toggle-card-title"><Icons.IconSparkles size={16} /> Smooth Page Transitions</span>
-                    <span className="toggle-card-desc">Enable subtle fade-in animations between page navigation</span>
+                    <span className="toggle-card-title">
+                      <Icons.IconSparkles size={16} /> Smooth Page Transitions
+                    </span>
+                    <span className="toggle-card-desc">
+                      Enable subtle fade-in animations between page navigation
+                    </span>
                   </div>
                   <div className={`switch-toggle ${settings.transitions !== false ? 'on' : ''}`}>
                     <span className="switch-slider" />
@@ -587,8 +608,12 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
                   onClick={() => update('scrollToTop', settings.scrollToTop === false)}
                 >
                   <div className="toggle-card-info">
-                    <span className="toggle-card-title"><Icons.IconArrowUp size={16} /> Scroll-to-Top Button</span>
-                    <span className="toggle-card-desc">Show a floating arrow that returns visitors to the top of long pages</span>
+                    <span className="toggle-card-title">
+                      <Icons.IconArrowUp size={16} /> Scroll-to-Top Button
+                    </span>
+                    <span className="toggle-card-desc">
+                      Show a floating arrow that returns visitors to the top of long pages
+                    </span>
                   </div>
                   <div className={`switch-toggle ${settings.scrollToTop !== false ? 'on' : ''}`}>
                     <span className="switch-slider" />
@@ -601,8 +626,12 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
                   onClick={() => update('analytics', settings.analytics === false)}
                 >
                   <div className="toggle-card-info">
-                    <span className="toggle-card-title"><Icons.IconBarChart size={16} /> Analytics Tracking</span>
-                    <span className="toggle-card-desc">Collect anonymous privacy-friendly visit statistics</span>
+                    <span className="toggle-card-title">
+                      <Icons.IconBarChart size={16} /> Analytics Tracking
+                    </span>
+                    <span className="toggle-card-desc">
+                      Collect anonymous privacy-friendly visit statistics
+                    </span>
                   </div>
                   <div className={`switch-toggle ${settings.analytics !== false ? 'on' : ''}`}>
                     <span className="switch-slider" />
@@ -615,10 +644,17 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
                   onClick={() => update('proofing.enabled', settings.proofing?.enabled === false)}
                 >
                   <div className="toggle-card-info">
-                    <span className="toggle-card-title"><Icons.IconHeart size={16} /> Client Proofing &amp; Favorites</span>
-                    <span className="toggle-card-desc">Allow visitors &amp; clients to heart, filter, and export favorite photo selections</span>
+                    <span className="toggle-card-title">
+                      <Icons.IconHeart size={16} /> Client Proofing &amp; Favorites
+                    </span>
+                    <span className="toggle-card-desc">
+                      Allow visitors &amp; clients to heart, filter, and export favorite photo
+                      selections
+                    </span>
                   </div>
-                  <div className={`switch-toggle ${settings.proofing?.enabled !== false ? 'on' : ''}`}>
+                  <div
+                    className={`switch-toggle ${settings.proofing?.enabled !== false ? 'on' : ''}`}
+                  >
                     <span className="switch-slider" />
                   </div>
                 </button>
@@ -632,7 +668,9 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
                     <span className="toggle-card-title">
                       <Icons.IconCamera size={16} /> About Page
                     </span>
-                    <span className="toggle-card-desc">Show a portrait, bio, and gear section on your portfolio</span>
+                    <span className="toggle-card-desc">
+                      Show a portrait, bio, and gear section on your portfolio
+                    </span>
                   </div>
                   <div className={`switch-toggle ${settings.about?.enabled !== false ? 'on' : ''}`}>
                     <span className="switch-slider" />
@@ -655,7 +693,10 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
                       const form = new FormData();
                       form.append('file', file);
                       try {
-                        const res = await fetch('/api/admin/favicon', { method: 'PUT', body: form });
+                        const res = await fetch('/api/admin/favicon', {
+                          method: 'PUT',
+                          body: form,
+                        });
                         const data = await res.json();
                         setFaviconMessage(res.ok ? data.message : `Error: ${data.error}`);
                       } catch {
@@ -689,7 +730,9 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
                   {faviconUploading && <div className="admin-spinner" />}
                 </div>
                 {faviconMessage && (
-                  <p className={`save-message ${faviconMessage.startsWith('Error') ? 'error' : 'success'}`}>
+                  <p
+                    className={`save-message ${faviconMessage.startsWith('Error') ? 'error' : 'success'}`}
+                  >
                     {faviconMessage}
                   </p>
                 )}
@@ -704,8 +747,12 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
           {activeSection === 'theme' && (
             <div className="settings-panel theme-settings-panel">
               <div className="settings-section-header">
-                <h3><Icons.IconPalette size={18} /> Theme Presets &amp; Color Mode</h3>
-                <p className="settings-section-sub">Choose a typography preset and preview in Light or Dark mode.</p>
+                <h3>
+                  <Icons.IconPalette size={18} /> Theme Presets &amp; Color Mode
+                </h3>
+                <p className="settings-section-sub">
+                  Choose a typography preset and preview in Light or Dark mode.
+                </p>
               </div>
 
               <div className="admin-field">
@@ -767,8 +814,17 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
 
               <div className="admin-field">
                 <label>Color Mode</label>
-                <p style={{ fontSize: '0.78rem', color: 'var(--admin-text-muted)', margin: '0.25rem 0 0.6rem', lineHeight: '1.4' }}>
-                  Presets like <strong>Editorial</strong>, <strong>Minimal</strong> &amp; <strong>Classic</strong> feature warm light/cream backgrounds in Light Mode and charcoal in Dark Mode.
+                <p
+                  style={{
+                    fontSize: '0.78rem',
+                    color: 'var(--admin-text-muted)',
+                    margin: '0.25rem 0 0.6rem',
+                    lineHeight: '1.4',
+                  }}
+                >
+                  Presets like <strong>Editorial</strong>, <strong>Minimal</strong> &amp;{' '}
+                  <strong>Classic</strong> feature warm light/cream backgrounds in Light Mode and
+                  charcoal in Dark Mode.
                 </p>
                 <div className="segmented-control">
                   <button
@@ -791,8 +847,12 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
               <div className="settings-section-divider" />
 
               <div className="settings-section-header">
-                <h3><Icons.IconTarget size={18} /> Accent Color</h3>
-                <p className="settings-section-sub">Pick a primary accent color for links, buttons, and highlights.</p>
+                <h3>
+                  <Icons.IconTarget size={18} /> Accent Color
+                </h3>
+                <p className="settings-section-sub">
+                  Pick a primary accent color for links, buttons, and highlights.
+                </p>
               </div>
 
               <div className="admin-field">
@@ -807,7 +867,9 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
                       { hex: '#ffffff', name: 'Monochrome White' },
                       { hex: '#000000', name: 'Obsidian Black' },
                     ].map((swatch) => {
-                      const isSelected = (settings.theme?.accent || '#e60012').toLowerCase() === swatch.hex.toLowerCase();
+                      const isSelected =
+                        (settings.theme?.accent || '#e60012').toLowerCase() ===
+                        swatch.hex.toLowerCase();
                       return (
                         <button
                           key={swatch.hex}
@@ -839,8 +901,12 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
               <div className="settings-section-divider" />
 
               <div className="settings-section-header">
-                <h3><Icons.IconFrame size={18} /> Photo Frame &amp; Layout</h3>
-                <p className="settings-section-sub">Customize image presentation borders and hero layouts.</p>
+                <h3>
+                  <Icons.IconFrame size={18} /> Photo Frame &amp; Layout
+                </h3>
+                <p className="settings-section-sub">
+                  Customize image presentation borders and hero layouts.
+                </p>
               </div>
 
               <div className="admin-field">
@@ -849,7 +915,10 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
                   {PHOTO_FRAMES.map((f) => {
                     const info = {
                       none: { label: 'None', desc: 'Flush image with crisp edges' },
-                      passepartout: { label: 'Passepartout', desc: 'Classic gallery matting border' },
+                      passepartout: {
+                        label: 'Passepartout',
+                        desc: 'Classic gallery matting border',
+                      },
                       shadow: { label: 'Shadow', desc: 'Soft floating drop shadow' },
                     }[f] || { label: f, desc: '' };
                     const isActive = (settings.theme?.photoFrame || 'none') === f;
@@ -887,7 +956,10 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
                       stacked: { label: 'Stacked', desc: 'Title stacked directly over photo' },
                       typographic: { label: 'Typographic', desc: 'Oversized magazine masthead' },
                       mosaic: { label: 'Mosaic', desc: 'Dynamic photo collage layout' },
-                      cover: { label: 'Cover (Experimental)', desc: 'Fullscreen splash with a single Enter link' },
+                      cover: {
+                        label: 'Cover (Experimental)',
+                        desc: 'Fullscreen splash with a single Enter link',
+                      },
                     }[s] || { label: s, desc: '' };
                     const isActive = (settings.theme?.heroStyle || 'split') === s;
 
@@ -963,8 +1035,12 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
               <div className="settings-section-divider" />
 
               <div className="settings-section-header">
-                <h3><Icons.IconSparkles size={18} /> Finishing Touches</h3>
-                <p className="settings-section-sub">Enable optional visual effects and indicators.</p>
+                <h3>
+                  <Icons.IconSparkles size={18} /> Finishing Touches
+                </h3>
+                <p className="settings-section-sub">
+                  Enable optional visual effects and indicators.
+                </p>
               </div>
 
               <div className="admin-toggle-cards-grid">
@@ -974,8 +1050,12 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
                   onClick={() => update('theme.grain', !settings.theme?.grain)}
                 >
                   <div className="toggle-card-info">
-                    <span className="toggle-card-title"><Icons.IconFilm size={16} /> Film Grain Texture</span>
-                    <span className="toggle-card-desc">Adds analog noise overlay across portfolio background</span>
+                    <span className="toggle-card-title">
+                      <Icons.IconFilm size={16} /> Film Grain Texture
+                    </span>
+                    <span className="toggle-card-desc">
+                      Adds analog noise overlay across portfolio background
+                    </span>
                   </div>
                   <div className={`switch-toggle ${settings.theme?.grain === true ? 'on' : ''}`}>
                     <span className="switch-slider" />
@@ -988,10 +1068,16 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
                   onClick={() => update('theme.headerDot', settings.theme?.headerDot === false)}
                 >
                   <div className="toggle-card-info">
-                    <span className="toggle-card-title"><Icons.IconTarget size={16} /> Header Accent Dot</span>
-                    <span className="toggle-card-desc">Displays accent dot next to active section header</span>
+                    <span className="toggle-card-title">
+                      <Icons.IconTarget size={16} /> Header Accent Dot
+                    </span>
+                    <span className="toggle-card-desc">
+                      Displays accent dot next to active section header
+                    </span>
                   </div>
-                  <div className={`switch-toggle ${settings.theme?.headerDot !== false ? 'on' : ''}`}>
+                  <div
+                    className={`switch-toggle ${settings.theme?.headerDot !== false ? 'on' : ''}`}
+                  >
                     <span className="switch-slider" />
                   </div>
                 </button>
@@ -1002,8 +1088,12 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
           {activeSection === 'grid' && (
             <div className="settings-panel">
               <div className="settings-section-header">
-                <h3><Icons.IconGrid size={18} /> Grid &amp; Layout Engine</h3>
-                <p className="settings-section-sub">Configure photography gallery column structures and thumbnail aspect ratios.</p>
+                <h3>
+                  <Icons.IconGrid size={18} /> Grid &amp; Layout Engine
+                </h3>
+                <p className="settings-section-sub">
+                  Configure photography gallery column structures and thumbnail aspect ratios.
+                </p>
               </div>
 
               <div className="admin-field">
@@ -1011,12 +1101,27 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
                 <div className="preset-card-grid">
                   {LAYOUTS.map((l) => {
                     const info = {
-                      masonry: { label: 'Masonry', desc: 'Dynamic pinterest-style staggered columns' },
+                      masonry: {
+                        label: 'Masonry',
+                        desc: 'Dynamic pinterest-style staggered columns',
+                      },
                       uniform: { label: 'Uniform Grid', desc: 'Clean equal aspect ratio grid' },
-                      showcase: { label: 'Showcase', desc: 'Featured hero photos mixed with smaller tiles' },
-                      filmstrip: { label: 'Filmstrip', desc: 'Horizontal scrollable film strip timeline' },
-                      'editorial-flow': { label: 'Editorial Flow', desc: 'Magazine story layout with varying photo sizes' },
-                      justified: { label: 'Justified (Experimental)', desc: 'Equal-height rows that fill the full width' },
+                      showcase: {
+                        label: 'Showcase',
+                        desc: 'Featured hero photos mixed with smaller tiles',
+                      },
+                      filmstrip: {
+                        label: 'Filmstrip',
+                        desc: 'Horizontal scrollable film strip timeline',
+                      },
+                      'editorial-flow': {
+                        label: 'Editorial Flow',
+                        desc: 'Magazine story layout with varying photo sizes',
+                      },
+                      justified: {
+                        label: 'Justified (Experimental)',
+                        desc: 'Equal-height rows that fill the full width',
+                      },
                     }[l] || { label: l, desc: '' };
                     const isActive = (settings.grid?.layout || 'masonry') === l;
 
@@ -1031,38 +1136,65 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
                           <div className={`mini-layout-demo layout-demo-${l}`}>
                             {l === 'masonry' && (
                               <div className="demo-masonry-col-group">
-                                <div className="demo-col"><div className="demo-tile h-high" /><div className="demo-tile h-low" /></div>
-                                <div className="demo-col"><div className="demo-tile h-low" /><div className="demo-tile h-high" /></div>
-                                <div className="demo-col"><div className="demo-tile h-med" /><div className="demo-tile h-med" /></div>
+                                <div className="demo-col">
+                                  <div className="demo-tile h-high" />
+                                  <div className="demo-tile h-low" />
+                                </div>
+                                <div className="demo-col">
+                                  <div className="demo-tile h-low" />
+                                  <div className="demo-tile h-high" />
+                                </div>
+                                <div className="demo-col">
+                                  <div className="demo-tile h-med" />
+                                  <div className="demo-tile h-med" />
+                                </div>
                               </div>
                             )}
                             {l === 'uniform' && (
                               <div className="demo-uniform-grid">
-                                <div className="demo-tile" /><div className="demo-tile" /><div className="demo-tile" />
-                                <div className="demo-tile" /><div className="demo-tile" /><div className="demo-tile" />
+                                <div className="demo-tile" />
+                                <div className="demo-tile" />
+                                <div className="demo-tile" />
+                                <div className="demo-tile" />
+                                <div className="demo-tile" />
+                                <div className="demo-tile" />
                               </div>
                             )}
                             {l === 'showcase' && (
                               <div className="demo-showcase-grid">
                                 <div className="demo-tile demo-hero" />
-                                <div className="demo-col"><div className="demo-tile" /><div className="demo-tile" /></div>
+                                <div className="demo-col">
+                                  <div className="demo-tile" />
+                                  <div className="demo-tile" />
+                                </div>
                               </div>
                             )}
                             {l === 'filmstrip' && (
                               <div className="demo-filmstrip-row">
-                                <div className="demo-tile strip" /><div className="demo-tile strip" /><div className="demo-tile strip" />
+                                <div className="demo-tile strip" />
+                                <div className="demo-tile strip" />
+                                <div className="demo-tile strip" />
                               </div>
                             )}
                             {l === 'editorial-flow' && (
                               <div className="demo-editorial-flow">
                                 <div className="demo-tile wide" />
-                                <div className="demo-row"><div className="demo-tile" /><div className="demo-tile" /></div>
+                                <div className="demo-row">
+                                  <div className="demo-tile" />
+                                  <div className="demo-tile" />
+                                </div>
                               </div>
                             )}
                             {l === 'justified' && (
                               <div className="demo-editorial-flow">
-                                <div className="demo-row"><div className="demo-tile wide" /><div className="demo-tile" /></div>
-                                <div className="demo-row"><div className="demo-tile" /><div className="demo-tile wide" /></div>
+                                <div className="demo-row">
+                                  <div className="demo-tile wide" />
+                                  <div className="demo-tile" />
+                                </div>
+                                <div className="demo-row">
+                                  <div className="demo-tile" />
+                                  <div className="demo-tile wide" />
+                                </div>
                               </div>
                             )}
                           </div>
@@ -1086,7 +1218,10 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
                       '3/2': { label: 'Landscape (3:2)', desc: 'Standard 35mm DSLR landscape' },
                       '2/3': { label: 'Portrait (2:3)', desc: 'Vertical portrait orientation' },
                       '16/9': { label: 'Cinema (16:9)', desc: 'Widescreen 16:9 cinematic ratio' },
-                      auto: { label: 'Original Auto', desc: 'Uncropped original image proportions' },
+                      auto: {
+                        label: 'Original Auto',
+                        desc: 'Uncropped original image proportions',
+                      },
                     }[r] || { label: r, desc: '' };
                     const isActive = (settings.grid?.aspectRatio || '1') === r;
 
@@ -1115,7 +1250,9 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
               <div className="settings-section-divider" />
 
               <div className="settings-section-header">
-                <h3><Icons.IconColumns size={18} /> Spacing &amp; Columns</h3>
+                <h3>
+                  <Icons.IconColumns size={18} /> Spacing &amp; Columns
+                </h3>
                 <p className="settings-section-sub">Adjust column counts and grid gap spacing.</p>
               </div>
 
@@ -1147,8 +1284,12 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
           {activeSection === 'footer' && (
             <div className="settings-panel">
               <div className="settings-section-header">
-                <h3><Icons.IconLink size={18} /> Footer &amp; Social Links</h3>
-                <p className="settings-section-sub">Display branding, Instagram, email and website links in portfolio footer.</p>
+                <h3>
+                  <Icons.IconLink size={18} /> Footer &amp; Social Links
+                </h3>
+                <p className="settings-section-sub">
+                  Display branding, Instagram, email and website links in portfolio footer.
+                </p>
               </div>
 
               <div className="admin-field">
@@ -1187,8 +1328,13 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
               </div>
 
               <div className="settings-section-header" style={{ marginTop: '2rem' }}>
-                <h3><Icons.IconLink size={18} /> Header Navigation Links (Experimental)</h3>
-                <p className="settings-section-sub">External links shown after your pages in the header menu. Only http(s) URLs are allowed; they open in a new tab.</p>
+                <h3>
+                  <Icons.IconLink size={18} /> Header Navigation Links (Experimental)
+                </h3>
+                <p className="settings-section-sub">
+                  External links shown after your pages in the header menu. Only http(s) URLs are
+                  allowed; they open in a new tab.
+                </p>
               </div>
 
               {(settings.navLinks || []).map((link, i) => (
@@ -1234,7 +1380,9 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
               <button
                 type="button"
                 className="admin-btn admin-btn-sm"
-                onClick={() => update('navLinks', [...(settings.navLinks || []), { label: '', url: '' }])}
+                onClick={() =>
+                  update('navLinks', [...(settings.navLinks || []), { label: '', url: '' }])
+                }
               >
                 + Add external link
               </button>
@@ -1244,8 +1392,13 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
           {activeSection === 'legal' && (
             <div className="settings-panel">
               <div className="settings-section-header">
-                <h3><Icons.IconScale size={18} /> Legal Notice &amp; Impressum</h3>
-                <p className="settings-section-sub">Configure required legal disclosure page for EU / German Telemediengesetz compliance.</p>
+                <h3>
+                  <Icons.IconScale size={18} /> Legal Notice &amp; Impressum
+                </h3>
+                <p className="settings-section-sub">
+                  Configure required legal disclosure page for EU / German Telemediengesetz
+                  compliance.
+                </p>
               </div>
 
               <div className="admin-toggle-cards-grid" style={{ marginBottom: '1.25rem' }}>
@@ -1255,8 +1408,12 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
                   onClick={() => update('legal.enabled', !settings.legal?.enabled)}
                 >
                   <div className="toggle-card-info">
-                    <span className="toggle-card-title"><Icons.IconFileText size={16} /> Enable Impressum Page (/impressum)</span>
-                    <span className="toggle-card-desc">Automatically generates and links /impressum in footer</span>
+                    <span className="toggle-card-title">
+                      <Icons.IconFileText size={16} /> Enable Impressum Page (/impressum)
+                    </span>
+                    <span className="toggle-card-desc">
+                      Automatically generates and links /impressum in footer
+                    </span>
                   </div>
                   <div className={`switch-toggle ${settings.legal?.enabled === true ? 'on' : ''}`}>
                     <span className="switch-slider" />
@@ -1337,14 +1494,20 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
           {activeSection === 'seo' && (
             <div className="settings-panel">
               <div className="settings-section-header">
-                <h3><Icons.IconSearch size={18} /> Search Engine Optimization (SEO)</h3>
-                <p className="settings-section-sub">Customize search engine metadata, OpenGraph tags, and indexing rules.</p>
+                <h3>
+                  <Icons.IconSearch size={18} /> Search Engine Optimization (SEO)
+                </h3>
+                <p className="settings-section-sub">
+                  Customize search engine metadata, OpenGraph tags, and indexing rules.
+                </p>
               </div>
 
               {/* Live Google Search Result Snippet Card */}
               <div className="google-snippet-preview">
                 <div className="google-snippet-header">
-                  <span><Icons.IconGlobe size={14} /> Google Search Result Preview</span>
+                  <span>
+                    <Icons.IconGlobe size={14} /> Google Search Result Preview
+                  </span>
                 </div>
                 <div className="google-snippet-card">
                   <div className="google-snippet-url">
@@ -1354,7 +1517,9 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
                     {settings.seo?.title || settings.title || 'My Photography Portfolio'}
                   </div>
                   <div className="google-snippet-desc">
-                    {settings.seo?.description || settings.subtitle || 'A curated selection of photography work.'}
+                    {settings.seo?.description ||
+                      settings.subtitle ||
+                      'A curated selection of photography work.'}
                   </div>
                 </div>
               </div>
@@ -1376,7 +1541,8 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
                   placeholder={`%s | ${settings.seo?.title || settings.title || 'My Portfolio'}`}
                 />
                 <p style={{ fontSize: '0.8rem', opacity: 0.7, marginTop: '4px' }}>
-                  Template for subpages &amp; albums. Use <code>%s</code> as placeholder for the page title.
+                  Template for subpages &amp; albums. Use <code>%s</code> as placeholder for the
+                  page title.
                   <br />
                   <strong>Preview:</strong>{' '}
                   {(
@@ -1399,8 +1565,12 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
               <div className="settings-section-divider" />
 
               <div className="settings-section-header">
-                <h3><Icons.IconGlobe size={18} /> Search Crawler Directives</h3>
-                <p className="settings-section-sub">Control how Googlebot and other web crawlers index your site.</p>
+                <h3>
+                  <Icons.IconGlobe size={18} /> Search Crawler Directives
+                </h3>
+                <p className="settings-section-sub">
+                  Control how Googlebot and other web crawlers index your site.
+                </p>
               </div>
 
               <div className="admin-toggle-cards-grid">
@@ -1410,8 +1580,12 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
                   onClick={() => update('seo.noIndex', !settings.seo?.noIndex)}
                 >
                   <div className="toggle-card-info">
-                    <span className="toggle-card-title"><Icons.IconBan size={16} /> noindex (Hide from Google)</span>
-                    <span className="toggle-card-desc">Instructs search engines NOT to index this site in search results</span>
+                    <span className="toggle-card-title">
+                      <Icons.IconBan size={16} /> noindex (Hide from Google)
+                    </span>
+                    <span className="toggle-card-desc">
+                      Instructs search engines NOT to index this site in search results
+                    </span>
                   </div>
                   <div className={`switch-toggle ${settings.seo?.noIndex === true ? 'on' : ''}`}>
                     <span className="switch-slider" />
@@ -1424,8 +1598,12 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
                   onClick={() => update('seo.noFollow', !settings.seo?.noFollow)}
                 >
                   <div className="toggle-card-info">
-                    <span className="toggle-card-title"><Icons.IconLink size={16} /> nofollow (Block Link Following)</span>
-                    <span className="toggle-card-desc">Instructs search engine crawlers not to follow outgoing links</span>
+                    <span className="toggle-card-title">
+                      <Icons.IconLink size={16} /> nofollow (Block Link Following)
+                    </span>
+                    <span className="toggle-card-desc">
+                      Instructs search engine crawlers not to follow outgoing links
+                    </span>
                   </div>
                   <div className={`switch-toggle ${settings.seo?.noFollow === true ? 'on' : ''}`}>
                     <span className="switch-slider" />
@@ -1438,21 +1616,33 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
           {activeSection === 'security' && (
             <div className="settings-panel">
               <div className="settings-section-header">
-                <h3><Icons.IconShieldCheck size={18} /> Asset Protection &amp; Watermark</h3>
-                <p className="settings-section-sub">Configure image protection rules, right-click prevention, and watermark overlay.</p>
+                <h3>
+                  <Icons.IconShieldCheck size={18} /> Asset Protection &amp; Watermark
+                </h3>
+                <p className="settings-section-sub">
+                  Configure image protection rules, right-click prevention, and watermark overlay.
+                </p>
               </div>
 
               <div className="admin-toggle-cards-grid">
                 <button
                   type="button"
                   className={`admin-toggle-card ${settings.protection?.disableRightClick === true ? 'active' : ''}`}
-                  onClick={() => update('protection.disableRightClick', !settings.protection?.disableRightClick)}
+                  onClick={() =>
+                    update('protection.disableRightClick', !settings.protection?.disableRightClick)
+                  }
                 >
                   <div className="toggle-card-info">
-                    <span className="toggle-card-title"><Icons.IconLock size={16} /> Disable Right-Click Menu</span>
-                    <span className="toggle-card-desc">Prevents context menu on portfolio images to hinder unauthorized downloads</span>
+                    <span className="toggle-card-title">
+                      <Icons.IconLock size={16} /> Disable Right-Click Menu
+                    </span>
+                    <span className="toggle-card-desc">
+                      Prevents context menu on portfolio images to hinder unauthorized downloads
+                    </span>
                   </div>
-                  <div className={`switch-toggle ${settings.protection?.disableRightClick === true ? 'on' : ''}`}>
+                  <div
+                    className={`switch-toggle ${settings.protection?.disableRightClick === true ? 'on' : ''}`}
+                  >
                     <span className="switch-slider" />
                   </div>
                 </button>
@@ -1460,13 +1650,21 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
                 <button
                   type="button"
                   className={`admin-toggle-card ${settings.protection?.disableImageDrag === true ? 'active' : ''}`}
-                  onClick={() => update('protection.disableImageDrag', !settings.protection?.disableImageDrag)}
+                  onClick={() =>
+                    update('protection.disableImageDrag', !settings.protection?.disableImageDrag)
+                  }
                 >
                   <div className="toggle-card-info">
-                    <span className="toggle-card-title"><Icons.IconBan size={16} /> Disable Image Dragging</span>
-                    <span className="toggle-card-desc">Prevents visitors from dragging images off the portfolio page</span>
+                    <span className="toggle-card-title">
+                      <Icons.IconBan size={16} /> Disable Image Dragging
+                    </span>
+                    <span className="toggle-card-desc">
+                      Prevents visitors from dragging images off the portfolio page
+                    </span>
                   </div>
-                  <div className={`switch-toggle ${settings.protection?.disableImageDrag === true ? 'on' : ''}`}>
+                  <div
+                    className={`switch-toggle ${settings.protection?.disableImageDrag === true ? 'on' : ''}`}
+                  >
                     <span className="switch-slider" />
                   </div>
                 </button>
@@ -1475,8 +1673,12 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
               <div className="settings-section-divider" />
 
               <div className="settings-section-header">
-                <h3><Icons.IconSparkles size={18} /> Dynamic Watermark Overlay</h3>
-                <p className="settings-section-sub">Overlay copyright branding text on Lightbox images.</p>
+                <h3>
+                  <Icons.IconSparkles size={18} /> Dynamic Watermark Overlay
+                </h3>
+                <p className="settings-section-sub">
+                  Overlay copyright branding text on Lightbox images.
+                </p>
               </div>
 
               <div className="admin-toggle-cards-grid" style={{ marginBottom: '1.25rem' }}>
@@ -1486,10 +1688,16 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
                   onClick={() => update('watermark.enabled', !settings.watermark?.enabled)}
                 >
                   <div className="toggle-card-info">
-                    <span className="toggle-card-title"><Icons.IconFrame size={16} /> Enable Watermark</span>
-                    <span className="toggle-card-desc">Overlay copyright text on portfolio image views</span>
+                    <span className="toggle-card-title">
+                      <Icons.IconFrame size={16} /> Enable Watermark
+                    </span>
+                    <span className="toggle-card-desc">
+                      Overlay copyright text on portfolio image views
+                    </span>
                   </div>
-                  <div className={`switch-toggle ${settings.watermark?.enabled === true ? 'on' : ''}`}>
+                  <div
+                    className={`switch-toggle ${settings.watermark?.enabled === true ? 'on' : ''}`}
+                  >
                     <span className="switch-slider" />
                   </div>
                 </button>
@@ -1519,7 +1727,9 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
                       </select>
                     </div>
                     <div className="admin-field">
-                      <label>Opacity ({Math.round((settings.watermark?.opacity ?? 0.3) * 100)}%)</label>
+                      <label>
+                        Opacity ({Math.round((settings.watermark?.opacity ?? 0.3) * 100)}%)
+                      </label>
                       <input
                         type="range"
                         min="0.1"

--- a/app/api/admin/backups/route.ts
+++ b/app/api/admin/backups/route.ts
@@ -83,7 +83,11 @@ export async function POST(req: Request) {
     }
 
     // Security check: prevent directory traversal
-    if (backupFilename.includes('..') || backupFilename.includes('/') || backupFilename.includes('\\')) {
+    if (
+      backupFilename.includes('..') ||
+      backupFilename.includes('/') ||
+      backupFilename.includes('\\')
+    ) {
       return NextResponse.json({ error: 'Invalid backup filename' }, { status: 400 });
     }
 

--- a/app/api/admin/journal/[slug]/route.ts
+++ b/app/api/admin/journal/[slug]/route.ts
@@ -1,10 +1,6 @@
 import { NextResponse } from 'next/server';
 import { isAdminAuthenticated, isAdminEnabled } from '@/lib/admin/auth';
-import {
-  isValidSlug,
-  sanitizeSlug,
-  parseJournalMarkdown,
-} from '@/lib/journal';
+import { isValidSlug, sanitizeSlug, parseJournalMarkdown } from '@/lib/journal';
 import {
   readJournalEntry,
   writeJournalEntry,
@@ -65,9 +61,7 @@ export async function PUT(request: Request, context: RouteContext) {
     parseJournalMarkdown(rawMarkdown);
 
     const targetSlug =
-      typeof body.newSlug === 'string' && body.newSlug
-        ? sanitizeSlug(body.newSlug)
-        : slug;
+      typeof body.newSlug === 'string' && body.newSlug ? sanitizeSlug(body.newSlug) : slug;
 
     if (!isValidSlug(targetSlug)) {
       return NextResponse.json({ error: 'Invalid target slug' }, { status: 400 });

--- a/app/api/admin/journal/route.ts
+++ b/app/api/admin/journal/route.ts
@@ -1,10 +1,6 @@
 import { NextResponse } from 'next/server';
 import { isAdminAuthenticated, isAdminEnabled } from '@/lib/admin/auth';
-import {
-  sanitizeSlug,
-  isValidSlug,
-  type JournalFrontmatter,
-} from '@/lib/journal';
+import { sanitizeSlug, isValidSlug, type JournalFrontmatter } from '@/lib/journal';
 import {
   listJournalEntries,
   writeJournalEntry,
@@ -47,7 +43,10 @@ export async function POST(request: Request) {
 
     const existing = await readJournalEntry(slug);
     if (existing) {
-      return NextResponse.json({ error: 'A journal entry with this slug already exists' }, { status: 409 });
+      return NextResponse.json(
+        { error: 'A journal entry with this slug already exists' },
+        { status: 409 },
+      );
     }
 
     const frontmatter: JournalFrontmatter = {
@@ -56,7 +55,9 @@ export async function POST(request: Request) {
       draft: true,
       ...(typeof body.subtitle === 'string' && body.subtitle ? { subtitle: body.subtitle } : {}),
       ...(typeof body.author === 'string' && body.author ? { author: body.author } : {}),
-      ...(typeof body.coverAssetId === 'string' && body.coverAssetId ? { coverAssetId: body.coverAssetId } : {}),
+      ...(typeof body.coverAssetId === 'string' && body.coverAssetId
+        ? { coverAssetId: body.coverAssetId }
+        : {}),
     };
 
     let initialMarkdown = body.content;

--- a/app/api/admin/settings/route.ts
+++ b/app/api/admin/settings/route.ts
@@ -40,7 +40,10 @@ export async function PUT(request: Request) {
     invalidateConfigCache();
     immich.invalidateAll();
     revalidatePath('/', 'layout');
-    return NextResponse.json({ success: true, message: 'Saved successfully. Backup of previous version created.' });
+    return NextResponse.json({
+      success: true,
+      message: 'Saved successfully. Backup of previous version created.',
+    });
   } catch (err) {
     console.error('[Admin] Failed to write settings.yaml:', err);
     return NextResponse.json({ error: 'Failed to save settings' }, { status: 500 });

--- a/app/api/auth/route.ts
+++ b/app/api/auth/route.ts
@@ -51,7 +51,8 @@ export async function POST(request: NextRequest) {
     }
 
     if (!isProtected(slug, type)) {
-      const typeLabel = type === 'journal' ? 'Journal entry' : type === 'subpage' ? 'Subpage' : 'Album';
+      const typeLabel =
+        type === 'journal' ? 'Journal entry' : type === 'subpage' ? 'Subpage' : 'Album';
       return NextResponse.json(
         {
           error: `${typeLabel} is not password-protected`,

--- a/components/AssetProtection.tsx
+++ b/components/AssetProtection.tsx
@@ -13,7 +13,13 @@ export default function AssetProtection({ disableRightClick, disableImageDrag }:
 
     function handleContextMenu(e: MouseEvent) {
       const target = e.target as HTMLElement;
-      if (disableRightClick && (target.tagName === 'IMG' || target.closest('img') || target.classList.contains('photo-tile') || target.classList.contains('lightbox-img'))) {
+      if (
+        disableRightClick &&
+        (target.tagName === 'IMG' ||
+          target.closest('img') ||
+          target.classList.contains('photo-tile') ||
+          target.classList.contains('lightbox-img'))
+      ) {
         e.preventDefault();
       }
     }

--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -8,26 +8,74 @@ export interface IconProps extends React.SVGProps<SVGSVGElement> {
   strokeWidth?: number;
 }
 
-export function IconSun({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconSun({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <circle cx="12" cy="12" r="4" />
       <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
     </svg>
   );
 }
 
-export function IconMoon({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconMoon({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
     </svg>
   );
 }
 
-export function IconPalette({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconPalette({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <circle cx="13.5" cy="6.5" r=".5" fill="currentColor" />
       <circle cx="17.5" cy="10.5" r=".5" fill="currentColor" />
       <circle cx="8.5" cy="7.5" r=".5" fill="currentColor" />
@@ -37,9 +85,25 @@ export function IconPalette({ size = 16, className = 'svg-icon', strokeWidth = 2
   );
 }
 
-export function IconTarget({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconTarget({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <circle cx="12" cy="12" r="10" />
       <circle cx="12" cy="12" r="6" />
       <circle cx="12" cy="12" r="2" />
@@ -47,18 +111,50 @@ export function IconTarget({ size = 16, className = 'svg-icon', strokeWidth = 2,
   );
 }
 
-export function IconFilm({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconFilm({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <rect width="18" height="18" x="3" y="3" rx="2" />
       <path d="M7 3v18M17 3v18M3 7.5h4M3 12h18M3 16.5h4M17 7.5h4M17 16.5h4" />
     </svg>
   );
 }
 
-export function IconFrame({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconFrame({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <line x1="22" x2="2" y1="6" y2="6" />
       <line x1="22" x2="2" y1="18" y2="18" />
       <line x1="6" x2="6" y1="2" y2="22" />
@@ -67,36 +163,100 @@ export function IconFrame({ size = 16, className = 'svg-icon', strokeWidth = 2, 
   );
 }
 
-export function IconSparkles({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconSparkles({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z" />
       <path d="M5 3v4M3 5h4M19 17v4M17 19h4" />
     </svg>
   );
 }
 
-export function IconGear({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconGear({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
       <circle cx="12" cy="12" r="3" />
     </svg>
   );
 }
 
-export function IconCamera({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconCamera({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <path d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3l-2.5-3z" />
       <circle cx="12" cy="13" r="3" />
     </svg>
   );
 }
 
-export function IconMap({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconMap({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <polygon points="3 6 9 3 15 6 21 3 21 18 15 21 9 18 3 21" />
       <line x1="9" x2="9" y1="3" y2="18" />
       <line x1="15" x2="15" y1="6" y2="21" />
@@ -104,9 +264,25 @@ export function IconMap({ size = 16, className = 'svg-icon', strokeWidth = 2, ..
   );
 }
 
-export function IconGrid({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconGrid({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <rect width="7" height="7" x="3" y="3" rx="1" />
       <rect width="7" height="7" x="14" y="3" rx="1" />
       <rect width="7" height="7" x="14" y="14" rx="1" />
@@ -115,26 +291,74 @@ export function IconGrid({ size = 16, className = 'svg-icon', strokeWidth = 2, .
   );
 }
 
-export function IconColumns({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconColumns({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <path d="M12 3v18M3 5h18v14H3z" />
     </svg>
   );
 }
 
-export function IconLink({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconLink({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
       <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
     </svg>
   );
 }
 
-export function IconScale({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconScale({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <path d="m16 16 3-8 3 8c-.87.65-1.92 1-3 1s-2.13-.35-3-1Z" />
       <path d="m2 16 3-8 3 8c-.87.65-1.92 1-3 1s-2.13-.35-3-1Z" />
       <path d="M7 21h10M12 3v18M3 7h18" />
@@ -142,27 +366,75 @@ export function IconScale({ size = 16, className = 'svg-icon', strokeWidth = 2, 
   );
 }
 
-export function IconFileText({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconFileText({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" />
       <path d="M14 2v4a2 2 0 0 0 2 2h4M10 9H8M16 13H8M16 17H8" />
     </svg>
   );
 }
 
-export function IconSearch({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconSearch({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <circle cx="11" cy="11" r="8" />
       <path d="m21 21-4.3-4.3" />
     </svg>
   );
 }
 
-export function IconGlobe({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconGlobe({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <circle cx="12" cy="12" r="10" />
       <line x1="2" x2="22" y1="12" y2="12" />
       <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
@@ -170,36 +442,100 @@ export function IconGlobe({ size = 16, className = 'svg-icon', strokeWidth = 2, 
   );
 }
 
-export function IconBan({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconBan({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <circle cx="12" cy="12" r="10" />
       <line x1="4.93" x2="19.07" y1="4.93" y2="19.07" />
     </svg>
   );
 }
 
-export function IconArchive({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconArchive({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <rect width="20" height="5" x="2" y="3" rx="1" />
       <path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8M10 12h4" />
     </svg>
   );
 }
 
-export function IconShieldCheck({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconShieldCheck({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" />
       <path d="m9 12 2 2 4-4" />
     </svg>
   );
 }
 
-export function IconRefresh({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconRefresh({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <path d="M21 12a9 9 0 0 0-9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
       <path d="M3 3v5h5M3 12a9 9 0 0 0 9 9 9.75 9.75 0 0 0 6.74-2.74L21 16" />
       <path d="M16 16h5v5" />
@@ -207,67 +543,195 @@ export function IconRefresh({ size = 16, className = 'svg-icon', strokeWidth = 2
   );
 }
 
-export function IconChevronDown({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconChevronDown({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <path d="m6 9 6 6 6-6" />
     </svg>
   );
 }
 
-export function IconFolder({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconFolder({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z" />
     </svg>
   );
 }
 
-export function IconTrash({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconTrash({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <path d="M3 6h18M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
     </svg>
   );
 }
 
-export function IconPencil({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconPencil({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <path d="M12 20h9M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z" />
     </svg>
   );
 }
 
-export function IconLock({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconLock({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <rect width="18" height="11" x="3" y="11" rx="2" ry="2" />
       <path d="M7 11V7a5 5 0 0 1 10 0v4" />
     </svg>
   );
 }
 
-export function IconHeart({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconHeart({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
     </svg>
   );
 }
 
 /** Filled by default — it marks a state (favourite), not an action. */
-export function IconStar({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconStar({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <path d="m12 2 3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14l-5-4.87 6.91-1.01Z" />
     </svg>
   );
 }
 
-export function IconImage({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconImage({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <rect width="18" height="18" x="3" y="3" rx="2" ry="2" />
       <circle cx="9" cy="9" r="2" />
       <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21" />
@@ -275,9 +739,25 @@ export function IconImage({ size = 16, className = 'svg-icon', strokeWidth = 2, 
   );
 }
 
-export function IconBarChart({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconBarChart({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <line x1="12" y1="20" x2="12" y2="10" />
       <line x1="18" y1="20" x2="18" y2="4" />
       <line x1="6" y1="20" x2="6" y2="16" />
@@ -285,9 +765,25 @@ export function IconBarChart({ size = 16, className = 'svg-icon', strokeWidth = 
   );
 }
 
-export function IconGripVertical({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconGripVertical({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <circle cx="9" cy="12" r="1" fill="currentColor" />
       <circle cx="9" cy="5" r="1" fill="currentColor" />
       <circle cx="9" cy="19" r="1" fill="currentColor" />
@@ -300,58 +796,165 @@ export function IconGripVertical({ size = 16, className = 'svg-icon', strokeWidt
 
 export function IconX({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <path d="M18 6 6 18M6 6l12 12" />
     </svg>
   );
 }
 
-export function IconPlus({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconPlus({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <path d="M5 12h14M12 5v14" />
     </svg>
   );
 }
 
-export function IconHome({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconHome({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
       <polyline points="9 22 9 12 15 12 15 22" />
     </svg>
   );
 }
 
-export function IconCopy({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconCopy({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
       <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
     </svg>
   );
 }
 
-export function IconQuote({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconQuote({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <path d="M3 21c3 0 7-1 7-8V5c0-1.25-.75-2-2-2H4c-1.25 0-2 .75-2 2v6c0 1.25.75 2 2 2h3c0 4-2 6-4 6" />
       <path d="M15 21c3 0 7-1 7-8V5c0-1.25-.75-2-2-2h-4c-1.25 0-2 .75-2 2v6c0 1.25.75 2 2 2h3c0 4-2 6-4 6" />
     </svg>
   );
 }
 
-export function IconChevronUp({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconChevronUp({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <path d="m18 15-6-6-6 6" />
     </svg>
   );
 }
 
-export function IconArrowLeftRight({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconArrowLeftRight({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <path d="m16 3 4 4-4 4" />
       <path d="M20 7H4" />
       <path d="m8 21-4-4 4-4" />
@@ -360,35 +963,99 @@ export function IconArrowLeftRight({ size = 16, className = 'svg-icon', strokeWi
   );
 }
 
-export function IconCalendar({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconCalendar({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <rect width="18" height="18" x="3" y="4" rx="2" />
       <path d="M8 2v4M16 2v4M3 10h18" />
     </svg>
   );
 }
 
-export function IconArrowDown({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconArrowDown({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <path d="M12 5v14M19 12l-7 7-7-7" />
     </svg>
   );
 }
 
-export function IconArrowUp({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconArrowUp({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <path d="M12 19V5M5 12l7-7 7 7" />
     </svg>
   );
 }
 
 /** An "A→Z" marker for alphabetical / filename ordering. */
-export function IconSortAlpha({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconSortAlpha({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <path d="M4 10 7 3l3 7M4.9 8.2h4.2" />
       <path d="M14 3h6l-6 7h6" />
       <path d="M17 14v7M14 18l3 3 3-3" />
@@ -396,9 +1063,25 @@ export function IconSortAlpha({ size = 16, className = 'svg-icon', strokeWidth =
   );
 }
 
-export function IconCheck({ size = 16, className = 'svg-icon', strokeWidth = 2, ...props }: IconProps) {
+export function IconCheck({
+  size = 16,
+  className = 'svg-icon',
+  strokeWidth = 2,
+  ...props
+}: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" className={className} {...props}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
       <path d="M20 6 9 17l-5-5" />
     </svg>
   );

--- a/components/Lightbox.tsx
+++ b/components/Lightbox.tsx
@@ -328,9 +328,7 @@ export function Lightbox({
             </div>
           ) : exifData ? (
             <>
-              {exifData.description && (
-                <p className={styles.exifCaption}>{exifData.description}</p>
-              )}
+              {exifData.description && <p className={styles.exifCaption}>{exifData.description}</p>}
               {exifData.model && (
                 <div className={styles.exifRow}>
                   <span className={styles.exifLabel}>Camera</span>

--- a/docs/admin-panel.md
+++ b/docs/admin-panel.md
@@ -38,6 +38,7 @@ Add Immich asset UUIDs for the homepage hero carousel. Supports single or multip
 Albums displayed directly on the homepage. Click **+ Add Album** to open the Album Picker and select from your Immich library.
 
 Each album card supports:
+
 - **Title override** — display a custom name instead of the Immich album name
 - **Description** — shown below the album title on the subpage
 - **Password** — protect individual albums with a password
@@ -47,6 +48,7 @@ Each album card supports:
 Group albums under custom URL paths (e.g., `/japan`, `/wedding-smith`).
 
 Each subpage has:
+
 - **Name** — used for navigation and URL generation (auto-slugified)
 - **Title** — optional display title (defaults to name)
 - **Subtitle** — optional text shown below the page heading
@@ -64,14 +66,14 @@ Use the **↑/↓** buttons on subpages to change their display order. The order
 
 The **Settings** tab lets you configure global site behavior:
 
-| Section   | Controls                                                         |
-| --------- | ---------------------------------------------------------------- |
-| General   | Site title, subtitle, language, EXIF on hover, map, transitions, scroll-to-top |
-| Theme     | Preset, accent color, photo frame, hero style, grain, header dot |
-| Grid      | Layout mode, columns, gap, aspect ratio                          |
-| Footer    | Name, Instagram, email, website                                  |
-| Legal     | Impressum toggle and all legal fields                            |
-| SEO       | Meta title, description, noindex, nofollow                       |
+| Section | Controls                                                                       |
+| ------- | ------------------------------------------------------------------------------ |
+| General | Site title, subtitle, language, EXIF on hover, map, transitions, scroll-to-top |
+| Theme   | Preset, accent color, photo frame, hero style, grain, header dot               |
+| Grid    | Layout mode, columns, gap, aspect ratio                                        |
+| Footer  | Name, Instagram, email, website                                                |
+| Legal   | Impressum toggle and all legal fields                                          |
+| SEO     | Meta title, description, noindex, nofollow                                     |
 
 Changes are applied immediately after saving — no server restart required.
 
@@ -86,14 +88,14 @@ When adding albums, a modal overlay shows **all shared albums** from your Immich
 
 ## Security
 
-| Aspect         | Implementation                                              |
-| -------------- | ----------------------------------------------------------- |
-| Authentication | HMAC-signed session token in an `HttpOnly` cookie           |
-| Session expiry | 24 hours (automatic logout)                                 |
-| Password check | Constant-time comparison to prevent timing attacks          |
-| Cookie flags   | `HttpOnly`, `Secure` (in production), `SameSite=Strict`    |
-| Rate limiting  | Admin endpoints share the global rate limiter               |
-| Robots         | `/admin` is marked `noindex, nofollow` in metadata          |
+| Aspect         | Implementation                                          |
+| -------------- | ------------------------------------------------------- |
+| Authentication | HMAC-signed session token in an `HttpOnly` cookie       |
+| Session expiry | 24 hours (automatic logout)                             |
+| Password check | Constant-time comparison to prevent timing attacks      |
+| Cookie flags   | `HttpOnly`, `Secure` (in production), `SameSite=Strict` |
+| Rate limiting  | Admin endpoints share the global rate limiter           |
+| Robots         | `/admin` is marked `noindex, nofollow` in metadata      |
 
 > [!NOTE]
 > The admin panel uses its own session management, completely separate from album password protection. Admin sessions use `AUTH_SECRET` for token signing.
@@ -125,7 +127,7 @@ services:
     environment:
       - ADMIN_PASSWORD=your-secure-password
     volumes:
-      - ./content:/app/content  # Must be writable for admin panel
+      - ./content:/app/content # Must be writable for admin panel
 ```
 
 > [!IMPORTANT]
@@ -134,6 +136,7 @@ services:
 ### Reload Button
 
 The admin header includes a **↻ Reload** button that:
+
 1. Invalidates the in-memory config cache
 2. Clears the Immich album/asset cache
 3. Forces the next request to re-read all YAML files

--- a/docs/brainstorm-2026-08-05.md
+++ b/docs/brainstorm-2026-08-05.md
@@ -51,7 +51,7 @@ wahrgenommenen Reifegrad.
 Default 300s). Läuft ein Eintrag ab und Immich antwortet nicht, gibt es keinen
 Fallback — die Seite ist tot.
 
-**Idee:** Abgelaufene Einträge nicht wegwerfen, sondern als *stale* markieren.
+**Idee:** Abgelaufene Einträge nicht wegwerfen, sondern als _stale_ markieren.
 Bei Upstream-Fehler den veralteten Eintrag trotzdem ausliefern, im Hintergrund
 erneut versuchen, und (optional konfigurierbar) einen dezenten Hinweis
 einblenden. Das öffentliche Portfolio überlebt damit ein Immich-Update,

--- a/docs/brainstorm.md
+++ b/docs/brainstorm.md
@@ -6,23 +6,23 @@ _Stand: 2026-05-29 — generiert aus Projekt-Review + ideas.md_
 
 ## ✅ Bereits implementiert
 
-| Feature | Datum | Notizen |
-|---|---|---|
-| **Album-Beschreibungen** | 2026-05-29 | `description:` in `gallery.yaml` (pro Album), eigenes `<p>` unter dem Titel in `AlbumDetailView` |
+| Feature                         | Datum      | Notizen                                                                                                      |
+| ------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------ |
+| **Album-Beschreibungen**        | 2026-05-29 | `description:` in `gallery.yaml` (pro Album), eigenes `<p>` unter dem Titel in `AlbumDetailView`             |
 | **Webhook Cache-Invalidierung** | 2026-05-29 | `POST /api/webhook`, HMAC-SHA256, `WEBHOOK_SECRET` in `.env`, gezielte oder vollständige Cache-Invalidierung |
-| **Video-Support** | 2026-05-29 | Proxy `GET /api/video/[token]` mit Range-Support, Play-Button im Grid, `<video controls>` in Lightbox |
+| **Video-Support**               | 2026-05-29 | Proxy `GET /api/video/[token]` mit Range-Support, Play-Button im Grid, `<video controls>` in Lightbox        |
 
 ---
 
 ## ⚡ Quick Wins (offen)
 
-| Idee | Effort | Warum interessant |
-|---|---|---|
-| **Sequentielle Album-Navigation** | XS | „← Vorheriges / Nächstes Album →" am Ende einer Detailseite |
-| **Alt-Text aus Immich-Description** | XS | Immich-Assets haben ein `description`-Feld → als `alt`-Text → bessere Accessibility & SEO |
-| **RSS/Atom Feed** | S | `/feed.xml` mit neuen Alben — Follower können „neue Arbeit" abonnieren |
-| **Globaler Passwortschutz** | S | Eine einzige `site_password` für die gesamte Site (jetzt: nur per Subpage/Album) |
-| **Privacy-Analytics-Integration** | S | Plausible / Umami / GoatCounter via Script-Tag in `settings.yaml` konfigurieren (kein Tracking-Framework nötig) |
+| Idee                                | Effort | Warum interessant                                                                                               |
+| ----------------------------------- | ------ | --------------------------------------------------------------------------------------------------------------- |
+| **Sequentielle Album-Navigation**   | XS     | „← Vorheriges / Nächstes Album →" am Ende einer Detailseite                                                     |
+| **Alt-Text aus Immich-Description** | XS     | Immich-Assets haben ein `description`-Feld → als `alt`-Text → bessere Accessibility & SEO                       |
+| **RSS/Atom Feed**                   | S      | `/feed.xml` mit neuen Alben — Follower können „neue Arbeit" abonnieren                                          |
+| **Globaler Passwortschutz**         | S      | Eine einzige `site_password` für die gesamte Site (jetzt: nur per Subpage/Album)                                |
+| **Privacy-Analytics-Integration**   | S      | Plausible / Umami / GoatCounter via Script-Tag in `settings.yaml` konfigurieren (kein Tracking-Framework nötig) |
 
 ---
 

--- a/docs/deep-dive-2026-08-05.md
+++ b/docs/deep-dive-2026-08-05.md
@@ -30,12 +30,12 @@ unterschiedliche Antworten brauchen:
 
 **Modus A — die Konfiguration wirft.** `getConfig()` wirft an mehreren Stellen hart:
 
-| Stelle | Auslöser |
-|---|---|
+| Stelle                    | Auslöser                                   |
+| ------------------------- | ------------------------------------------ |
 | `lib/config/index.ts:136` | `gallery.yaml` ohne Album und ohne Subpage |
-| `lib/config/index.ts:144` | Subpage ohne `name` |
-| `lib/config/index.ts:170` | Subpage ohne Alben/Sections |
-| `lib/secret.ts:20` | `AUTH_SECRET` fehlt in Production |
+| `lib/config/index.ts:144` | Subpage ohne `name`                        |
+| `lib/config/index.ts:170` | Subpage ohne Alben/Sections                |
+| `lib/secret.ts:20`        | `AUTH_SECRET` fehlt in Production          |
 
 Nicht in dieser Liste: `validateUuid()` (`lib/config/parser.ts`) wirft **nicht** —
 es warnt und liefert bewusst eine Dummy-UUID zurück, damit der Build nicht bricht.
@@ -85,8 +85,8 @@ Immich-Antwort warten, bevor irgendetwas erscheint.
 Heute kann die App nicht unterscheiden zwischen „dieses Album existiert nicht"
 und „ich kann Immich gerade nicht fragen". Beides endet in `notFound()`.
 
-Das ist nicht nur kosmetisch: Ein 404 sagt Suchmaschinen *„diese URL löschen"*,
-ein 503 sagt *„später nochmal versuchen"*. Ein Immich-Update während eines
+Das ist nicht nur kosmetisch: Ein 404 sagt Suchmaschinen _„diese URL löschen"_,
+ein 503 sagt _„später nochmal versuchen"_. Ein Immich-Update während eines
 Google-Crawls kann so die Sichtbarkeit des Portfolios kosten.
 
 **Vorschlag:** Bevor `app/[...path]/page.tsx` `notFound()` aufruft, den
@@ -108,12 +108,12 @@ erst mit der Statusunterscheidung werden sie ein Feature.
 ### Befund: das Hindernis
 
 `components/SetupScreen.tsx` erklärt vier Dateikopien und endet mit
-*„restart your server"*. Ein Assistent müsste stattdessen selbst schreiben — und
+_„restart your server"_. Ein Assistent müsste stattdessen selbst schreiben — und
 stößt sofort auf ein Problem:
 
 ```ts
 // lib/env.ts, letzte Zeile
-export const env = parseEnv();   // läuft genau einmal beim Modul-Load
+export const env = parseEnv(); // läuft genau einmal beim Modul-Load
 ```
 
 `IMMICH_API_URL` und `IMMICH_API_KEY` kommen aus der Umgebung. Ein Browser-Formular
@@ -145,14 +145,14 @@ aufgelöst werden (Zeilen 53–54). Ein Eingriff, eine Stelle.
 
 Bemerkenswert viel — der Assistent ist eher Verdrahtung als Neubau:
 
-| Baustein | Wo |
-|---|---|
+| Baustein                                      | Wo                                                        |
+| --------------------------------------------- | --------------------------------------------------------- |
 | `/admin` bleibt während des Setups erreichbar | `app/layout.tsx:68–79`, `isAdminPath()`, Commit `8f0bb94` |
-| Atomares YAML-Schreiben mit Backups | `lib/admin/yaml-service.ts` |
-| Alle Shared Albums listen (ohne Allowlist) | `GET /api/admin/albums` |
-| Visuelle Album-/Asset-Auswahl | `AlbumPicker.tsx`, `AssetPicker.tsx` |
-| Theme-Vorschaubilder | `docs/screenshots/theme-*.png` |
-| Cache nach dem Speichern invalidieren | `invalidateConfigCache()` |
+| Atomares YAML-Schreiben mit Backups           | `lib/admin/yaml-service.ts`                               |
+| Alle Shared Albums listen (ohne Allowlist)    | `GET /api/admin/albums`                                   |
+| Visuelle Album-/Asset-Auswahl                 | `AlbumPicker.tsx`, `AssetPicker.tsx`                      |
+| Theme-Vorschaubilder                          | `docs/screenshots/theme-*.png`                            |
+| Cache nach dem Speichern invalidieren         | `invalidateConfigCache()`                                 |
 
 Dass `/admin` während `needsSetup` offen bleibt, wurde in `#392` bewusst gebaut —
 mit genau dieser Begründung („it is the tool that completes the setup").
@@ -199,12 +199,12 @@ Credentials-Entscheidung (c) sinnvoll anzufangen, weil sie den Rest bestimmt.
 Meine ursprüngliche Formulierung war ungenau. `request()` wirft nicht, es gibt
 `null` zurück. Wenn Immich weg ist, passiert Folgendes:
 
-| Aufruf | Ergebnis | Für den Besucher |
-|---|---|---|
-| `getAlbums()` | `[]` | Startseite ohne Alben |
-| `getAlbum(id)` | `null` → `notFound()` | **HTTP 404 auf echter URL** |
-| `getAssetInfo()` | `null` | Kein EXIF, keine Map-Punkte |
-| `/api/image/[id]` | 404 pro Bild | Kaputte Bildplätze |
+| Aufruf            | Ergebnis              | Für den Besucher            |
+| ----------------- | --------------------- | --------------------------- |
+| `getAlbums()`     | `[]`                  | Startseite ohne Alben       |
+| `getAlbum(id)`    | `null` → `notFound()` | **HTTP 404 auf echter URL** |
+| `getAssetInfo()`  | `null`                | Kein EXIF, keine Map-Punkte |
+| `/api/image/[id]` | 404 pro Bild          | Kaputte Bildplätze          |
 
 Immerhin sauber gelöst: das leere Ergebnis wird **nicht** gecacht
 (`lib/immich.ts:214`, `if (!all) return []` steht vor `cache.set`) — es brennt
@@ -230,7 +230,7 @@ zuerst `cache.getStale()` versuchen. Die Rückgabe sollte mitführen, ob die Dat
 frisch oder stale sind — sonst kann die Seite es nicht anzeigen.
 
 **3. Konsequenz ziehen: nicht `notFound()`, wenn der Upstream tot ist.**
-Gibt es weder frische noch stale Daten *und* ist Immich nachweislich unerreichbar,
+Gibt es weder frische noch stale Daten _und_ ist Immich nachweislich unerreichbar,
 dann werfen statt 404. Das ist derselbe Eingriff wie in Thema 1 — die beiden
 Punkte sind eigentlich ein Feature von zwei Seiten. Den Ping nicht neu bauen:
 `app/api/health/route.ts` hat bereits einen 10-Sekunden-gecachten, gegen
@@ -286,8 +286,8 @@ Der Einstieg ist also billiger, als es aussieht.
 Ein Album aus `gallery.yaml` entfernen → Route muss 404 liefern.
 
 **Token-Grenze.** `/api/image/[id]` mit roher UUID statt Token → 400. Mit einem
-Token, das unter einem *anderen* `AUTH_SECRET` erzeugt wurde → 400. `tokens.ts`
-ist unit-getestet; hier geht es darum, dass die *Route* das durchsetzt.
+Token, das unter einem _anderen_ `AUTH_SECRET` erzeugt wurde → 400. `tokens.ts`
+ist unit-getestet; hier geht es darum, dass die _Route_ das durchsetzt.
 
 **Die Lücke, die dokumentiert gehört.** Der Bild-Proxy dekodiert den Token und
 streamt (`app/api/image/[id]/route.ts:78`) — er prüft **nicht**, ob das Asset noch
@@ -313,7 +313,7 @@ Secret signierten Token. Das ist genau die Fläche von Commit `37f7f62`.
 
 Entscheidend ist die Bauform: **tabellengetrieben über die Liste der
 Admin-Routen**, nicht sieben Einzeltests. Dann schlägt die Suite auch bei einer
-*künftig hinzugefügten* Route ohne Guard an — sie testet dann die Regel statt der
+_künftig hinzugefügten_ Route ohne Guard an — sie testet dann die Regel statt der
 sieben bekannten Fälle. Das ist der Unterschied zwischen einer Suite, die alte
 Bugs festhält, und einer, die neue verhindert.
 

--- a/docs/journal-studio-design.md
+++ b/docs/journal-studio-design.md
@@ -7,11 +7,11 @@ _Status: Entwurf genehmigt (Brainstorming abgeschlossen) · Datum: 2026-08-14_
 ## 1. Understanding Summary
 
 - **Ziel & Vision:** Bereitstellung eines intuitiven, erstklassigen **Journal Studios** für Fotografen, um Bild-Text-Reportagen, Reisetagebücher und Ausstellungsberichte (im Stil von Leica Journal / National Geographic) zu verfassen und zu veröffentlichen.
-- **Zielgruppe:** 
+- **Zielgruppe:**
   - **Besucher:** Immersives, typografisch elegantes Leseerlebnis mit progressiv ladenden Bildern (ThumbHash), responsiven Layouts und Lightbox-Interaktion.
   - **Fotograf:** Mühelose Redaktion im Admin-Panel mit Live-Split-Screen-Vorschau und universeller Immich-Bildauswahl.
 - **Konzept:** Reines Markdown mit Frontmatter im Content-Volume (`content/journal/*.md`), verwaltet über eine dedizierte Admin-UI und ausgeliefert über saubere Next.js Server Components.
-- **Kern-Vorteile:** 
+- **Kern-Vorteile:**
   - Trennung von Galerie-Konfiguration (`gallery.yaml`) und redaktionellen Inhalten.
   - Volle Git- & Backup-Kompatibilität durch Standard-Markdown.
   - Schnelle Erstellung ohne manuelle UUID-Eingabe.
@@ -29,30 +29,31 @@ _Status: Entwurf genehmigt (Brainstorming abgeschlossen) · Datum: 2026-08-14_
 
 ## 3. Decision Log
 
-| # | Entscheidung | Alternativen | Begründung |
-|---|---|---|---|
-| 1 | **Nomenklatur "Journal"** | Stories, Photo Essays, Magazin | "Stories" wirkt wie flüchtige Social-Media-Inhalte. "Journal" spiegelt zeitlose, fotografische Wertigkeit (wie Leica Journal) wider. |
-| 2 | **Architektur-Ansatz 1 (Eigenständiges Studio)** | Subpage-Drawer, Quick-Fix | Maximale Schreib- und Layout-Ergonomie durch echten Split-Screen und Entkopplung von `gallery.yaml`. |
-| 3 | **Persistenz als `.md`-Dateien** | Strings in `gallery.yaml`, SQLite/DB | Behält das dateibasierte, zustandsarme Self-Hosting-Paradigma bei; einfache Versionierung via Git. |
-| 4 | **Bidirektionaler Editor (Blöcke ↔ Markdown)** | Nur WYSIWYG, Nur Markdown | Fotografen können visuell Blöcke anordnen oder direkt mit Markdown-Code arbeiten, ohne Datenverlust. |
-| 5 | **Sicherheit via Slug-Sanitisierung** | Ungeprüfte Dateinamen | Verhindert Path Traversal (`../`) im Docker-Container/Dateisystem. |
+| #   | Entscheidung                                     | Alternativen                         | Begründung                                                                                                                           |
+| --- | ------------------------------------------------ | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| 1   | **Nomenklatur "Journal"**                        | Stories, Photo Essays, Magazin       | "Stories" wirkt wie flüchtige Social-Media-Inhalte. "Journal" spiegelt zeitlose, fotografische Wertigkeit (wie Leica Journal) wider. |
+| 2   | **Architektur-Ansatz 1 (Eigenständiges Studio)** | Subpage-Drawer, Quick-Fix            | Maximale Schreib- und Layout-Ergonomie durch echten Split-Screen und Entkopplung von `gallery.yaml`.                                 |
+| 3   | **Persistenz als `.md`-Dateien**                 | Strings in `gallery.yaml`, SQLite/DB | Behält das dateibasierte, zustandsarme Self-Hosting-Paradigma bei; einfache Versionierung via Git.                                   |
+| 4   | **Bidirektionaler Editor (Blöcke ↔ Markdown)**   | Nur WYSIWYG, Nur Markdown            | Fotografen können visuell Blöcke anordnen oder direkt mit Markdown-Code arbeiten, ohne Datenverlust.                                 |
+| 5   | **Sicherheit via Slug-Sanitisierung**            | Ungeprüfte Dateinamen                | Verhindert Path Traversal (`../`) im Docker-Container/Dateisystem.                                                                   |
 
 ---
 
 ## 4. Technische Architektur & Komponenten
 
 ### A. Dateisystem & Datenmodell
+
 Jeder Eintrag ist eine `.md`-Datei mit folgendem Schema:
 
 ```markdown
 ---
-title: "Expedition Nordkap"
-subtitle: "Mit dem Bulli durch die Fjorde"
-date: "2026-08-14"
-author: "Ralf"
-coverAssetId: "b8c2d111-0000-4000-8000-000000000000"
-password: ""       # Optionaler Passwortschutz (scrypt)
-draft: false       # Entwurf oder öffentlich
+title: 'Expedition Nordkap'
+subtitle: 'Mit dem Bulli durch die Fjorde'
+date: '2026-08-14'
+author: 'Ralf'
+coverAssetId: 'b8c2d111-0000-4000-8000-000000000000'
+password: '' # Optionaler Passwortschutz (scrypt)
+draft: false # Entwurf oder öffentlich
 ---
 
 Hier beginnt der Text der Reportage...
@@ -61,6 +62,7 @@ Hier beginnt der Text der Reportage...
 ```
 
 Unterstützte Block-Typen:
+
 - **Heading:** `# H1`, `## H2`, `### H3`
 - **Paragraph:** Fliesstext mit Inline-Markdown (`**fett**`, `*kursiv*`, `[Link](url)`)
 - **Pullquote:** `> Zitattext` mit optionalem `— Autor`
@@ -81,7 +83,7 @@ Unterstützte Block-Typen:
 ### C. UI: Das Journal Studio (`/admin` ➔ Tab "Journal")
 
 1. **Journal Dashboard:**
-   - Übersicht aller Einträge als Karten mit Thumbnail, Status (*Draft*, *Live*, *Protected*), Erstellungsdatum.
+   - Übersicht aller Einträge als Karten mit Thumbnail, Status (_Draft_, _Live_, _Protected_), Erstellungsdatum.
    - Button `+ New Journal Entry`.
 2. **Studio Split-Screen Editor:**
    - **Top Navigation:** Titel-Eingabe, Slug, Status-Schalter, Metadaten-Modal (Autor, Datum, Passwort, Cover-Foto) und Save-Button (`Cmd+S`).

--- a/docs/superpowers/plans/2026-08-05-resilience-boundaries.md
+++ b/docs/superpowers/plans/2026-08-05-resilience-boundaries.md
@@ -14,17 +14,17 @@
 
 Der ursprüngliche Plan (v1) entstand gegen v0.9.1. PR #394 hat davon einen großen Teil umgesetzt — teils anders und besser als geplant. Ersatzlos gestrichen:
 
-| Ehemalige Task | Status in v0.9.2 |
-|---|---|
-| Upstream-Statusmodul (`lib/upstream.ts`) | **Überholt.** Statt eines Seiten-Pings unterscheidet `request()` jetzt an der Quelle: `ImmichUnavailableError` für Ausfälle, `null` nur für 404/410. Das ist die bessere Lösung — kein Nebenkanal, keine Race zwischen Ping und Abruf. |
-| 404-vs-503-Politik in `app/[...path]/page.tsx` | **Erledigt.** Der Fehler propagiert, Seiten liefern 5xx statt 404. Zusätzlich geben `/api/exif` und `/api/map` 503 mit `Retry-After`. |
-| `app/error.tsx`, `app/not-found.tsx` | **Erledigt**, mit `.empty-state` aus `globals.css` und 8 Tests in `lib/__tests__/error-pages.test.ts`. |
-| `app/global-error.tsx` | **Nicht mehr nötig.** Das Layout wirft nicht mehr: `getConfigOrNull()` (`lib/config/index.ts:39`) fängt ab und rendert den SetupScreen, wobei `/admin` erreichbar bleibt. Das war der einzige konkrete Anlass für die Boundary. |
-| Bild-Größen-Tiers | **Erledigt**, nach `lib/imageSize.ts` ausgelagert und getestet. |
+| Ehemalige Task                                 | Status in v0.9.2                                                                                                                                                                                                                       |
+| ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Upstream-Statusmodul (`lib/upstream.ts`)       | **Überholt.** Statt eines Seiten-Pings unterscheidet `request()` jetzt an der Quelle: `ImmichUnavailableError` für Ausfälle, `null` nur für 404/410. Das ist die bessere Lösung — kein Nebenkanal, keine Race zwischen Ping und Abruf. |
+| 404-vs-503-Politik in `app/[...path]/page.tsx` | **Erledigt.** Der Fehler propagiert, Seiten liefern 5xx statt 404. Zusätzlich geben `/api/exif` und `/api/map` 503 mit `Retry-After`.                                                                                                  |
+| `app/error.tsx`, `app/not-found.tsx`           | **Erledigt**, mit `.empty-state` aus `globals.css` und 8 Tests in `lib/__tests__/error-pages.test.ts`.                                                                                                                                 |
+| `app/global-error.tsx`                         | **Nicht mehr nötig.** Das Layout wirft nicht mehr: `getConfigOrNull()` (`lib/config/index.ts:39`) fängt ab und rendert den SetupScreen, wobei `/admin` erreichbar bleibt. Das war der einzige konkrete Anlass für die Boundary.        |
+| Bild-Größen-Tiers                              | **Erledigt**, nach `lib/imageSize.ts` ausgelagert und getestet.                                                                                                                                                                        |
 
 Obendrein neu und relevant: `IMMICH_TIMEOUT_MS`, ein `MISSING`-Sentinel, der definitive 404-Antworten cacht, `middleware.ts` → `proxy.ts`, sowie 210 statt 98 Unit-Tests.
 
-**Was das für Task 1 bedeutet:** Die vitest-Grenze wurde in #394 zweimal *umgangen* statt gehoben — `lib/imageSize.ts` wurde eigens ausgelagert, damit die Größenlogik aus `lib/__tests__/` erreichbar ist, und `error-pages.test.ts` benutzt `createElement` statt JSX, weil eine `.tsx`-Datei dort nie ausgeführt würde (so im Commit-Text vermerkt). Die Sicherheitslogik, die sich nicht auslagern lässt — Admin-Guards und Content-Type-Sanitisierung — ist deshalb weiterhin ungetestet.
+**Was das für Task 1 bedeutet:** Die vitest-Grenze wurde in #394 zweimal _umgangen_ statt gehoben — `lib/imageSize.ts` wurde eigens ausgelagert, damit die Größenlogik aus `lib/__tests__/` erreichbar ist, und `error-pages.test.ts` benutzt `createElement` statt JSX, weil eine `.tsx`-Datei dort nie ausgeführt würde (so im Commit-Text vermerkt). Die Sicherheitslogik, die sich nicht auslagern lässt — Admin-Guards und Content-Type-Sanitisierung — ist deshalb weiterhin ungetestet.
 
 ## Global Constraints
 
@@ -44,25 +44,25 @@ Obendrein neu und relevant: `IMMICH_TIMEOUT_MS`, ein `MISSING`-Sentinel, der def
 
 **Neu:**
 
-| Datei | Verantwortung |
-|---|---|
+| Datei                                          | Verantwortung                                              |
+| ---------------------------------------------- | ---------------------------------------------------------- |
 | `app/api/admin/__tests__/admin-guards.test.ts` | Tabellengetrieben: jede Admin-Route lehnt ohne Session ab. |
-| `app/api/image/__tests__/image-route.test.ts` | Token-Grenze, Content-Type-Sanitisierung, ETag/304. |
-| `lib/__tests__/cache-stale.test.ts` | Stale-Fenster und harte Obergrenze des Caches. |
-| `app/loading.tsx` | Skeleton für die Startseite. |
-| `app/[...path]/loading.tsx` | Skeleton für Album-/Subpage-Routen. |
-| `app/loading.module.css` | Skeleton-Styles. |
+| `app/api/image/__tests__/image-route.test.ts`  | Token-Grenze, Content-Type-Sanitisierung, ETag/304.        |
+| `lib/__tests__/cache-stale.test.ts`            | Stale-Fenster und harte Obergrenze des Caches.             |
+| `app/loading.tsx`                              | Skeleton für die Startseite.                               |
+| `app/[...path]/loading.tsx`                    | Skeleton für Album-/Subpage-Routen.                        |
+| `app/loading.module.css`                       | Skeleton-Styles.                                           |
 
 **Geändert:**
 
-| Datei | Änderung |
-|---|---|
-| `vitest.config.ts` | `include` um `app/**/__tests__/**/*.test.ts` erweitern. |
-| `lib/cache.ts` | Zwei Deadlines pro Eintrag, `getStale()`. |
-| `lib/immich.ts` | `ImmichUnavailableError` abfangen, Stale-Fallback, sonst weiterwerfen. |
-| `lib/env.ts`, `.env.local.example` | `STALE_MAX_AGE`. |
-| `lib/config/schema.ts`, `lib/config/index.ts` | `staleMaxAge` in `AppConfig` und beide Rückgabepfade. |
-| `README.md`, `CLAUDE.md` | Stale-Verhalten und Token-Widerruf dokumentieren. |
+| Datei                                         | Änderung                                                               |
+| --------------------------------------------- | ---------------------------------------------------------------------- |
+| `vitest.config.ts`                            | `include` um `app/**/__tests__/**/*.test.ts` erweitern.                |
+| `lib/cache.ts`                                | Zwei Deadlines pro Eintrag, `getStale()`.                              |
+| `lib/immich.ts`                               | `ImmichUnavailableError` abfangen, Stale-Fallback, sonst weiterwerfen. |
+| `lib/env.ts`, `.env.local.example`            | `STALE_MAX_AGE`.                                                       |
+| `lib/config/schema.ts`, `lib/config/index.ts` | `staleMaxAge` in `AppConfig` und beide Rückgabepfade.                  |
+| `README.md`, `CLAUDE.md`                      | Stale-Verhalten und Token-Widerruf dokumentieren.                      |
 
 **Abhängigkeiten:**
 
@@ -79,14 +79,16 @@ Task 4 (Doku)                          ── nach Task 2
 
 **Warum:** `vitest.config.ts` schließt alles außerhalb von `lib/__tests__/` aus. Zwei Stellen sind deshalb ungetestet und lassen sich auch nicht auslagern: die Guards der acht Admin-Routen und die Content-Type-Normalisierung in `app/api/image/[id]/route.ts:99-107`, die aus einem Stored-XSS-Fix stammt (`c2fa8e7`).
 
-**Erwartungshaltung:** Beide Mechanismen funktionieren heute korrekt. Diese Tests finden keinen Bug — sie sind Regressionsbremsen. Der Wert der Admin-Tabelle liegt darin, dass eine *künftig* ergänzte Route ohne Guard die Suite rot macht.
+**Erwartungshaltung:** Beide Mechanismen funktionieren heute korrekt. Diese Tests finden keinen Bug — sie sind Regressionsbremsen. Der Wert der Admin-Tabelle liegt darin, dass eine _künftig_ ergänzte Route ohne Guard die Suite rot macht.
 
 **Files:**
+
 - Modify: `vitest.config.ts`
 - Create: `app/api/admin/__tests__/admin-guards.test.ts`
 - Create: `app/api/image/__tests__/image-route.test.ts`
 
 **Interfaces:**
+
 - Consumes: `isAdminAuthenticated()`, `isAdminEnabled()` (`lib/admin/auth.ts`, gemockt); `encodeAssetId()` (`lib/tokens.ts`); `immich.streamAsset()` (gemockt).
 - Produces: nichts für spätere Tasks.
 
@@ -414,6 +416,7 @@ Run: `npm run test:unit -- app/api/image/__tests__/image-route.test.ts`
 Erwartung: 12 Tests PASS.
 
 Zwei mögliche Stolperstellen — beide zuerst gegen den Code prüfen, bevor der Test angepasst wird:
+
 - Falls der Rate-Limiter über die Aufrufe hinweg greift, in `vitest.setup.ts` `process.env.RATE_LIMIT_RPM = '100000'` ergänzen.
 - Falls die 503-Header anders heißen als erwartet, den tatsächlichen Wert aus `app/api/image/[id]/route.ts` übernehmen — der Test soll das reale Verhalten festschreiben.
 
@@ -451,9 +454,10 @@ git commit -m "test: enable route-handler tests and cover admin guards and image
 
 **Warum:** v0.9.2 unterscheidet Ausfall und Nichtexistenz sauber und liefert bei Ausfall 5xx statt 404 — das war die dringendere Hälfte. Die andere Hälfte fehlt: Ein Besucher sieht während eines Immich-Neustarts eine Fehlerseite, obwohl die Alben Sekunden zuvor noch im Speicher lagen. `lib/cache.ts` löscht abgelaufene Einträge beim Zugriff (Zeile 23).
 
-**Wichtig zur Abgrenzung:** v0.9.2 cacht Ausfälle bewusst *nicht* — ein `ImmichUnavailableError` wird nie gespeichert, damit die Galerie nach der Erholung nicht kaputt bleibt. Diese Task ändert daran nichts. Sie sorgt nur dafür, dass ein früherer **Erfolg** länger verfügbar bleibt, als seine TTL erlaubt. Beides zusammen ergibt: Ausfälle werden nicht eingebrannt, Erfolge überdauern sie.
+**Wichtig zur Abgrenzung:** v0.9.2 cacht Ausfälle bewusst _nicht_ — ein `ImmichUnavailableError` wird nie gespeichert, damit die Galerie nach der Erholung nicht kaputt bleibt. Diese Task ändert daran nichts. Sie sorgt nur dafür, dass ein früherer **Erfolg** länger verfügbar bleibt, als seine TTL erlaubt. Beides zusammen ergibt: Ausfälle werden nicht eingebrannt, Erfolge überdauern sie.
 
 **Files:**
+
 - Modify: `lib/cache.ts`
 - Create: `lib/__tests__/cache-stale.test.ts`
 - Modify: `lib/env.ts`, `.env.local.example`
@@ -461,6 +465,7 @@ git commit -m "test: enable route-handler tests and cover admin guards and image
 - Modify: `lib/immich.ts`, `lib/__tests__/immich.test.ts`
 
 **Interfaces:**
+
 - Consumes: `ImmichUnavailableError` aus `lib/immich.ts` (in v0.9.2 eingeführt, Zeile 97).
 - Produces:
   - `cache.get<T>(key): T | null` — unverändert, nur frische Daten.
@@ -664,19 +669,17 @@ Erwartung: alle 218 Tests grün. Schlägt `config-cache.test.ts` oder `immich.te
 In `lib/env.ts` im `Env`-Interface direkt nach `CACHE_TTL: number;` ergänzen:
 
 ```ts
-  STALE_MAX_AGE: number;
+STALE_MAX_AGE: number;
 ```
 
 In `parseEnv()` nach dem `cacheTtl`-Block einfügen:
 
 ```ts
-  // How long an expired cache entry may still be served while Immich is
-  // unreachable. 0 disables the fallback.
-  const staleMaxAgeStr = process.env.STALE_MAX_AGE;
-  const staleMaxAge =
-    staleMaxAgeStr && !isNaN(parseInt(staleMaxAgeStr, 10))
-      ? parseInt(staleMaxAgeStr, 10)
-      : 86400; // 24 hours
+// How long an expired cache entry may still be served while Immich is
+// unreachable. 0 disables the fallback.
+const staleMaxAgeStr = process.env.STALE_MAX_AGE;
+const staleMaxAge =
+  staleMaxAgeStr && !isNaN(parseInt(staleMaxAgeStr, 10)) ? parseInt(staleMaxAgeStr, 10) : 86400; // 24 hours
 ```
 
 Im Rückgabeobjekt nach `CACHE_TTL: Math.max(0, cacheTtl),` einfügen:
@@ -688,7 +691,7 @@ Im Rückgabeobjekt nach `CACHE_TTL: Math.max(0, cacheTtl),` einfügen:
 In `lib/config/schema.ts` im `AppConfig`-Interface neben `cacheTtl` ergänzen:
 
 ```ts
-  staleMaxAge: number;
+staleMaxAge: number;
 ```
 
 In `lib/config/index.ts` **beide** Rückgabepfade ergänzen — jeweils direkt nach `cacheTtl: env.CACHE_TTL * 1000,` (Zeilen 278 und 358):
@@ -924,11 +927,13 @@ git commit -m "feat: serve stale cache entries while Immich is unavailable"
 **Warum:** Alle Galerieseiten sind `force-dynamic` und warten vollständig auf Immich. Mit `IMMICH_TIMEOUT_MS` (Default 15 s) kann diese Wartezeit im Störungsfall lang werden — ohne `loading.tsx` sieht der Besucher währenddessen nichts.
 
 **Files:**
+
 - Create: `app/loading.module.css`
 - Create: `app/loading.tsx`
 - Create: `app/[...path]/loading.tsx`
 
 **Interfaces:**
+
 - Consumes: Tokens aus `app/tokens.css`; die Grid-Variablen, die `app/[...path]/page.tsx` setzt.
 - Produces: nichts.
 
@@ -1060,6 +1065,7 @@ git commit -m "feat: add loading skeletons for dynamic gallery routes"
 ## Task 4: Dokumentation
 
 **Files:**
+
 - Modify: `README.md`
 - Modify: `CLAUDE.md`
 

--- a/lib/__tests__/essay.test.ts
+++ b/lib/__tests__/essay.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { parseEssayMarkdown, parseFrontmatter, sanitizeHtml, renderInlineMarkdown, serializeEssayMarkdown } from '../essay';
+import {
+  parseEssayMarkdown,
+  parseFrontmatter,
+  sanitizeHtml,
+  renderInlineMarkdown,
+  serializeEssayMarkdown,
+} from '../essay';
 
 describe('Essay Parser', () => {
   it('sanitizes script tags to prevent XSS', () => {
@@ -20,7 +26,9 @@ describe('Essay Parser', () => {
     const rendered = renderInlineMarkdown(text);
     expect(rendered).toContain('<strong>bold</strong>');
     expect(rendered).toContain('<em>italic</em>');
-    expect(rendered).toContain('<a href="https://example.com" target="_blank" rel="noopener noreferrer">link</a>');
+    expect(rendered).toContain(
+      '<a href="https://example.com" target="_blank" rel="noopener noreferrer">link</a>',
+    );
   });
 
   it('parses frontmatter correctly', () => {
@@ -111,8 +119,17 @@ A closing paragraph with **bold** details.`;
         { type: 'heading' as const, level: 1, text: 'Chapter One' },
         { type: 'paragraph' as const, html: 'This is <strong>bold</strong> text.' },
         { type: 'quote' as const, text: 'A great quote', author: 'Person' },
-        { type: 'photo' as const, assetId: 'photo-1', caption: 'Caption', layout: 'fullbleed' as const },
-        { type: 'photo-pair' as const, assetIds: ['p1', 'p2'] as [string, string], caption: 'Pair caption' },
+        {
+          type: 'photo' as const,
+          assetId: 'photo-1',
+          caption: 'Caption',
+          layout: 'fullbleed' as const,
+        },
+        {
+          type: 'photo-pair' as const,
+          assetIds: ['p1', 'p2'] as [string, string],
+          caption: 'Pair caption',
+        },
       ],
       referencedAssetIds: ['photo-1', 'p1', 'p2'],
     };

--- a/lib/__tests__/journal.test.ts
+++ b/lib/__tests__/journal.test.ts
@@ -95,8 +95,15 @@ Es war ein stürmischer Tag am Fjord.
       expect(parsed.frontmatter.coverAssetId).toBe('cover-uuid-1');
 
       expect(parsed.blocks).toHaveLength(5);
-      expect(parsed.blocks[0]).toEqual({ type: 'heading', level: 1, text: 'Kapitel 1: Die Reise beginnt' });
-      expect(parsed.blocks[1]).toEqual({ type: 'paragraph', html: 'Es war ein stürmischer Tag am Fjord.' });
+      expect(parsed.blocks[0]).toEqual({
+        type: 'heading',
+        level: 1,
+        text: 'Kapitel 1: Die Reise beginnt',
+      });
+      expect(parsed.blocks[1]).toEqual({
+        type: 'paragraph',
+        html: 'Es war ein stürmischer Tag am Fjord.',
+      });
       expect(parsed.blocks[2]).toEqual({
         type: 'quote',
         text: 'Das Licht im Norden ist unvergleichlich.',

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -80,7 +80,10 @@ function findPassword(key: string, type: 'subpage' | 'album' | 'journal'): strin
 /**
  * Check if a subpage slug, album ID, or journal entry is password-protected.
  */
-export function isProtected(key: string, type: 'subpage' | 'album' | 'journal' = 'subpage'): boolean {
+export function isProtected(
+  key: string,
+  type: 'subpage' | 'album' | 'journal' = 'subpage',
+): boolean {
   return !!findPassword(key, type);
 }
 

--- a/lib/config/schema.ts
+++ b/lib/config/schema.ts
@@ -88,13 +88,7 @@ export interface GridConfig {
   gap: number;
   aspectRatio: string;
   layout:
-    | 'masonry'
-    | 'uniform'
-    | 'showcase'
-    | 'filmstrip'
-    | 'editorial-flow'
-    | 'essay'
-    | 'justified';
+    'masonry' | 'uniform' | 'showcase' | 'filmstrip' | 'editorial-flow' | 'essay' | 'justified';
 }
 
 export interface AppConfig {

--- a/lib/proofing.ts
+++ b/lib/proofing.ts
@@ -27,10 +27,7 @@ export function encodeProofBitmask(indices: number[]): string {
     binary += String.fromCharCode(bytes[i]);
   }
 
-  return btoa(binary)
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=+$/, '');
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 }
 
 /**


### PR DESCRIPTION
Prettier is configured as an eslint *error* but had never been run over the repo, so `npm run lint` reported ~800 formatting findings and the real errors were invisible underneath. CI only warns about unformatted files (#424), so the debt kept growing — #431 added a large batch of it.

Pure formatting, no behaviour change. 28 files: the admin components, a few lib/route files, the tests and the docs.

## Verification

- `npm run format:check` — clean
- `npx tsc --noEmit` — clean
- 426/426 unit tests pass

## Follow-up, not fixed here

With the formatting noise gone, `npm run lint` now surfaces 10 real errors that were buried:

- 8 unused variables (`hasDescription` in PageBuilder, `err` in the analytics route, `verifyScrypt`/`isScryptHash` in the journal page, `isModalOpen` in ProofingModal, two unused imports in `journal.test.ts`, `errors` in `lib/env.ts`)
- 2 `setState` calls made synchronously inside an effect (`EssayBlockEditor`, `ProofingContext`) — those need a real look, not a mechanical fix

Kept out of this PR so the formatting diff stays reviewable as pure noise.