### PR TITLE
fix(lint): clear the eslint errors the formatting pass uncovered

### DIFF
--- a/app/admin/components/EssayBlockEditor.tsx
+++ b/app/admin/components/EssayBlockEditor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import {
   parseEssayMarkdown,
   serializeEssayMarkdown,
@@ -31,13 +31,16 @@ export function EssayBlockEditor({ markdown, onChange, onSelectPhoto }: EssayBlo
     parseEssayMarkdown(markdown || '# Title\n\nWrite your story here...'),
   );
 
-  // Sync internal state when prop changes from outside (e.g. initial load)
-  useEffect(() => {
-    const currentSerialized = serializeEssayMarkdown(essay);
-    if (markdown !== currentSerialized && markdown) {
+  // Sync internal state when the prop changes from outside (e.g. initial load).
+  // Adjusting during render rather than in an effect: an effect would commit the
+  // stale essay first and re-render, which flashes the previous story's blocks.
+  const [lastMarkdown, setLastMarkdown] = useState(markdown);
+  if (markdown !== lastMarkdown) {
+    setLastMarkdown(markdown);
+    if (markdown && markdown !== serializeEssayMarkdown(essay)) {
       setEssay(parseEssayMarkdown(markdown));
     }
-  }, [markdown]); // eslint-disable-line react-hooks/exhaustive-deps
+  }
 
   const updateBlocks = useCallback(
     (newBlocks: EssayBlock[]) => {

--- a/app/admin/components/PageBuilder.tsx
+++ b/app/admin/components/PageBuilder.tsx
@@ -2039,7 +2039,6 @@ function AlbumCard({
   const heroThumb = album.heroImage || thumbnailId;
   const hasPassword = !!album.password;
   const hasTitleOverride = !!album.title;
-  const hasDescription = !!album.description;
 
   return (
     <div className={`album-tile ${hasPassword ? 'has-password' : ''}`}>

--- a/app/api/analytics/track/route.ts
+++ b/app/api/analytics/track/route.ts
@@ -69,7 +69,7 @@ export async function POST(req: Request) {
 
     await saveAnalytics(data);
     return NextResponse.json({ ok: true });
-  } catch (err) {
+  } catch {
     return NextResponse.json({ error: 'Failed to record tracking' }, { status: 500 });
   }
 }

--- a/app/journal/[slug]/page.tsx
+++ b/app/journal/[slug]/page.tsx
@@ -19,7 +19,6 @@ import type { PhotoItem } from '@/app/[...path]/PhotoGrid';
 import type { ImmichAsset } from '@/lib/immich';
 import PasswordGate from '@/components/PasswordGate';
 import { BackLink } from '@/components/BackLink';
-import { verifyScrypt, isScryptHash } from '@/lib/password';
 import crypto from 'crypto';
 
 export const dynamic = 'force-dynamic';

--- a/components/ProofingContext.tsx
+++ b/components/ProofingContext.tsx
@@ -36,7 +36,9 @@ export function ProofingProvider({
 
   const storageKey = `folio_fav_${albumName.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`;
 
-  // Hydrate from localStorage and URL query params on mount
+  // Hydrate from localStorage and URL query params on mount. This has to stay in
+  // an effect: both sources are browser-only, so reading them during render would
+  // break SSR and produce a hydration mismatch.
   useEffect(() => {
     try {
       const saved = localStorage.getItem(storageKey);
@@ -60,6 +62,9 @@ export function ProofingProvider({
         });
       }
 
+      // Mount-time hydration from an external store, not a render cascade:
+      // the state lands in the same commit and never re-triggers this effect.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setFavorites(initialSet);
     } catch (e) {
       console.error('Failed to load favorites', e);

--- a/components/ProofingModal.tsx
+++ b/components/ProofingModal.tsx
@@ -12,7 +12,6 @@ export function ProofingModal() {
 
   const {
     favorites,
-    isModalOpen,
     setIsModalOpen,
     getProofingUrl,
     getFormattedList,

--- a/lib/__tests__/journal.test.ts
+++ b/lib/__tests__/journal.test.ts
@@ -4,8 +4,6 @@ import {
   serializeJournalMarkdown,
   sanitizeHtml,
   renderInlineMarkdown,
-  calculateReadingTime,
-  extractExcerpt,
   isValidSlug,
   sanitizeSlug,
 } from '../journal';

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -21,8 +21,6 @@ export interface Env {
 }
 
 function parseEnv(): Env {
-  const errors: string[] = [];
-
   const urlRaw = process.env.IMMICH_API_URL;
   let apiUrl = '';
   if (urlRaw) {


### PR DESCRIPTION
Follow-up to #450. With ~800 Prettier findings out of the way, `npm run lint` had ten real errors left. `npm run lint` is clean after this (warnings remain).

## Unused bindings — all dead on arrival

| Where | What |
| --- | --- |
| `PageBuilder` | `hasDescription` was computed but never rendered, unlike its `hasPassword` / `hasTitleOverride` siblings which both drive a class |
| `app/api/analytics/track` | the catch swallows the error on purpose — no longer binds one |
| `app/journal/[slug]/page.tsx` | imported `verifyScrypt` / `isScryptHash`, but the page authenticates against the HMAC cookie, not the password |
| `ProofingModal` | destructured `isModalOpen` after the guard above had already read `proofing.isModalOpen` |
| `lib/env.ts` | declared an `errors` array nothing ever pushed to |
| `lib/__tests__/journal.test.ts` | two imported helpers with no assertions |

On `lib/env.ts`: I flagged this earlier as a validation that might be running into the void. It is not — every check calls `console.warn` directly, so the array is a leftover from an earlier shape, and removing it changes no behaviour.

## setState inside an effect — one fixed, one kept

- **`EssayBlockEditor`** now adjusts its parsed essay during render instead of in an effect. The effect committed the stale essay first and re-rendered, which flashes the previous story's blocks when switching entries. This is React's documented "adjusting state when a prop changes" pattern.
- **`ProofingContext`** keeps its effect, with a targeted `eslint-disable` and the reason in a comment: it hydrates from `localStorage` and the URL query, both browser-only, so reading them during render would break SSR and cause a hydration mismatch.

## Verification

- `npm run lint` — 0 errors; `npm run format:check` clean; `npx tsc --noEmit` clean; 426/426 unit tests pass; `npm run build` succeeds
- The EssayBlockEditor change is the only behavioural one, so I exercised it in the running admin: opened a story in the Studio, typed into a text block (edit is kept, live preview follows, save bar arms), went back and opened a second story — its blocks load clean with no residue from the first.