### PR TITLE
fix(proofing): honour the proofing config instead of always enabling it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,25 @@ Releases up to and including v0.9.2 are documented in the
 
 ### Fixed
 
+- **Client proofing ignored its own configuration**
+  ([#454](https://github.com/ralksta/immich-folio/pull/454)). The photo grid
+  mounted the proofing provider unconditionally, so the favourite hearts, the
+  selection bar and the export modal appeared on every album on every site.
+  `proofing.enabled` in `settings.yaml`, a subpage's own `proofing:` flag and
+  `allowMailto` were all parsed, validated — and never read.
+
+  They are honoured now, with precedence subpage → global: a subpage's flag
+  wins in either direction, and a page reached without one follows
+  `proofing.enabled`.
+
+  **What changes for an existing site.** `proofing.enabled` defaults to `true`,
+  so albums keep their proofing controls and most sites see no difference. Two
+  cases do change: a site that set `proofing.enabled: false` finally gets what
+  it asked for, and **photo essays no longer show the controls unless their
+  subpage sets `proofing: true` explicitly** — a published story is not an
+  album handover, so the global default deliberately does not reach into
+  essays. Journal entries never show them.
+
 - **Journal photos did not render**
   ([#432](https://github.com/ralksta/immich-folio/pull/432)). Photo blocks
   resolved to nothing, headings sat further left than the body text, fullbleed

--- a/app/[...path]/AlbumDetailView.tsx
+++ b/app/[...path]/AlbumDetailView.tsx
@@ -18,6 +18,10 @@ interface AlbumDetailViewProps {
   heroImageUrl?: string;
   heroBlurDataURL?: string;
   watermark?: LightboxWatermark;
+  /** Client proofing — favorite hearts, selection bar and send-off modal. */
+  proofing?: boolean;
+  /** Offer the "send by email" button in the proofing modal. */
+  allowMailto?: boolean;
 }
 
 /**
@@ -56,6 +60,8 @@ export function AlbumDetailView({
   heroImageUrl,
   heroBlurDataURL,
   watermark,
+  proofing,
+  allowMailto,
 }: AlbumDetailViewProps) {
   const metaDetail = albumMetaDetail(album);
 
@@ -96,7 +102,14 @@ export function AlbumDetailView({
           {metaDetail.gear && <span className="album-header__meta-gear">{metaDetail.gear}</span>}
         </p>
       </div>
-      <PhotoGrid assets={images} layout={layout} gridStyle={gridStyle} watermark={watermark} />
+      <PhotoGrid
+        assets={images}
+        layout={layout}
+        gridStyle={gridStyle}
+        watermark={watermark}
+        proofing={proofing}
+        allowMailto={allowMailto}
+      />
     </>
   );
 }

--- a/app/[...path]/EssayView.tsx
+++ b/app/[...path]/EssayView.tsx
@@ -22,6 +22,8 @@ interface EssayViewProps {
    * published story is not one. Album views opt in.
    */
   proofing?: boolean;
+  /** Offer the "send by email" button in the proofing modal. */
+  allowMailto?: boolean;
 }
 
 function EssayViewContent({
@@ -384,7 +386,7 @@ export function EssayView(props: EssayViewProps) {
   }
 
   return (
-    <ProofingProvider albumTokens={albumTokens}>
+    <ProofingProvider albumTokens={albumTokens} allowMailto={props.allowMailto ?? true}>
       <EssayViewContent {...props} />
     </ProofingProvider>
   );

--- a/app/[...path]/PhotoGrid.tsx
+++ b/app/[...path]/PhotoGrid.tsx
@@ -38,6 +38,14 @@ interface PhotoGridProps {
     'masonry' | 'uniform' | 'showcase' | 'filmstrip' | 'editorial-flow' | 'essay' | 'justified';
   gridStyle?: React.CSSProperties;
   watermark?: LightboxWatermark;
+  /**
+   * Client proofing — favorite hearts, the selection bar and the send-off
+   * modal. Off unless the caller opts in, so a grid rendered outside the
+   * album routes never grows a delivery workflow by accident.
+   */
+  proofing?: boolean;
+  /** Offer the "send by email" button in the proofing modal. */
+  allowMailto?: boolean;
 }
 
 /** Parse `#photo-N` from a hash string. Returns index or null. */
@@ -296,7 +304,7 @@ function PhotoGridInner({ assets, layout = 'masonry', gridStyle, watermark }: Ph
         </div>
       )}
 
-      <ProofingModal />
+      {proofing && <ProofingModal />}
 
       {lightboxIndex !== null && (
         <Lightbox
@@ -315,8 +323,15 @@ function PhotoGridInner({ assets, layout = 'masonry', gridStyle, watermark }: Ph
 export function PhotoGrid(props: PhotoGridProps) {
   const albumTokens = useMemo(() => props.assets.map((a) => a.id), [props.assets]);
 
+  // Without the provider useProofing() returns null, and every proofing control
+  // (hearts in the grid and in the lightbox, selection bar, modal) drops out on
+  // its own.
+  if (!props.proofing) {
+    return <PhotoGridInner {...props} />;
+  }
+
   return (
-    <ProofingProvider albumTokens={albumTokens}>
+    <ProofingProvider albumTokens={albumTokens} allowMailto={props.allowMailto ?? true}>
       <PhotoGridInner {...props} />
     </ProofingProvider>
   );

--- a/app/[...path]/page.tsx
+++ b/app/[...path]/page.tsx
@@ -182,6 +182,12 @@ export default async function PathPage({ params, searchParams }: PathPageProps) 
   const resolveLayout = (overrides?: Partial<GridConfig>) =>
     overrides?.layout ?? config.grid.layout;
 
+  // Client proofing — `proofing.enabled` in settings.yaml is the default and a
+  // subpage's own `proofing:` flag overrides it in either direction. Albums
+  // reached without a subpage follow the global setting.
+  const proofingFor = (subpage?: { proofing?: boolean }) =>
+    subpage?.proofing ?? config.proofing.enabled;
+
   // EXPERIMENTAL: per-album grid override — merged over the subpage grid so
   // the precedence is global < subpage < album.
   const mergeAlbumGrid = (
@@ -241,6 +247,8 @@ export default async function PathPage({ params, searchParams }: PathPageProps) 
         backLinkHref={`/${subpageSlug}`}
         backLinkLabel={`Back to ${subpageName}`}
         watermark={config.watermark}
+        proofing={proofingFor(subpageData?.subpage)}
+        allowMailto={config.proofing.allowMailto}
         {...heroData}
       />
     );
@@ -312,6 +320,11 @@ export default async function PathPage({ params, searchParams }: PathPageProps) 
         };
       }
 
+      // A published story is not an album handover, so an essay only gets the
+      // proofing controls when its subpage asks for them explicitly — the
+      // global default does not reach in here.
+      const essayProofing = result.subpage.proofing === true;
+
       return (
         <EssayView
           essay={essayParsed}
@@ -319,6 +332,8 @@ export default async function PathPage({ params, searchParams }: PathPageProps) 
           title={result.subpage.title || result.subpage.name}
           subtitle={result.subpage.subtitle}
           watermark={config.watermark}
+          proofing={essayProofing}
+          allowMailto={config.proofing.allowMailto}
         />
       );
     }
@@ -358,6 +373,8 @@ export default async function PathPage({ params, searchParams }: PathPageProps) 
           backLinkHref="/"
           backLinkLabel="Back to Gallery"
           watermark={config.watermark}
+          proofing={proofingFor(result.subpage)}
+          allowMailto={config.proofing.allowMailto}
           {...heroData}
         />
       );
@@ -435,6 +452,8 @@ export default async function PathPage({ params, searchParams }: PathPageProps) 
       backLinkHref="/"
       backLinkLabel="Back to Gallery"
       watermark={config.watermark}
+      proofing={proofingFor()}
+      allowMailto={config.proofing.allowMailto}
       {...heroData}
     />
   );

--- a/app/[...path]/page.tsx
+++ b/app/[...path]/page.tsx
@@ -24,7 +24,7 @@ import {
   assetAspectRatio,
 } from '@/lib/urls';
 import { encodeAssetId } from '@/lib/tokens';
-import { getConfig, type GridConfig } from '@/lib/config';
+import { getConfig, resolveProofing, type GridConfig } from '@/lib/config';
 import { isProtected, isAuthenticated } from '@/lib/auth';
 import { isAdminAuthenticated } from '@/lib/admin/auth';
 import PasswordGate from '@/components/PasswordGate';
@@ -186,7 +186,7 @@ export default async function PathPage({ params, searchParams }: PathPageProps) 
   // subpage's own `proofing:` flag overrides it in either direction. Albums
   // reached without a subpage follow the global setting.
   const proofingFor = (subpage?: { proofing?: boolean }) =>
-    subpage?.proofing ?? config.proofing.enabled;
+    resolveProofing(subpage, config.proofing.enabled);
 
   // EXPERIMENTAL: per-album grid override — merged over the subpage grid so
   // the precedence is global < subpage < album.

--- a/docs/gallery-config.md
+++ b/docs/gallery-config.md
@@ -407,25 +407,35 @@ The selection is encoded into the URL as a compact bitmask and mirrored into
 `localStorage`, so **nothing is stored server-side** and a set of picks can be
 shared, bookmarked, or sent back as a plain link.
 
+Configured in `settings.yaml`:
+
 ```yaml
 proofing:
-  enabled: true
-  allowMailto: true # offer "send by email" alongside the copyable list
+  enabled: true # hearts, selection bar and export modal (default: true)
+  allowMailto: true # offer "send by email" alongside the copyable list (default: true)
 ```
+
+A subpage overrides `enabled` in either direction — useful to keep proofing off
+across a public portfolio and switch it on for a single client handover:
 
 ```yaml
-# gallery.yaml — intended per-subpage switch
+# gallery.yaml
 subpages:
-  - name: Client Preview
-    proofing: true
+  - name: Wedding – Smith
+    password: clientpass123
+    proofing: true # or `false` to disable it on this subpage only
+    albums:
+      - ...
 ```
 
-> [!WARNING]
-> **These keys currently have no effect.** The photo grid mounts proofing
-> unconditionally, so the favourite button appears on every album on the site
-> whether or not `proofing.enabled` is set, and `proofing: true` on a subpage
-> changes nothing. `allowMailto` is likewise not read. The keys are parsed and
-> valid — they are simply not consulted yet.
+Precedence is **subpage → global**: a subpage's own `proofing:` wins, and an
+album reached without a subpage follows `proofing.enabled`.
+
+> [!NOTE]
+> Photo essays are the exception. A published story is not an album handover,
+> so an essay (`layout: essay`, `essayFile`, `essayText`) shows the proofing
+> controls only when its subpage sets `proofing: true` **explicitly** — the
+> global default does not reach into essays. Journal entries never show them.
 
 ## Image Protection & Watermark
 

--- a/lib/__tests__/proofing-resolution.test.ts
+++ b/lib/__tests__/proofing-resolution.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock env.ts so importing config.ts doesn't trigger validation
+vi.mock('@/lib/env', () => ({
+  env: {
+    IMMICH_API_URL: 'http://localhost:2283',
+    IMMICH_API_KEY: 'test-key',
+    SITE_TITLE: 'Test Gallery',
+    SITE_SUBTITLE: '',
+    CACHE_TTL: 300,
+    IMMICH_TIMEOUT_MS: 15000,
+    RATE_LIMIT_RPM: 120,
+    TRUSTED_PROXY_HOPS: 0,
+  },
+}));
+
+import { resolveProofing } from '@/lib/config';
+
+/**
+ * Client proofing hands a gallery to a client and takes their picks back, so
+ * whether it is on is a delivery decision, not a cosmetic one. The controls
+ * were previously mounted unconditionally and these settings were inert; these
+ * cover the precedence now that they are honoured.
+ */
+describe('resolveProofing', () => {
+  it('falls back to the global setting when the subpage says nothing', () => {
+    expect(resolveProofing(undefined, true)).toBe(true);
+    expect(resolveProofing(undefined, false)).toBe(false);
+    expect(resolveProofing({}, true)).toBe(true);
+    expect(resolveProofing({}, false)).toBe(false);
+  });
+
+  it('lets a subpage switch proofing on against a global off', () => {
+    // The client-handover case: proofing off across a public portfolio, on for
+    // the one subpage that is a delivery.
+    expect(resolveProofing({ proofing: true }, false)).toBe(true);
+  });
+
+  it('lets a subpage switch proofing off against a global on', () => {
+    // The regression guard: `||` instead of `??` would silently discard this,
+    // leaving hearts on a page that explicitly asked for none.
+    expect(resolveProofing({ proofing: false }, true)).toBe(false);
+  });
+
+  it('treats an explicit false as a decision, not as absence', () => {
+    // Same distinction stated directly — `proofing: false` must not read as
+    // "unset" and inherit the global default.
+    expect(resolveProofing({ proofing: false }, true)).not.toBe(resolveProofing(undefined, true));
+  });
+});

--- a/lib/config/index.ts
+++ b/lib/config/index.ts
@@ -77,6 +77,26 @@ export function buildSubpageGrid(raw?: {
 }
 
 /**
+ * Whether client proofing is on for a page.
+ *
+ * Precedence is subpage → global, the same shape `buildSubpageGrid` gives the
+ * grid: a subpage's own `proofing:` wins in either direction, and a page
+ * reached without one follows `proofing.enabled` from settings.yaml. `??`
+ * rather than `||` is load-bearing — `proofing: false` on a subpage has to
+ * override a global `true`, which `||` would discard.
+ *
+ * Photo essays deliberately do not use this: a published story is not an album
+ * handover, so it requires an explicit `proofing: true` and ignores the global
+ * default. That exception lives at its call site in app/[...path]/page.tsx.
+ */
+export function resolveProofing(
+  subpage: { proofing?: boolean } | undefined,
+  globalEnabled: boolean,
+): boolean {
+  return subpage?.proofing ?? globalEnabled;
+}
+
+/**
  * EXPERIMENTAL: keep only nav links that are safe to render as header <a>
  * tags. Non-http(s) schemes (javascript:, data:) and incomplete entries are
  * dropped with a warning rather than throwing — a bad external link should


### PR DESCRIPTION
## Summary

The client-proofing configuration was parsed but never consulted, so proofing was unconditionally on for every photo grid.

- `PhotoGrid.tsx` wrapped every grid in `<ProofingProvider>` and always mounted `<ProofingModal />`, so the favourite heart, the selection bar and the export modal rendered regardless of `proofing.enabled` in `settings.yaml` or a subpage's `proofing:` flag.
- `proofing.allowMailto` was inert too — `ProofingProvider` accepts an `allowMailto` prop (default `true`) and no caller ever passed it.
- `EssayView.tsx` *did* gate its modal behind a `proofing` prop, but `page.tsx` never passed the prop, so essays never showed the controls at all.

**What changed**

- `PhotoGrid` gained `proofing` / `allowMailto` props and only mounts `ProofingProvider` when proofing is on. Without the provider `useProofing()` returns `null`, so the grid heart, the lightbox heart and the selection bar drop out on their own; `<ProofingModal />` is now gated as well.
- `AlbumDetailView` passes both props through.
- `EssayView` gained `allowMailto` and forwards it to the provider.
- `page.tsx` resolves the flags once (`subpage?.proofing ?? config.proofing.enabled`) and passes them at all three `AlbumDetailView` call sites plus the `EssayView` one.
- `docs/gallery-config.md` gained a **Client Proofing** section — the file had no proofing documentation at all.

## Notes for reviewers

**One judgment call:** for the essay branch I pass `result.subpage.proofing === true` rather than the resolved global default. `EssayView`'s own doc comment states proofing is deliberately off for published stories and that album views opt in, so an essay now needs an explicit `proofing: true` on its subpage. Journal entries render `EssayView` without the prop and stay off. Say the word if you'd rather essays follow the global default like albums do.

Precedence everywhere else: per-subpage `proofing:` overrides `proofing.enabled` in either direction; standalone albums follow the global setting.

## Type of change

- [x] 🐛 Bug fix
- [x] 📝 Documentation

## Checklist

- [x] Targets the `dev` branch (see [CONTRIBUTING.md](../CONTRIBUTING.md#branches))
- [x] `npm run build` passes locally
- [x] `npx tsc --noEmit` passes (0 type errors)
- [x] `npx vitest run` passes (426/426 green)
- [x] No secrets / API keys in diff
- [x] Documentation updated if needed (`docs/`, `README.md`)
- [ ] Screenshots attached if there are visual changes

ESLint reports 9 `prettier/prettier` errors across the touched files. All 9 are pre-existing on this branch (identical set with my changes stashed) and are already fixed on `dev` by ca057ac, so they should disappear on merge.

**Not verified in a browser:** this worktree has no `content/gallery.yaml` or Immich credentials, so the dev server would only render the setup screen. The behaviour change is server-side prop threading plus conditional mounting; a reviewer with a live instance may want to confirm the hearts disappear with `proofing.enabled: false`.