### PR TITLE
docs: bring the documentation up to date with dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,39 @@ Releases up to and including v0.9.2 are documented in the
 
 ### Added
 
+- **Journal** ([#432](https://github.com/ralksta/immich-folio/pull/432)). A
+  section for photo essays and travel stories at `/journal`, with its own index,
+  cover images, reading times and drafts. Entries are plain Markdown in
+  `content/journal/`, written either by hand or in the new **Journal Studio** —
+  a split-screen block editor with a resizable divider and a live preview of the
+  real page. Photos are inserted through the asset picker rather than by typing
+  UUIDs. A `/journal` link appears in the navigation as soon as one published
+  entry exists; drafts stay visible to a logged-in admin only. Entries can carry
+  their own password. See [docs/journal.md](docs/journal.md).
+- **About page editor and toggle**
+  ([#446](https://github.com/ralksta/immich-folio/pull/446)). Portrait, name,
+  location, gear list and biography are edited under admin Settings › About,
+  which writes `content/about.md`. `about.enabled: false` in `settings.yaml`
+  takes the page offline without deleting it.
+- **Per-album photo order, independent of Immich**
+  ([#414](https://github.com/ralksta/immich-folio/pull/414)). A `sort` key per
+  album — `immich`, `newest`, `oldest`, `filename` or `manual` — so a curated
+  series can have a narrative order without changing the archive. `manual` is a
+  pinned prefix: only the photos you place by hand are listed, everything else
+  follows in the Immich order, and the admin panel has a drag & drop editor
+  for it.
+- **Experimental portfolio features**
+  ([#431](https://github.com/ralksta/immich-folio/pull/431)). Marked
+  experimental in the schema and the UI:
+  - `justified` grid layout — every row fills the width at one shared height,
+    aspect ratios intact
+  - `cover` hero style — a fullscreen splash with the site title and a single
+    **Enter** link
+  - `hidden: true` subpages — reachable by direct link, absent from the
+    navigation (unlisting, not access control)
+  - per-album `grid` overrides, merged over the subpage and global grid
+  - per-album `coverPosition` — the focal point for the cover crop
+  - `navLinks` — external `http(s)` links appended to the header navigation
 - **First-run setup wizard at `/install`**
   ([#419](https://github.com/ralksta/immich-folio/pull/419)). A fresh deployment
   can now be configured from the browser: connect to Immich, optionally pick
@@ -30,6 +63,29 @@ Releases up to and including v0.9.2 are documented in the
 
 ### Changed
 
+- **Every admin area has its own URL**
+  ([#432](https://github.com/ralksta/immich-folio/pull/432)) — `/admin/pages`,
+  `/admin/journal`, `/admin/settings/<section>`, `/admin/analytics` — so a
+  section can be bookmarked and the back button behaves. The auth gate and the
+  panel chrome moved into the layout, and no longer re-run on every tab switch.
+  A floating save bar keeps Save reachable without scrolling
+  ([#426](https://github.com/ralksta/immich-folio/pull/426)).
+- **Design system gaps in the admin panel are closed**
+  ([#432](https://github.com/ralksta/immich-folio/pull/432)). Several classes
+  were referenced but never defined — every input used a class no stylesheet
+  had, the Analytics bars had no fill, and all grid previews collapsed to the
+  same height. The album sort dropdown is now a themed listbox rendered in a
+  portal, so it no longer clips inside modals.
+- **The last emojis in the public frontend are SVG icons**
+  ([#445](https://github.com/ralksta/immich-folio/pull/445)), matching the admin
+  panel ([#415](https://github.com/ralksta/immich-folio/pull/415),
+  [#416](https://github.com/ralksta/immich-folio/pull/416),
+  [#418](https://github.com/ralksta/immich-folio/pull/418)).
+- **The sample journal story ships as a template, not a live entry**
+  ([#443](https://github.com/ralksta/immich-folio/pull/443)). It is
+  `content/journal/sample-story.md.example`, so a fresh install does not publish
+  someone else's story — and since the asset IDs in it belong to no server, the
+  template ships without any.
 - **A gallery with no albums is now a valid, rendered state**
   ([#421](https://github.com/ralksta/immich-folio/pull/421)) instead of an error
   — the setup wizard can finish without picking one, and albums can be added
@@ -47,8 +103,39 @@ Releases up to and including v0.9.2 are documented in the
   write into it, and `:ro` silently breaks all three.
 - **Contributors are credited in the README.**
 
+### Fixed
+
+- **Journal photos did not render**
+  ([#432](https://github.com/ralksta/immich-folio/pull/432)). Photo blocks
+  resolved to nothing, headings sat further left than the body text, fullbleed
+  photos bled only to the left, photo pairs forced both images to equal width
+  regardless of their real shapes, the preview claimed 3:2 for every photo, and
+  the lightbox had neither keyboard control nor navigation inside a journal
+  entry.
+
 ### Security
 
+- **Journal author markdown is escaped, not filtered**
+  ([#432](https://github.com/ralksta/immich-folio/pull/432)). The previous pass
+  stripped `<script>` tags, `on*="…"` handlers and the literal `javascript:` —
+  a denylist, and trivially bypassable: an unquoted `onerror=`, single-quoted
+  handlers, `<svg onload=…>` and `javasjavascript:cript:` (the replacement
+  recombines) all reached `dangerouslySetInnerHTML`. With escaping there is
+  nothing left to enumerate.
+- **Journal file paths are contained**
+  ([#432](https://github.com/ralksta/immich-folio/pull/432)), frontmatter
+  escaping is fixed, and two regexes with polynomial backtracking were replaced
+  by linear scans.
+- **The admin session signing key is derived with scrypt**
+  ([#432](https://github.com/ralksta/immich-folio/pull/432)) rather than a plain
+  digest, and the key cache is keyed on its inputs instead of on a digest of
+  them.
+- **Asset tokens are length-capped before decoding**
+  ([#423](https://github.com/ralksta/immich-folio/pull/423)). `decodeAssetId()`
+  passed arbitrary-length URL input straight to `Buffer.from(…, 'base64url')`,
+  so a huge crafted token could exhaust memory or throw `RangeError` despite the
+  surrounding `try`/`catch`. A real v2 token is ~110 characters; anything over
+  256 is now rejected outright.
 - **Next.js 16.3.0** — picks up the fix for CVE-2025-13465 in Next's vendored
   lodash ([#402](https://github.com/ralksta/immich-folio/pull/402)).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,14 @@ Configuration is loaded once at startup (cached in a module-level singleton, re-
 - `content/gallery.yaml` — gallery structure: hero asset IDs, standalone albums, subpages (with optional sections, passwords, per-subpage grid overrides). Use `gallery.yaml.example` as reference.
 - `content/settings.yaml` — site-wide settings: title, subtitle, theme, grid defaults, footer, legal, map, transitions, SEO. Use `settings.yaml.example` as reference.
 - `content/about.md` — Markdown with frontmatter for the about page (portrait, name, location, gear).
+- `content/journal/*.md` — journal entries, one file per entry (`<slug>.md` → `/journal/<slug>`). `content/essays/` is the legacy location, still resolved.
+- `content/install.json` — written by the setup wizard: Immich URL, API key, generated site secret, scrypt-hashed admin password. Mode `0600`; env vars override every field.
+- `content/analytics.json` — cookieless view counters.
+- `content/favicon.svg` — uploaded favicon (whatever the source format), served via `/api/favicon`.
+- `content/.setup-token` — one-time `/install` gate token (mode `0600`), deleted once setup completes.
+- `content/.backups/`, `content/journal/.backups/` — rotating backups (10 per file) written before every admin save.
+
+The whole `content/` directory must be writable: the wizard, admin panel, journal, favicon upload, analytics and backup rotation all write into it.
 
 ### Immich client (`lib/immich.ts`)
 
@@ -61,19 +69,41 @@ Singleton `ImmichClient` class exported as `immich`. All Immich API calls are se
 
 ### API routes (`app/api/`)
 
-| Route                             | Purpose                                                       |
-| --------------------------------- | ------------------------------------------------------------- |
-| `GET /api/image/[id]`             | Image proxy — decodes token, rate-limits, streams from Immich |
-| `GET /api/exif/[id]`              | EXIF data for lightbox panel                                  |
-| `POST /api/auth`                  | Password submission → sets `HttpOnly` cookie                  |
-| `GET /api/og`                     | Dynamic OG image generation (rate-limited)                    |
-| `GET /api/map`                    | Aggregated GPS coordinates for map view                       |
-| `GET /api/health`                 | Health check                                                  |
-| `GET/POST/DELETE /api/admin/auth` | Admin login, session check, logout                            |
-| `GET/PUT /api/admin/gallery`      | Read/write `gallery.yaml`                                     |
-| `GET/PUT /api/admin/settings`     | Read/write `settings.yaml`                                    |
-| `GET /api/admin/albums`           | Browse all shared Immich albums (admin-only)                  |
-| `POST /api/admin/reload`          | Invalidate config + Immich cache                              |
+Public:
+
+| Route                                          | Purpose                                                                          |
+| ---------------------------------------------- | -------------------------------------------------------------------------------- |
+| `GET /api/image/[id]`                          | Image proxy — decodes token, rate-limits, streams from Immich                    |
+| `GET /api/video/[id]`                          | Video proxy, range requests included                                             |
+| `GET /api/exif/[id]`                           | EXIF data for lightbox panel                                                     |
+| `POST /api/auth`                               | Password submission (`subpage` \| `album` \| `journal`) → sets `HttpOnly` cookie |
+| `GET /api/og`                                  | Dynamic OG image generation (rate-limited)                                       |
+| `GET /api/map`                                 | Aggregated GPS coordinates for map view                                          |
+| `GET /api/favicon`                             | Uploaded favicon from `content/`, with an SVG-safe content policy                |
+| `POST /api/analytics/track`                    | Cookieless view counter; refuses when `analytics: false`                         |
+| `POST /api/webhook`                            | Immich cache invalidation, HMAC-verified; `501` unless `WEBHOOK_SECRET` is set   |
+| `GET /api/health`                              | Health check                                                                     |
+| `POST /api/install`, `GET /api/install/albums` | First-run wizard; refuse to run once setup completed                             |
+
+Admin (every route re-checks `isAdminEnabled()` + `isAdminAuthenticated()`):
+
+| Route                                      | Purpose                                              |
+| ------------------------------------------ | ---------------------------------------------------- |
+| `GET/POST/DELETE /api/admin/auth`          | Admin login, session check, logout                   |
+| `GET/PUT /api/admin/gallery`               | Read/write `gallery.yaml`                            |
+| `GET/PUT /api/admin/settings`              | Read/write `settings.yaml`                           |
+| `GET/PUT /api/admin/about`                 | Read/write `content/about.md`                        |
+| `GET/POST /api/admin/journal`              | List / create journal entries                        |
+| `GET/PUT/DELETE /api/admin/journal/[slug]` | Read, write, delete one entry                        |
+| `GET /api/admin/albums`                    | Browse all shared Immich albums (bypasses allowlist) |
+| `GET /api/admin/albums/[albumId]/assets`   | Assets of one album, for the manual-order editor     |
+| `GET /api/admin/assets`                    | Library search (`POST /search/metadata`) for pickers |
+| `GET /api/admin/thumbnail/[id]`            | Raw-UUID thumbnails for the admin UI                 |
+| `GET/POST /api/admin/backups`              | List and restore backups                             |
+| `POST/DELETE /api/admin/favicon`           | Favicon upload and reset                             |
+| `GET /api/admin/analytics`                 | Aggregated view counts                               |
+| `GET /api/admin/status`                    | Immich reachability, config validity, cache, backups |
+| `POST /api/admin/reload`                   | Invalidate config + Immich cache                     |
 
 The image proxy maps requested pixel widths (`?w=`) to Immich size tiers: `≤250px→thumbnail`, `≤1440px→preview`, `>1440px→original` (`lib/imageSize.ts`).
 
@@ -87,15 +117,41 @@ Single catch-all route handles three cases:
 2. `/[subpage-slug]` — if subpage has >1 album, renders `SubpageGridView`; if exactly 1 album, renders `AlbumDetailView` directly
 3. `/[album-slug]` — standalone album detail
 
+A subpage renders as an essay instead when any of `grid.layout === 'essay'`, `essayFile`, or `essayText` is set. With `layout: essay` and no markdown, the essay is generated from the albums (heading per album + its photos).
+
+Fixed routes outside the catch-all: `/about`, `/map`, `/impressum`, `/journal`, `/journal/[slug]`, `/install`, `/admin/*`.
+
+### Journal & essays (`lib/journal.ts`, `lib/essay.ts`, `lib/admin/journal-service.ts`)
+
+- `lib/journal.ts` — **client-safe**, no `fs`. Parses and serializes the block markdown (`parseJournalMarkdown` / `serializeJournalMarkdown`), and owns `sanitizeHtml`, `isValidSlug`, reading time and excerpts. Photo blocks are `![<assetId>:fullbleed|wide](caption)` and `![<id>, <id>](caption)`.
+- `lib/admin/journal-service.ts` — **server only**: reads/writes `content/journal/`, falls back to the legacy `content/essays/`, rotates backups. The client/server split is load-bearing — importing the service from a client component breaks the build.
+- `essayFile` is a **slug**, not a path: `isValidSlug` rejects dots and slashes, so `content/essays/x.md` cannot resolve.
+- Author markdown is escaped, never filtered — `sanitizeHtml` runs first and the renderer only emits tags it builds itself.
+- Drafts (`draft: true`) are hidden from the index and the nav check, but remain visible to an authenticated admin. Entry passwords use the `lb_auth_journal_<slug>` cookie.
+
+### Proofing (`lib/proofing.ts`, `components/ProofingContext.tsx`)
+
+Client-side favourite selection encoded as a bitmask in the URL and mirrored to `localStorage`; nothing is stored server-side. Note that `PhotoGrid` mounts `ProofingProvider` unconditionally — the `proofing.enabled` / per-subpage `proofing` config keys are parsed but not consulted, so the feature is currently always on for grids.
+
+### Analytics
+
+`POST /api/analytics/track` appends to `content/analytics.json` and short-circuits when `config.analytics === false`. `GET /api/admin/analytics` is admin-only. No cookies, no third party.
+
+### First-run setup (`lib/install.ts`, `app/install/`)
+
+A deployment with no `gallery.yaml` and no credentials serves `SetupScreen`, and `/install` runs the wizard. It is gated by a one-time token printed to the server log and stored in `content/.setup-token` — a fresh deployment is reachable before it is configured. Credentials are verified against Immich before anything is written, then land in `content/install.json`. Environment variables always take precedence over that file, so rotation works without touching it. Once `isInstalled()` is true the wizard routes return `403`.
+
 All pages are `dynamic = 'force-dynamic'` (no SSG; requires live Immich).
 
 ### Password protection (`lib/auth.ts`)
 
-Per-subpage and per-album password gating using HMAC tokens in `HttpOnly` cookies (no database). Cookie names: `lb_auth_<slug>` (subpage) and `lb_auth_album_<slug>` (album). Password storage supports plaintext (deprecated, logs a warning with recommended scrypt hash), `scrypt:salt:hash` format, and rejects legacy bcrypt. Token expiry: 24 hours.
+Per-subpage, per-album and per-journal-entry password gating using HMAC tokens in `HttpOnly` cookies (no database). Cookie names: `lb_auth_<slug>` (subpage), `lb_auth_album_<slug>` (album) and `lb_auth_journal_<slug>` (journal entry). Password storage supports plaintext (deprecated, logs a warning with recommended scrypt hash), `scrypt:salt:hash` format (`lib/password.ts`), and rejects legacy bcrypt. Token expiry: 24 hours.
 
 ### Rate limiting (`lib/rate-limit.ts`)
 
-In-memory sliding-window rate limiter. Important: **in-memory only** — does not work across multiple Node.js instances. Uses FIFO eviction (not reject-on-full) to prevent DoS via store flooding. Configurable via `RATE_LIMIT_RPM`. `TRUSTED_PROXY_HOPS` must be set to the number of reverse proxies in front of the app (nginx = 1); the client IP is then read that many entries from the right of `X-Forwarded-For`, which proxies append to. Without it the IP comes from a spoofable header. Bucket keys are namespaced per endpoint (`image:`, `map:`, `auth:`, …) so limits don't collide.
+In-memory sliding-window rate limiter. Important: **in-memory only** — does not work across multiple Node.js instances. Uses FIFO eviction (not reject-on-full) to prevent DoS via store flooding. `TRUSTED_PROXY_HOPS` must be set to the number of reverse proxies in front of the app (nginx = 1); the client IP is then read that many entries from the right of `X-Forwarded-For`, which proxies append to. Without it the IP comes from a spoofable header. Bucket keys are namespaced per endpoint (`image:`, `map:`, `auth:`, …) so limits don't collide.
+
+`RATE_LIMIT_RPM` (default 1500) covers image, video, EXIF and health. Endpoints where a high ceiling would be wrong carry a fixed constant in the route: `admin-auth` 5, `auth` 10, `install` 10, `og` 30, `install-albums` 30, `webhook` 60, `map` 120.
 
 ### Theming system
 
@@ -107,18 +163,21 @@ A custom loader (`lib/immichLoader.ts`) maps `next/image` requests to `/api/imag
 
 ### Admin Panel (`app/admin/`, `lib/admin/`, `app/api/admin/`)
 
-Visual page builder and settings editor at `/admin`. Enabled by setting `ADMIN_PASSWORD` env var.
+Visual page builder, journal studio, settings editor and analytics at `/admin`. Enabled by setting `ADMIN_PASSWORD` env var, or via the setup wizard (scrypt hash in `install.json`).
 
-- `lib/admin/auth.ts` — HMAC-signed session tokens (HttpOnly cookie `folio_admin_session`), constant-time password verification, 24h expiry.
+Each area is a real route — `/admin/pages`, `/admin/journal`, `/admin/journal/[slug]`, `/admin/settings/[section]`, `/admin/analytics`. `app/admin/AdminShell.tsx` lives in the layout and holds the auth gate and chrome, so switching tabs does not re-run the session check.
+
+- `lib/admin/auth.ts` — HMAC-signed session tokens (HttpOnly cookie `folio_admin_session`), 24h expiry. The signing key is derived from `ADMIN_PASSWORD` + `AUTH_SECRET` with scrypt and cached keyed on its inputs.
 - `lib/admin/yaml-service.ts` — Atomic YAML read/write with automatic backups to `content/.backups/` (max 10 per file). Writes use temp-file + rename pattern.
-- `app/api/admin/auth` — POST login, GET session check, DELETE logout.
-- `app/api/admin/gallery` — GET/PUT for `gallery.yaml`.
-- `app/api/admin/settings` — GET/PUT for `settings.yaml`.
-- `app/api/admin/albums` — GET lists ALL shared Immich albums (bypasses allowlist, admin-only).
-- `app/api/admin/reload` — POST invalidates config cache + Immich cache.
-- `app/admin/components/PageBuilder.tsx` — Tree editor for hero, standalone albums, subpages, and sections.
-- `app/admin/components/AlbumPicker.tsx` — Modal to browse/search all Immich albums.
-- `app/admin/components/SettingsEditor.tsx` — Sidebar-nav settings form (theme, grid, footer, legal, SEO).
+- `lib/admin/journal-service.ts` — the same pattern for `content/journal/*.md`.
+- `lib/admin/paths.ts` — `containedPath()`; every admin file path goes through it so a slug cannot escape its directory.
+- `app/admin/components/PageBuilder.tsx` — Tree editor for hero, standalone albums, subpages, and sections, with a slide-over drawer per item.
+- `app/admin/components/JournalStudio.tsx` — Split-screen block editor with live preview.
+- `app/admin/components/SettingsEditor.tsx` — Sidebar-nav settings form (general, theme, grid, footer, legal, SEO, security & protection, about).
+- `app/admin/components/AlbumPicker.tsx` / `AssetPicker.tsx` / `AssetOrderEditor.tsx` — album browser, library search, manual photo ordering.
+- `app/admin/components/BackupManagerModal.tsx` — list and restore backups.
+
+Every `/api/admin/*` route must check `isAdminEnabled()` **and** `isAdminAuthenticated()` itself — there is no shared middleware guard. `app/api/admin/__tests__/admin-guards.test.ts` enforces this across all of them.
 
 After saving, `invalidateConfigCache()` is called so the next request picks up the new YAML without restart.
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,25 @@ Immich Folio acts as a **secure reverse proxy** between your visitors and your p
   <img src="docs/screenshots/lightbox-exif.png" width="98%" alt="Fullscreen lightbox with the EXIF panel open" />
 </p>
 
-## What's New in v0.10.0
+## What's New
 
-The largest release so far — two new ways to present work, a seventh theme preset, and an admin panel rebuilt around visual controls.
+### Unreleased
+
+Since v0.10.0 — a first-run wizard, a journal, and a set of experimental
+portfolio features.
+
+- **First-run setup wizard at `/install`** — configure a fresh deployment from the browser instead of writing config files: connect to Immich, pick albums, name the site. Credentials are verified before anything is written → [First-Run Setup](#first-run-setup)
+- **Journal** — a section for photo essays and travel stories at `/journal`, with a split-screen block editor in the admin panel, drafts, per-entry passwords, cover images and reading times → [Journal guide](docs/journal.md)
+- **About page editor** — portrait, name, location, gear and bio edited in the admin panel, plus a toggle to take the page offline
+- **Custom favicon upload** — SVG, PNG, ICO or JPEG, stored in the content volume
+- **Experimental portfolio features** — justified grid layout, `cover` hero splash screen, unlisted subpages, per-album grid overrides, cover focal points, and external navigation links
+- **Admin panel** — every area has its own URL, a floating save bar, and a manual photo-order editor with drag & drop
+
+**Upgrading:** no migration, no configuration change.
+
+### v0.10.0
+
+Two new ways to present work, a seventh theme preset, and an admin panel rebuilt around visual controls.
 
 - **New theme preset: Studio Modern** — the Leica language of `studio` rebuilt around the Archivo grotesque, with IBM Plex Mono for all photographic metadata, an indexed hero navigation with album counts, caption bars under album covers, and a film-edge EXIF strip in the lightbox → [Theming guide](docs/theming.md)
 
@@ -43,7 +59,7 @@ The largest release so far — two new ways to present work, a seventh theme pre
 - **Resilience** — the gallery keeps serving the last known albums during an Immich outage instead of erroring, with loading skeletons while the round-trip is in flight
 - **Fixed:** the map page ignored the configured theme fonts and borders (all presets), album order now mirrors the Immich timeline across time zones, the admin status panel no longer reports faults that are not faults, and the Docker health check no longer fails on IPv6-first `localhost` resolution
 
-**Upgrading:** no migration, no configuration change — pull the new image and restart. One exception: if you copied `docker-compose.override.yml.example` in the past, its health check needs a one-line edit. See the [upgrade notes](CHANGELOG.md#upgrade-notes) for that and for the rollback caveat when switching presets.
+**Upgrading to v0.10.0:** no migration, no configuration change — pull the new image and restart. One exception: if you copied `docker-compose.override.yml.example` in the past, its health check needs a one-line edit. See the [upgrade notes](CHANGELOG.md#upgrade-notes) for that and for the rollback caveat when switching presets.
 
 ### Security releases
 
@@ -64,7 +80,9 @@ Full history in the [GitHub releases](https://github.com/ralksta/immich-folio/re
 - **Masonry photo grid** — responsive layout with natural aspect ratios and configurable columns, gap, and aspect ratio
 - **Uniform grid mode** — switch to a fixed-aspect uniform grid per-subpage or globally
 - **Showcase / filmstrip / editorial-flow layouts** — featured hero + grid, horizontal scroll strips, or alternating full-width and paired images
-- **Per-subpage grid overrides** — each subpage can define its own columns, gap, aspect ratio, and layout mode
+- **Justified rows** _(experimental)_ — every row fills the width at one shared height, aspect ratios intact, nothing cropped
+- **Per-subpage grid overrides** — each subpage can define its own columns, gap, aspect ratio, and layout mode, and individual albums can override that again _(experimental)_
+- **Cover focal points** _(experimental)_ — decide which part of a cover survives the crop
 - **Fullscreen lightbox** — keyboard and swipe navigation, EXIF panel, adjacent image preloading
 - **EXIF metadata on hover** — camera body, lens, focal length, aperture, shutter speed, ISO shown directly on the grid
 - **ThumbHash placeholders** — instant blurred previews while full images load
@@ -74,8 +92,12 @@ Full history in the [GitHub releases](https://github.com/ralksta/immich-folio/re
 - **Subpage grouping** — organize albums into named collections (e.g. `/japan/tokyo-2023`)
 - **Auto-generated slugs** — URL slugs derived from album names automatically
 - **YAML gallery config** — all gallery structure defined in a single `content/gallery.yaml` file
-- **Markdown about page** — `content/about.md` with frontmatter for portrait, name, location, and gear list
+- **Markdown about page** — `content/about.md` with frontmatter for portrait, name, location, and gear list, editable from the admin panel
+- **Journal** — photo essays and travel stories at `/journal`, with drafts, per-entry passwords, cover images and reading times
 - **Photo Essay mode** — long-form storytelling pages alternating text with fullbleed and paired image layouts
+- **Unlisted subpages** _(experimental)_ — reachable by direct link, absent from the navigation
+- **Subpage on/off toggle** — take a page offline without deleting it
+- **External navigation links** _(experimental)_ — point the header at a shop, a blog, or a social profile
 - **Client proofing** — clients favorite photos and export the selection; picks are encoded in the URL, nothing is stored server-side
 - **Lightbox watermark** — configurable overlay on fullscreen images
 - **Privacy-friendly analytics** — cookieless view counts, no third parties, can be switched off
@@ -91,9 +113,12 @@ Full history in the [GitHub releases](https://github.com/ralksta/immich-folio/re
 
 - **Visual page builder** — drag & drop interface to manage hero images, standalone albums, subpages, and sections
 - **Album picker** — browse all shared Immich albums with search, see photo counts, and add them with one click
-- **Settings editor** — configure theme, grid layout, footer, legal/impressum, and SEO from a visual UI
+- **Settings editor** — configure theme, grid layout, footer, legal/impressum, SEO, image protection and the about page from a visual UI
 - **Visual previews everywhere** — grid layout, theme, photo frame, hero style and the Google search snippet are picked from preview cards instead of text fields
+- **Journal Studio** — split-screen block editor with a live preview of the real page
 - **Essay block editor** — assemble photo essays block by block without touching Markdown
+- **Photo order editor** — drag & drop a hand-picked opening sequence for any album
+- **Favicon upload** — give the site its own icon in the browser tab
 - **Backup manager** — every save is backed up automatically; restore any of them with one click
 - **Live YAML sync** — changes are written directly to `gallery.yaml` and `settings.yaml` with automatic backups
 - **Password protected** — secured with its own admin password, separate from album passwords
@@ -223,11 +248,14 @@ CACHE_TTL=300                          # seconds, default: 300
 STALE_MAX_AGE=86400                    # seconds an expired cache entry survives during an outage, default: 86400 (24h), 0 disables
 IMMICH_TIMEOUT_MS=15000                # Immich response wait, default: 15000
 IMAGE_CACHE_VERSION=1                  # bump to bust browser image caches, default: off
-RATE_LIMIT_RPM=1500                    # requests/min/IP, default: 1500
+RATE_LIMIT_RPM=1500                    # requests/min/IP for images, default: 1500
 AUTH_SECRET=long-random-string        # required in production
 TRUSTED_PROXY_HOPS=1                   # reverse proxies in front, default: 0
 ADMIN_PASSWORD=your-secure-password   # enables /admin panel
+WEBHOOK_SECRET=long-random-string     # enables POST /api/webhook cache invalidation
 ```
+
+> Login and setup endpoints have their own, much lower limits that `RATE_LIMIT_RPM` does not raise — see [Rate Limiting](docs/gallery-config.md#rate-limiting).
 
 > Behind a reverse proxy, set `TRUSTED_PROXY_HOPS` to the number of proxies in front of the app (nginx/Traefik/Caddy = 1; Cloudflare in front of nginx = 2). Without it the client IP is read from a header the client itself can set, which defeats the brute-force limits on the password endpoints. See [Trusted Proxies](docs/gallery-config.md#trusted-proxies).
 
@@ -250,6 +278,12 @@ Create a dedicated API key in Immich under **Account Settings → API Keys**. Im
 All gallery structure — hero images, albums, subpages, grid layout, footer — is defined in `content/gallery.yaml`.
 
 → **[Gallery Configuration Guide](docs/gallery-config.md)**
+
+### Journal & Photo Essays
+
+Long-form storytelling with fullbleed photos, side-by-side pairs, quotes and captions — as a standalone `/journal` section, or as a single essay on one subpage.
+
+→ **[Journal & Photo Essays Guide](docs/journal.md)**
 
 ### Theming
 

--- a/content/gallery.yaml.example
+++ b/content/gallery.yaml.example
@@ -92,11 +92,20 @@ subpages:
           - "album-uuid-osaka-2"
 
   # ── Photo Essay / Storytelling Subpage Example ───────────────────
-  # Render editorial Markdown essays with fullbleed & side-by-side images
+  # Render editorial Markdown essays with fullbleed & side-by-side images.
+  #
+  # essayFile is a SLUG, not a path: "sample-story" resolves to
+  # content/journal/sample-story.md (or content/essays/sample-story.md).
+  # Slashes and dots are rejected. Copy the shipped template to get started:
+  #   cp content/journal/sample-story.md.example content/journal/sample-story.md
+  #
+  # Leave essayFile out and keep `layout: essay`, and the essay is generated
+  # from the albums below — one heading per album, followed by its photos.
+  # See docs/journal.md for the Markdown block syntax.
   - name: Highlands
     title: "Icelandic Highlands"
     subtitle: "A Photo Essay"
-    essayFile: "content/essays/sample-story.md"
+    essayFile: "sample-story"
     grid:
       layout: essay
     albums:

--- a/docs/admin-panel.md
+++ b/docs/admin-panel.md
@@ -1,13 +1,16 @@
 # Admin Panel
 
-Immich Folio includes a built-in visual admin panel at `/admin` that lets you manage your gallery structure and site settings without editing YAML files by hand.
+Immich Folio includes a built-in visual admin panel at `/admin` that lets you manage your gallery structure, journal entries and site settings without editing YAML files by hand.
 
 **Contents:**
 
 - [Enabling the Admin Panel](#enabling-the-admin-panel)
-- [Page Builder](#page-builder)
-- [Settings Editor](#settings-editor)
-- [Album Picker](#album-picker)
+- [Layout](#layout)
+- [Pages](#pages)
+- [Journal](#journal)
+- [Settings](#settings)
+- [Analytics](#analytics)
+- [Album & Asset Pickers](#album--asset-pickers)
 - [Security](#security)
 - [Backups](#backups)
 - [Docker Usage](#docker-usage)
@@ -22,99 +25,147 @@ ADMIN_PASSWORD=your-secure-admin-password
 
 Then navigate to `http://your-site/admin`. The panel is completely disabled if no password is set — it won't even render the login page.
 
+The [setup wizard](../README.md#first-run-setup) can set the password instead, storing it as an scrypt hash in `content/install.json`. An `ADMIN_PASSWORD` environment variable takes precedence if both are present.
+
 > [!IMPORTANT]
 > The admin password is separate from any album or subpage passwords. It controls access to the entire gallery configuration.
 
-## Page Builder
+## Layout
 
-The **Pages** tab provides a visual tree view of your gallery structure:
+Each area has its own URL, so a section can be bookmarked and the browser's back button works as expected:
+
+| Tab           | URL                | Writes to                                   |
+| ------------- | ------------------ | ------------------------------------------- |
+| **Pages**     | `/admin/pages`     | `content/gallery.yaml`                      |
+| **Journal**   | `/admin/journal`   | `content/journal/<slug>.md`                 |
+| **Settings**  | `/admin/settings`  | `content/settings.yaml`, `content/about.md` |
+| **Analytics** | `/admin/analytics` | nothing — read-only                         |
+
+Unsaved changes raise a save bar pinned to the bottom of the viewport, so the Save button is reachable without scrolling back up. Saving applies immediately — no server restart.
+
+## Pages
+
+A visual tree of your gallery structure. Each item opens a slide-over drawer with its settings.
 
 ### Hero Images
 
-Add Immich asset UUIDs for the homepage hero carousel. Supports single or multiple images that crossfade automatically.
+Immich asset UUIDs for the homepage hero. One image, or several that crossfade as a carousel. Pick them from your library with the [asset picker](#album--asset-pickers) instead of typing UUIDs.
 
 ### Standalone Albums
 
-Albums displayed directly on the homepage. Click **+ Add Album** to open the Album Picker and select from your Immich library.
+Albums displayed directly on the homepage. **+ Add Album** opens the [Album Picker](#album--asset-pickers).
 
-Each album card supports:
+Each album supports:
 
-- **Title override** — display a custom name instead of the Immich album name
-- **Description** — shown below the album title on the subpage
-- **Password** — protect individual albums with a password
+- **Title override** — a display name instead of the Immich album name
+- **Description** — shown below the album title
+- **Password** — protect a single album (written as an scrypt hash)
+- **Cover image** — override the album cover with any asset
+- **Photo order** — Immich order, newest, oldest, filename, or **Manual** with a drag & drop editor
+- **Grid override** _(experimental)_ — a different grid layout for this album alone (the panel exposes the layout; columns, gap and aspect ratio can be set in `gallery.yaml`)
+- **Cover focal point** _(experimental)_ — which part of the cover survives the crop
 
 ### Subpages
 
-Group albums under custom URL paths (e.g., `/japan`, `/wedding-smith`).
+Group albums under custom URL paths (e.g. `/japan`, `/wedding-smith`).
 
-Each subpage has:
+- **Name** — navigation label; the URL slug is derived from it
+- **Title / Subtitle** — page heading and subline
+- **Password** — protect the whole subpage
+- **Grid override** — layout settings for this page
+- **Enabled** — take the page offline without deleting it
+- **Hidden** _(experimental)_ — unlisted: reachable by direct link, absent from the navigation
+- **Essay** — turn the page into a photo essay, with a block editor for the text
 
-- **Name** — used for navigation and URL generation (auto-slugified)
-- **Title** — optional display title (defaults to name)
-- **Subtitle** — optional text shown below the page heading
-- **Password** — optional protection for the entire subpage
+A live preview shows the page as visitors will see it.
 
 ### Sections
 
-Within a subpage, you can organize albums into named sections. This generates a table of contents with anchor links. Add sections with **+ Add Section** and fill each with albums from the picker.
+Within a subpage, albums can be grouped into named sections, which renders a table of contents with anchor links.
 
 ### Reordering
 
-Use the **↑/↓** buttons on subpages to change their display order. The order in the admin panel matches the order on your site.
+Subpages, albums and sections are reordered in place; the order in the panel is the order on the site.
 
-## Settings Editor
+## Journal
 
-The **Settings** tab lets you configure global site behavior:
+The **Journal Studio** — a split-screen editor with the blocks on the left and a live preview of the real page on the right, separated by a divider you can drag with mouse, keyboard or touch.
 
-| Section | Controls                                                                       |
-| ------- | ------------------------------------------------------------------------------ |
-| General | Site title, subtitle, language, EXIF on hover, map, transitions, scroll-to-top |
-| Theme   | Preset, accent color, photo frame, hero style, grain, header dot               |
-| Grid    | Layout mode, columns, gap, aspect ratio                                        |
-| Footer  | Name, Instagram, email, website                                                |
-| Legal   | Impressum toggle and all legal fields                                          |
-| SEO     | Meta title, description, noindex, nofollow                                     |
+Blocks are added from a menu (heading, text, quote, photo, photo pair), reordered, and deleted; each carries a type chip so long entries stay scannable. Photos are inserted through the asset picker, which fills in the Immich asset UUID for you. The frontmatter — cover image, title, subtitle, author, date, draft flag, password — is edited as form fields.
 
-Changes are applied immediately after saving — no server restart required.
+Saving writes plain Markdown to `content/journal/<slug>.md`, which can equally be edited by hand.
 
-## Album Picker
+→ **[Journal & Photo Essays](journal.md)** for the file format.
 
-When adding albums, a modal overlay shows **all shared albums** from your Immich instance (not just the ones already configured). Features:
+## Settings
+
+Eight sections, each at its own URL (`/admin/settings/theme`, …):
+
+| Section                   | Controls                                                                                                                            |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| **General**               | Site title, subtitle, language, favicon upload, and the feature toggles (EXIF on hover, map, transitions, scroll-to-top, analytics) |
+| **Theme**                 | Preset, colour mode, accent, photo frame, hero style, grain, header dot                                                             |
+| **Grid**                  | Layout algorithm, columns, gap, aspect ratio                                                                                        |
+| **Footer**                | Name, Instagram, email, website, and the header navigation links                                                                    |
+| **Legal**                 | Impressum toggle and all legal fields                                                                                               |
+| **SEO**                   | Meta title, subpage title template, description, noindex, nofollow                                                                  |
+| **Security & Protection** | Right-click and image-drag deterrents, lightbox watermark (text, position, opacity)                                                 |
+| **About**                 | Portrait asset, name, location, gear list, and the biography — written to `content/about.md`                                        |
+
+Theme presets, grid layouts, photo frames, hero styles and the Google search snippet are picked from **preview cards** rather than text fields, so the effect of a choice is visible before saving. A light/dark toggle previews both variants of a preset.
+
+### Favicon
+
+**General → Favicon** accepts an SVG, PNG, ICO or JPEG. It is stored in the writable `content/` volume and served through `/api/favicon` under a policy that stops an uploaded SVG from executing script. **Reset** restores the bundled default.
+
+## Analytics
+
+View counts per page and album, read from `content/analytics.json`. No cookies, no third party, nothing leaving your server. Switch the collection off entirely in **Settings → General**; the tracking endpoint then refuses to record.
+
+## Album & Asset Pickers
+
+**Album Picker** — a modal listing **all shared albums** from your Immich instance, not just the configured ones:
 
 - **Search** by album name or UUID
-- **Photo count** shown for each album
+- **Photo count** per album
 - **"In use" badge** for albums already assigned somewhere
-- Albums are sorted: configured first, then alphabetically
+- Sorted configured-first, then alphabetically
+
+**Asset Picker** — browses your full Immich library for hero images, album covers, journal photos and the about-page portrait. It uses `POST /search/metadata`, which is covered by the `asset.read` permission your API key already needs.
 
 ## Security
 
-| Aspect         | Implementation                                          |
-| -------------- | ------------------------------------------------------- |
-| Authentication | HMAC-signed session token in an `HttpOnly` cookie       |
-| Session expiry | 24 hours (automatic logout)                             |
-| Password check | Constant-time comparison to prevent timing attacks      |
-| Cookie flags   | `HttpOnly`, `Secure` (in production), `SameSite=Strict` |
-| Rate limiting  | Admin endpoints share the global rate limiter           |
-| Robots         | `/admin` is marked `noindex, nofollow` in metadata      |
+| Aspect         | Implementation                                                        |
+| -------------- | --------------------------------------------------------------------- |
+| Authentication | HMAC-signed session token in an `HttpOnly` cookie                     |
+| Signing key    | Derived from `AUTH_SECRET` with scrypt                                |
+| Session expiry | 24 hours (automatic logout)                                           |
+| Password check | Constant-time comparison to prevent timing attacks                    |
+| Cookie flags   | `HttpOnly`, `Secure` (in production), `SameSite=Strict`               |
+| Rate limiting  | `POST /api/admin/auth` is capped at 5 attempts per minute per IP      |
+| Authorization  | Every `/api/admin/*` route re-checks the session, including analytics |
+| Robots         | `/admin` is marked `noindex, nofollow` in metadata                    |
 
 > [!NOTE]
-> The admin panel uses its own session management, completely separate from album password protection. Admin sessions use `AUTH_SECRET` for token signing.
+> The admin panel uses its own session management, completely separate from album password protection. Rotating `AUTH_SECRET` invalidates every admin session along with every unlocked gallery.
 
 ## Backups
 
-Every time you save changes, the previous YAML file is automatically backed up to `content/.backups/`:
+Every time you save, the previous file is backed up automatically:
 
 ```
 content/.backups/
 ├── gallery.yaml.2026-05-29T14-30-00-000Z.bak
-├── gallery.yaml.2026-05-29T15-45-00-000Z.bak
 ├── settings.yaml.2026-05-29T14-30-00-000Z.bak
 └── ...
+content/journal/.backups/
+└── my-story.md.2026-05-29T14-30-00-000Z.bak
 ```
 
 - Up to **10 backups** per file are retained (oldest are pruned)
+- The **Backup Manager** lists them and restores any one with a single click
 - Before a restore, a `*.pre-restore.bak` snapshot is created
-- All writes are **atomic** (write to temp file, then rename) — no risk of corrupted YAML
+- All writes are **atomic** (write to temp file, then rename) — no risk of a half-written YAML
 
 ## Docker Usage
 
@@ -131,7 +182,7 @@ services:
 ```
 
 > [!IMPORTANT]
-> When using the admin panel, the content volume must be **read-write** (not `:ro`). Remove the `:ro` flag if you had it set previously.
+> The content volume must be **read-write** (not `:ro`). The admin panel, the journal, the favicon upload, the setup wizard and the backup rotation all write into it.
 
 ### Reload Button
 
@@ -142,3 +193,9 @@ The admin header includes a **↻ Reload** button that:
 3. Forces the next request to re-read all YAML files
 
 This is useful after making external changes to config files or when Immich data has changed.
+
+### Diagnostics
+
+The panel reports the health of the installation: whether Immich answers, whether `gallery.yaml` and `settings.yaml` parse, the number of cached entries, and the backup count with the timestamp of the most recent one. `settings.yaml` is optional, so its absence is not a fault — only a file that exists and cannot be parsed counts as invalid. A check that could not run (an expired session, for example) is reported as such rather than as an outage.
+
+Separately, while you are logged in, the public site shows a diagnostic banner on any album Immich returns empty — the case that otherwise looks like a broken page to you and to nobody else.

--- a/docs/gallery-config.md
+++ b/docs/gallery-config.md
@@ -1,24 +1,50 @@
 # Gallery Configuration
 
-All gallery structure is defined in `content/gallery.yaml`. Copy the example to get started:
+Configuration is split across two files in `content/`:
+
+| File            | Contains                                                                     |
+| --------------- | ---------------------------------------------------------------------------- |
+| `gallery.yaml`  | **Structure** — hero assets, albums, subpages, sections, per-album settings  |
+| `settings.yaml` | **Behaviour and identity** — title, theme, grid defaults, footer, legal, SEO |
+
+Copy the examples to get started:
 
 ```bash
 cp content/gallery.yaml.example content/gallery.yaml
+cp content/settings.yaml.example content/settings.yaml
 ```
+
+`settings.yaml` is optional — without it, everything falls back to defaults.
 
 > [!TIP]
 > Prefer a visual interface? Enable the **[Admin Panel](admin-panel.md)** by setting `ADMIN_PASSWORD` in your environment. It provides a drag-and-drop page builder that writes to these same YAML files automatically.
 
 **Contents:**
 
+`gallery.yaml`
+
 - [Hero Images](#hero-images)
 - [Standalone Albums](#standalone-albums)
 - [Subpages & Categories](#subpages)
+- [Per-Album Options](#per-album-options)
+- [Photo Order Within an Album](#photo-order-within-an-album)
+
+`settings.yaml`
+
 - [Grid Layout](#grid-layout)
-- [EXIF on Hover](#exif-on-hover)
+- [Site Behaviour](#site-behaviour)
+- [Navigation Links](#navigation-links)
+- [Client Proofing](#client-proofing)
+- [Image Protection & Watermark](#image-protection--watermark)
+- [SEO](#seo)
 - [Footer](#footer)
+
+Other
+
 - [About Page](#about-page)
+- [Journal & Photo Essays](journal.md)
 - [Finding UUIDs](#finding-uuids)
+- [System & Security](#system--security)
 
 ## Hero Images
 
@@ -82,6 +108,43 @@ subpages:
       - 33333333-3333-3333-3333-333333333333
 ```
 
+### Subpage Options
+
+| Key         | Type    | Description                                                                          |
+| ----------- | ------- | ------------------------------------------------------------------------------------ |
+| `name`      | string  | Navigation label; the URL slug is derived from it                                    |
+| `title`     | string  | Page heading, defaults to `name`                                                     |
+| `subtitle`  | string  | Subline under the heading                                                            |
+| `password`  | string  | Gates the whole subpage — see [Password Protection](#password-protection)            |
+| `albums`    | list    | Album UUIDs, optionally with [per-album options](#per-album-options)                 |
+| `sections`  | list    | Named groups of albums — see [Sections](#sections)                                   |
+| `grid`      | object  | Grid override for this page — see [Grid Layout](#grid-layout)                        |
+| `proofing`  | boolean | Enables [client proofing](#client-proofing) on this page                             |
+| `essayFile` | string  | Render a Markdown essay instead of a grid — see [Journal & Photo Essays](journal.md) |
+| `essayText` | string  | Essay Markdown inline; written by the admin block editor                             |
+| `enabled`   | boolean | `false` takes the page offline without deleting it                                   |
+| `hidden`    | boolean | **Experimental.** Reachable by direct link, but hidden from the navigation           |
+
+```yaml
+subpages:
+  - name: Client Preview
+    hidden: true # unlisted: not in the nav, still reachable at /client-preview
+    proofing: true # visitors can mark favourites and export the selection
+    password: 'clientpass123'
+    albums:
+      - 55555555-5555-5555-5555-555555555555
+
+  - name: Old Series
+    enabled: false # offline, keeps its configuration
+    albums:
+      - 66666666-6666-6666-6666-666666666666
+```
+
+> [!NOTE]
+> `hidden` is unlisting, not access control. The URL is guessable — a slug is
+> derived from the name — and nothing stops a visitor who has it. Combine it
+> with `password` for anything that must stay private.
+
 ### Sections
 
 When a subpage contains many albums you can split them into **named sections**. A typographic table of contents with anchor links is automatically rendered above the albums. Sections are fully optional — omit them and you get the standard flat grid.
@@ -94,18 +157,7 @@ Each section can have:
 | `description` | string | ➖       | Optional subline under the heading          |
 | `albums`      | list   | ✅       | Album UUIDs (same format as regular albums) |
 
-Within the `albums` list you can use a plain UUID, a simple title override, or an object with any of `title`, `description`, `password`, `heroImage`, `sort` and `assetOrder`:
-
-```yaml
-albums:
-  - 'album-uuid' # → uses the Immich album name
-  - 'album-uuid': My Title # → displays "My Title" instead
-  - 'album-uuid':
-      title: My Private Title
-      password: 'secure-password' # → adds a password gate to this specific album
-      heroImage: 'asset-uuid' # → overrides the album cover
-      sort: filename # → see "Photo Order Within an Album" below
-```
+Within the `albums` list you can use a plain UUID, a simple title override, or an object — see [Per-Album Options](#per-album-options).
 
 **Full example:**
 
@@ -134,6 +186,86 @@ subpages:
 
 > [!NOTE]
 > Each section title is automatically converted to a URL-safe anchor (`#tokyo`, `#kyoto`, …). The TOC appearance (separator character, numbering style, section rule) is fully controlled by the active theme.
+
+## Per-Album Options
+
+Every album entry — standalone, on a subpage, or inside a section — accepts the
+same three notations:
+
+```yaml
+albums:
+  - 'album-uuid' # → uses the Immich album name
+  - 'album-uuid': My Title # → displays "My Title" instead
+  - 'album-uuid':
+      title: My Private Title
+      description: 'Shot on 35mm film in Vienna, spring 2025.'
+      password: 'secure-password'
+      heroImage: 'asset-uuid'
+      sort: filename
+```
+
+| Key             | Description                                                                   |
+| --------------- | ----------------------------------------------------------------------------- |
+| `title`         | Display name instead of the Immich album name                                 |
+| `description`   | Shown below the album title                                                   |
+| `password`      | Gates this album alone — see [Password Protection](#password-protection)      |
+| `heroImage`     | Asset UUID overriding the album cover                                         |
+| `sort`          | Photo order — see [Photo Order Within an Album](#photo-order-within-an-album) |
+| `assetOrder`    | Pinned asset UUIDs for `sort: manual`                                         |
+| `grid`          | **Experimental.** Grid override for this album only                           |
+| `coverPosition` | **Experimental.** Focal point for the cover crop                              |
+
+### Per-album grid (experimental)
+
+An album can override the grid it is shown in. It is merged over the subpage
+grid, which is merged over the global default — so an album only has to state
+what differs:
+
+```yaml
+albums:
+  - 'album-uuid':
+      title: Panoramas
+      grid:
+        layout: justified
+        columns: 2
+```
+
+### Cover focal point (experimental)
+
+Album covers are cropped to the card. `coverPosition` decides which part
+survives the crop — the same values CSS `object-position` takes:
+
+```yaml
+albums:
+  - 'album-uuid':
+      coverPosition: '50% 25%' # or: "top", "center bottom", "left"
+```
+
+Useful when the automatic centre crop cuts off a horizon or a face.
+
+## Password Protection
+
+A password can be set on a subpage, on a single album, and on a
+[journal entry](journal.md#password-protected-entries). Unlocking sets an
+`HttpOnly` cookie that is valid for 24 hours; nothing is stored server-side.
+
+Three storage formats are accepted:
+
+| Format             | Status                                                                |
+| ------------------ | --------------------------------------------------------------------- |
+| `scrypt:salt:hash` | **Recommended.** The password is not recoverable from `gallery.yaml`. |
+| Plaintext          | Works, but deprecated — logs a warning naming the recommended hash.   |
+| bcrypt (`$2a$…`)   | Rejected.                                                             |
+
+To get the hash for an existing plaintext password, unlock the gallery once and
+read the server log: the successful unlock prints the matching `scrypt:…` line
+to paste back into `gallery.yaml`. The admin panel writes the hashed form
+directly.
+
+> [!NOTE]
+> Album and subpage gates protect the **page**. Image URLs handed out while a
+> gallery was unlocked keep working — see
+> [Image Token Revocation](#image-token-revocation).
 
 ## Photo Order Within an Album
 
@@ -178,37 +310,159 @@ The `/admin` page builder has a drag & drop editor for this (album → **Photo o
 
 ## Grid Layout
 
-Configure the photo grid globally or per-subpage:
+The global default lives in `settings.yaml`; subpages and individual albums can
+override it in `gallery.yaml`. The three levels merge, most specific winning:
+
+**global (`settings.yaml`) → subpage → album**
 
 ```yaml
-# Global defaults
+# settings.yaml — global defaults
 grid:
   columns: 3 # number of columns (default: 3)
   gap: 12 # gap in pixels (default: 12)
-  aspectRatio: '1' # "1", "3/2", "auto", etc. (default: "1")
-  layout: masonry # "masonry" | "uniform" | "showcase" | "filmstrip" | "editorial-flow"
+  aspectRatio: '1' # "1", "3/2", "2/3", "16/9", "auto" (default: "1")
+  layout: masonry
+```
 
+```yaml
+# gallery.yaml — per-subpage override
 subpages:
   - name: Japan
-    grid: # per-subpage override
+    grid:
       columns: 4
       layout: uniform
       aspectRatio: '3/2'
     albums:
-      - ...
+      - '33333333-3333-3333-3333-333333333333'
 ```
 
-## EXIF on Hover
+Available layouts: `masonry`, `uniform`, `showcase`, `filmstrip`,
+`editorial-flow`, `justified` (experimental), and `essay`
+(see [Journal & Photo Essays](journal.md)). Each is illustrated in the
+**[Theming guide](theming.md#gridlayout)**.
 
-Show camera/lens/settings when hovering over photos (enabled by default):
+## Site Behaviour
+
+Feature toggles in `settings.yaml`:
 
 ```yaml
-exifOnHover: false # set to false to disable
+title: 'My Portfolio'
+subtitle: 'A visual journal'
+lang: 'en'
+
+exifOnHover: true # camera/lens/settings on photo grid hover
+map: true # the interactive world map at /map
+transitions: true # smooth page transitions between routes
+scrollToTop: true # floating back-to-top arrow on long pages
+analytics: true # cookieless view counts, see below
+
+about:
+  enabled: true # the /about page, rendered from content/about.md
 ```
+
+| Key             | Default | Notes                                       |
+| --------------- | ------- | ------------------------------------------- |
+| `lang`          | `en`    | `<html lang>` and date formatting           |
+| `exifOnHover`   | on      |                                             |
+| `map`           | **off** | Opt-in: must be set to `true` explicitly    |
+| `transitions`   | on      |                                             |
+| `scrollToTop`   | on      |                                             |
+| `analytics`     | on      |                                             |
+| `about.enabled` | on      | Needs a `content/about.md` to show anything |
+
+### Analytics
+
+Page and album view counts, stored in `content/analytics.json` — no cookies, no
+third party, nothing leaving your server. The numbers are shown in the admin
+panel's **Analytics** tab.
+
+```yaml
+analytics: false # stop counting entirely
+```
+
+With `analytics: false` the tracking endpoint refuses to record, so no data is
+collected regardless of what the browser sends.
+
+## Navigation Links
+
+**Experimental.** External links appended to the header navigation. Only
+`http(s)` URLs are accepted, and they open in a new tab:
+
+```yaml
+navLinks:
+  - label: 'Shop'
+    url: 'https://shop.example.com'
+  - label: 'Instagram'
+    url: 'https://instagram.com/your-handle'
+```
+
+## Client Proofing
+
+Lets a visitor mark favourites and export the selection — for handing a client a
+gallery and getting their picks back. A heart button sits on every photo in the
+grid; once something is picked, a bar appears with a filter and an export
+dialog.
+
+The selection is encoded into the URL as a compact bitmask and mirrored into
+`localStorage`, so **nothing is stored server-side** and a set of picks can be
+shared, bookmarked, or sent back as a plain link.
+
+```yaml
+proofing:
+  enabled: true
+  allowMailto: true # offer "send by email" alongside the copyable list
+```
+
+```yaml
+# gallery.yaml — intended per-subpage switch
+subpages:
+  - name: Client Preview
+    proofing: true
+```
+
+> [!WARNING]
+> **These keys currently have no effect.** The photo grid mounts proofing
+> unconditionally, so the favourite button appears on every album on the site
+> whether or not `proofing.enabled` is set, and `proofing: true` on a subpage
+> changes nothing. `allowMailto` is likewise not read. The keys are parsed and
+> valid — they are simply not consulted yet.
+
+## Image Protection & Watermark
+
+```yaml
+protection:
+  disableRightClick: true # suppress the context menu on images
+  disableImageDrag: true # block drag-to-desktop
+
+watermark:
+  enabled: true
+  text: '© Your Name'
+  opacity: 0.5
+  position: 'bottom-right' # bottom-right | bottom-left | center
+```
+
+> [!NOTE]
+> Both are deterrents against casual copying, not protection. The image is in
+> the browser, and anyone who wants it can take a screenshot. The watermark is
+> an overlay on the lightbox, not burned into the file.
+
+## SEO
+
+```yaml
+seo:
+  title: 'My Portfolio | Photography'
+  description: 'A curated selection of my best photography work.'
+  titleTemplate: '%s | My Portfolio' # %s is the subpage or album title
+  noIndex: false # true → ask search engines not to index the site
+  noFollow: false # true → ask search engines not to follow links
+```
+
+`titleTemplate` shapes the browser and search-result title of every subpage and
+album; the homepage uses `title` unchanged.
 
 ## Footer
 
-Optional minimal footer with social links:
+Optional minimal footer with social links, in `settings.yaml`:
 
 ```yaml
 footer:
@@ -217,6 +471,9 @@ footer:
   email: hello@example.com
   website: https://example.com
 ```
+
+A `legal:` block with `enabled: true` adds an Impressum page at `/impressum` and
+links it in the footer — see `content/settings.yaml.example` for every field.
 
 ## About Page
 
@@ -235,6 +492,26 @@ gear:
 Your bio text here. Supports full Markdown.
 ```
 
+The page is served at `/about` and linked in the navigation. Turn it off in
+`settings.yaml` without deleting the file:
+
+```yaml
+about:
+  enabled: false
+```
+
+The admin panel's **Settings → About** section edits the same file — portrait,
+name, location, gear list and bio — so `about.md` does not have to be written by
+hand.
+
+## Journal & Photo Essays
+
+Long-form storytelling with fullbleed photos, side-by-side pairs, quotes and
+captions lives in `content/journal/`, served at `/journal`. A subpage can also
+be turned into a single photo essay.
+
+→ **[Journal & Photo Essays](journal.md)**
+
 ## Finding UUIDs
 
 - **Album UUIDs**: In Immich, go to Albums → click an album → the UUID is in the URL bar
@@ -246,9 +523,25 @@ Advanced system settings are configured via environment variables in your `.env`
 
 ### Rate Limiting
 
-To protect against brute-force attacks and resource exhaustion, Immich Folio includes an in-memory rate limiter.
+To protect against brute-force attacks and resource exhaustion, Immich Folio includes an in-memory rate limiter. Each endpoint has its own bucket, so heavy image traffic cannot exhaust the budget for the password endpoints.
 
-- `RATE_LIMIT_RPM`: Maximum requests per minute per IP (default: `1500` for general API, `120` for map data).
+- `RATE_LIMIT_RPM`: requests per minute per IP for image, video, EXIF and health requests (default: `1500`).
+
+The endpoints where a high limit would be the wrong default are fixed and not configurable:
+
+| Endpoint               | Limit (req/min/IP) |
+| ---------------------- | ------------------ |
+| `POST /api/admin/auth` | 5                  |
+| `POST /api/auth`       | 10                 |
+| `/api/install`         | 10                 |
+| `/api/og`              | 30                 |
+| `/api/install/albums`  | 30                 |
+| `/api/webhook`         | 60                 |
+| `/api/map`             | 120                |
+
+> [!IMPORTANT]
+> The limiter lives in the process memory of a single instance. It does not
+> coordinate across replicas, and it starts empty after a restart.
 
 ### Trusted Proxies
 

--- a/docs/journal.md
+++ b/docs/journal.md
@@ -1,0 +1,213 @@
+# Journal & Photo Essays
+
+Immich Folio has two ways to publish long-form, text-and-image storytelling. They
+share one Markdown format and one renderer, and differ only in where the result
+appears:
+
+| Feature         | Lives in               | URL               | Use for                                                          |
+| --------------- | ---------------------- | ----------------- | ---------------------------------------------------------------- |
+| **Journal**     | `content/journal/*.md` | `/journal/<slug>` | A running series of stories, listed on a `/journal` index page   |
+| **Photo Essay** | `content/essays/*.md`  | the subpage's URL | Turning one subpage of your gallery into a single narrative page |
+
+If you are unsure: use the **Journal**. A photo essay is the older mechanism and
+is tied to a subpage; the journal is a standalone section with its own index,
+cover images, reading times, and drafts.
+
+**Contents:**
+
+- [Journal Entries](#journal-entries)
+- [Frontmatter](#frontmatter)
+- [Block Syntax](#block-syntax)
+- [Drafts](#drafts)
+- [Password-protected Entries](#password-protected-entries)
+- [Journal Studio](#journal-studio)
+- [Photo Essays on a Subpage](#photo-essays-on-a-subpage)
+
+## Journal Entries
+
+Each entry is one Markdown file in `content/journal/`. The filename is the URL
+slug — `content/journal/iceland-highlands.md` is served at
+`/journal/iceland-highlands`.
+
+A `/journal` link appears in the site navigation automatically as soon as at
+least one **published** (non-draft) entry exists. There is no setting to turn
+the journal on: an empty `content/journal/` directory means no journal.
+
+A template ships with the project:
+
+```bash
+cp content/journal/sample-story.md.example content/journal/my-first-story.md
+```
+
+The template is an `.example` file on purpose — it references no asset IDs
+(those are specific to your Immich server), so copying it gives you a working
+skeleton rather than a page full of broken images.
+
+## Frontmatter
+
+Optional YAML block at the top of the file:
+
+```markdown
+---
+title: 'The Icelandic Highlands'
+subtitle: 'A visual journey across volcanic deserts and arctic silence'
+author: 'Your Name'
+date: '2026-08-05'
+coverAssetId: 'asset-uuid-for-the-cover'
+draft: false
+password: 'clients-only'
+---
+```
+
+| Field          | Description                                                                              |
+| -------------- | ---------------------------------------------------------------------------------------- |
+| `title`        | Entry heading and browser/OG title. Defaults to the slug.                                |
+| `subtitle`     | Subline under the heading; also used as the meta description.                            |
+| `author`       | Shown in the entry byline.                                                               |
+| `date`         | Publication date shown on the index and the entry.                                       |
+| `coverAssetId` | Immich asset UUID used as the index card image and the OG preview image.                 |
+| `draft`        | `true` hides the entry from visitors — see [Drafts](#drafts).                            |
+| `password`     | Gates this single entry — see [Password-protected Entries](#password-protected-entries). |
+
+Reading time and the index excerpt are computed from the text; you do not
+configure them.
+
+## Block Syntax
+
+The parser is deliberately small. It understands headings, paragraphs, quotes
+and photos — one block per blank-line-separated chunk.
+
+### Headings
+
+```markdown
+# Into the Wilderness
+
+## Landmannalaugar
+```
+
+`#` through `######` are supported.
+
+### Text
+
+Plain paragraphs. Inline `**bold**`, `*italic*` and `[links](https://example.com)`
+work; links open in a new tab. Everything else is escaped rather than passed
+through, so a paragraph can never inject HTML into the page.
+
+### Quotes
+
+```markdown
+> Silence in the highlands is a physical weight. -- Anonymous
+```
+
+Text after a `--` separator becomes the attribution line.
+
+### Photos
+
+Photos are referenced by their **Immich asset UUID**, not by a file path:
+
+```markdown
+![asset-uuid:fullbleed](Optional caption)
+![asset-uuid:wide](Optional caption)
+![asset-uuid](Optional caption)
+```
+
+| Suffix       | Width                                         |
+| ------------ | --------------------------------------------- |
+| `:fullbleed` | Edge to edge, breaking out of the text column |
+| `:wide`      | Wider than the text column, but still inset   |
+| _(none)_     | Contained — same width as the text            |
+
+Two UUIDs separated by a comma render as a side-by-side pair, sized to their
+real aspect ratios rather than forced equal:
+
+```markdown
+![asset-uuid-left, asset-uuid-right](Optional caption)
+```
+
+Photos in an entry open in the same lightbox as the rest of the site, with
+keyboard and swipe navigation.
+
+> [!TIP]
+> Writing asset UUIDs by hand is tedious. In the [Journal Studio](#journal-studio),
+> **Add Block → Photo** opens the asset picker and fills the UUID in for you.
+
+## Drafts
+
+`draft: true` in the frontmatter keeps an entry out of the `/journal` index and
+out of the navigation link check — but a logged-in admin still sees it, both in
+the index and at its URL. That makes the draft a preview of the real page rather
+than a separate preview mode.
+
+Drafts are not secret: the entry stays reachable at its URL for anyone who knows
+the slug. Use a `password` if it must not be readable.
+
+## Password-protected Entries
+
+A `password` in the frontmatter puts the entry behind the same gate used for
+subpages and albums. The unlock cookie is `lb_auth_journal_<slug>` and expires
+after 24 hours.
+
+Store a hash rather than the plaintext where possible — the `scrypt:salt:hash`
+format described in [Gallery Configuration](gallery-config.md) applies here too.
+A plaintext password works but is logged as a warning at startup.
+
+## Journal Studio
+
+The admin panel's **Journal** tab is a split-screen editor: blocks on the left,
+a live preview of the real page on the right, with a draggable divider between
+them (mouse, keyboard, and touch).
+
+- **Add Block** — heading, text, quote, photo, or photo pair
+- **Photo picker** — browse your Immich library and insert the asset UUID
+- **Cover image, title, subtitle, author, date, draft, password** — the
+  frontmatter fields, as form controls
+- **Reorder and delete** blocks; each block carries a type chip so a long entry
+  stays scannable
+- **Save** writes `content/journal/<slug>.md` in exactly the format documented
+  above, with a backup of the previous version in `content/journal/.backups/`
+
+Everything the studio writes can be edited by hand afterwards, and vice versa —
+the studio parses the same files.
+
+> [!NOTE]
+> Entries written before the current photo syntax may contain position-based
+> photo references. The studio marks those blocks instead of silently
+> misrendering them, so they can be repointed at an asset UUID.
+
+## Photo Essays on a Subpage
+
+A subpage can render a Markdown essay instead of an album grid. Point it at a
+file, inline the text, or let it build itself from the albums:
+
+```yaml
+subpages:
+  - name: Highlands
+    title: 'Icelandic Highlands'
+    subtitle: 'A Photo Essay'
+    essayFile: 'sample-story' # content/journal/sample-story.md
+    albums:
+      - 'album-uuid-iceland-1'
+```
+
+| Key           | Description                                                                                       |
+| ------------- | ------------------------------------------------------------------------------------------------- |
+| `essayFile`   | A **slug**, not a path — resolved as `content/journal/<slug>.md`, then `content/essays/<slug>.md` |
+| `essayText`   | The essay Markdown inline in `gallery.yaml` — what the admin block editor writes                  |
+| `grid.layout` | `essay` — renders as an essay even without `essayFile` or `essayText`                             |
+
+Any one of the three switches the page into essay mode; setting `essayFile` or
+`essayText` implies it, so `grid.layout: essay` is only needed on its own.
+
+> [!IMPORTANT]
+> `essayFile` takes a bare slug — letters, digits, `-` and `_`. A path such as
+> `content/essays/sample-story.md` is rejected (dots and slashes are not valid
+> slug characters) and the page falls back to the generated essay below.
+
+The Markdown format is identical to a journal entry, including the photo block
+syntax. The admin panel has a visual block editor for `essayText` under the
+subpage's settings.
+
+The album list is used either way: it supplies the photos the lightbox pages
+through. And with `grid.layout: essay` but no Markdown at all, the essay is
+generated from those albums — one heading per album, followed by its photos,
+using each photo's Immich description as the caption.

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -97,7 +97,7 @@ theme:
   photoFrame: none # "none" | "passepartout" | "shadow"
   grain: false # film grain overlay on photos
   headerDot: false # accent-colored dot in the nav bar
-  heroStyle: split # "split" | "fullbleed" | "minimal" | "stacked" | "typographic" | "mosaic"
+  heroStyle: split # "split" | "fullbleed" | "minimal" | "stacked" | "typographic" | "mosaic" | "cover"
 ```
 
 All properties are optional — omitted values fall back to the preset defaults.
@@ -150,6 +150,7 @@ Controls the homepage hero layout:
 - **`stacked`** — full-viewport hero image with title gradient-overlaid at the bottom, horizontal thumbnail navigation strip below
 - **`typographic`** — no hero image; massive centered title with numbered album navigation list (used by Monograph)
 - **`mosaic`** — asymmetric multi-image grid with frosted-glass title overlay centered on top
+- **`cover`** _(experimental)_ — a splash screen: one fullscreen image, the site title and subtitle, and a single **Enter** link into the first navigation entry. The rest of the homepage is not rendered — visitors arrive at a title page and click through.
 
 <table>
   <tr>
@@ -183,15 +184,18 @@ Controls the photo grid layout on album pages:
 - **`showcase`** — first image displayed at full width (16:9), rest in standard grid
 - **`filmstrip`** — horizontal scroll of tall vertical image strips with scroll snapping
 - **`editorial-flow`** — alternating full-width (21:9) and side-by-side (4:3) image pairs
+- **`justified`** _(experimental)_ — row-based: every row fills the container width and all images in a row share one height, so aspect ratios stay intact and nothing is cropped. `columns` sets the density — more columns give shorter rows. The last row keeps its natural sizes rather than stretching.
+- **`essay`** — not a grid: renders the page as a photo essay. See **[Journal & Photo Essays](journal.md)**.
 
-Set it globally in `settings.yaml`, or per subpage in `gallery.yaml`:
+Set it globally in `settings.yaml`, per subpage in `gallery.yaml`, or on a
+single album (experimental) — the three merge, most specific winning:
 
 ```yaml
 grid:
   layout: showcase
 ```
 
-The same album in all five layouts (theme `studio-modern`):
+The same album in five of the grid layouts (theme `studio-modern`):
 
 <table>
   <tr>


### PR DESCRIPTION
## Summary

The documentation still described roughly the v0.10.0 codebase. Everything from the v0.11.0 squash (#432) onward was undocumented: the Journal, the setup wizard, the about editor, the experimental portfolio features from #431, and about half the API surface.

**New — `docs/journal.md`:** Journal vs. photo essays, frontmatter fields, the block syntax (`![asset-uuid:fullbleed](caption)`, photo pairs), drafts, per-entry passwords, and the Journal Studio.

**`docs/gallery-config.md`:** separates `gallery.yaml` from `settings.yaml` (`exifOnHover` and `footer` were filed under gallery structure, where they don't live), adds a full subpage-options table, per-album `grid` and `coverPosition`, a Password Protection section covering the `scrypt:salt:hash` format, plus `navLinks`, watermark/protection, analytics, SEO `titleTemplate` and the about toggle.

**`docs/admin-panel.md`:** rewritten for the four-tab, own-URL panel — the previous version described a single-page panel that no longer exists.

**`docs/theming.md`:** `justified` and `essay` layouts, `cover` hero style.

**`README.md` / `CLAUDE.md` / `CHANGELOG.md`:** What's-New for the unreleased work, feature lists, the complete API route tables, the new `lib/` subsystems, and `WEBHOOK_SECRET` — which was missing from the env documentation entirely.

## Corrections to previously wrong statements

- **`RATE_LIMIT_RPM`** was documented as one global limit. It covers image, video, EXIF and health only; login and setup endpoints carry fixed, much lower constants (admin auth is 5/min). Both docs now list them.
- **`map`** was documented as on by default. It is opt-in — `settings.map === true`.
- **`content/gallery.yaml.example`** shipped `essayFile: "content/essays/sample-story.md"`, which cannot resolve: `essayFile` is a slug and `isValidSlug` rejects dots and slashes, so the page silently fell back to the generated essay. Fixed to the bare slug form and documented.

## Worth a reviewer's attention

Client proofing is documented **as it behaves**, not as intended. `proofing.enabled`, the per-subpage `proofing` flag and `allowMailto` are parsed but never read — `PhotoGrid` mounts `ProofingProvider` unconditionally, so the favourite button is on for every album on every site regardless of configuration. Rather than documenting config that does nothing, the section carries a warning block. Wiring it up is a separate code change.

The only non-`.md` file touched is `content/gallery.yaml.example`.

## Type of change

- [x] 📝 Documentation

## Checklist

- [x] Targets the `dev` branch (see [CONTRIBUTING.md](../CONTRIBUTING.md#branches))
- [x] `npm run build` passes locally
- [x] `npx tsc --noEmit` passes (0 type errors)
- [x] `npx vitest run` passes (426 tests, 32 files, all green)
- [x] No secrets / API keys in diff
- [x] Documentation updated if needed (`docs/`, `README.md`)
- [x] Screenshots attached if there are visual changes — n/a, no visual changes
