### PR TITLE
release: v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Releases up to and including v0.9.2 are documented in the
 
 ## [Unreleased]
 
+## [0.11.0] — 2026-08-15
+
 ### Added
 
 - **Journal** ([#432](https://github.com/ralksta/immich-folio/pull/432)). A
@@ -123,6 +125,20 @@ Releases up to and including v0.9.2 are documented in the
   `content/` read-only: the wizard, the admin panel and the backup rotation all
   write into it, and `:ro` silently breaks all three.
 - **Contributors are credited in the README.**
+- **The documentation was brought back in line with `dev`**
+  ([#452](https://github.com/ralksta/immich-folio/pull/452),
+  [#453](https://github.com/ralksta/immich-folio/pull/453)). The README is
+  restructured and `studio-modern` is documented as the default preset, which it
+  had already become in the code.
+- **The journal guide has screenshots**
+  ([#455](https://github.com/ralksta/immich-folio/pull/455),
+  [#456](https://github.com/ralksta/immich-folio/pull/456),
+  [#457](https://github.com/ralksta/immich-folio/pull/457)). The one guide
+  describing a visual editor had no picture of it. `scripts/screenshots.ts`
+  gained a `journal` section that writes throwaway entries from real albums,
+  shoots the index, a rendered entry, the entry list and the studio — including
+  its draft and password states and the Story Settings form — and deletes them
+  again, so a run never leaves a demo story on a live site.
 
 ### Fixed
 
@@ -201,6 +217,11 @@ Nothing user-facing; recorded so the next release notes are complete.
   transitively through Next, and 0.35 moved from `export =` to ESM: the module
   namespace stopped being callable and the factory moved to `.default`. The
   Next bump above would otherwise have broken `npx tsc --noEmit`.
+- **Prettier was run across the tree**
+  ([#450](https://github.com/ralksta/immich-folio/pull/450)), and the eslint
+  errors that pass uncovered were cleared
+  ([#451](https://github.com/ralksta/immich-folio/pull/451)). The formatting
+  churn is in one commit of its own, so it does not sit inside a feature diff.
 - Dev-dependency bumps: prettier 3.9.6, eslint 9.39.5, `@types/leaflet` 1.9.22,
   and `github/codeql-action` v4.
 

--- a/README.md
+++ b/README.md
@@ -328,8 +328,8 @@ own password, separate from any album passwords, and writes straight to
 
 ## What's New
 
-Unreleased, since v0.10.0 — a first-run wizard, a journal, and a set of
-experimental portfolio features:
+v0.11.0 — a first-run wizard, a journal, and a set of experimental portfolio
+features:
 
 - **First-run setup wizard at `/install`** — configure a fresh deployment from the browser instead of writing config files → [First-Run Setup](#first-run-setup)
 - **Journal** — photo essays and travel stories at `/journal`, with a split-screen block editor, drafts, per-entry passwords and cover images → [Journal guide](docs/journal.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "immich-lightbox",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "immich-lightbox",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "immich-lightbox",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Release preparation. No code changes.

## Why the version jumps to 0.11.0

The version had drifted. `package.json` said `0.10.0` on **both** `main` and `dev`, and the newest tag is `v0.10.0` — while commit `2fe1157` ("release: v0.11.0", #432) only wrote changelog entries: no bump, no tag. Everything under `[Unreleased]` is therefore the 0.11.0 content:

journal + Journal Studio, about page editor, first-run install wizard, per-album sorting, favicon upload, the experimental portfolio features, and the security fixes from #423 and #432.

## What this changes

- `package.json` + lockfile → `0.11.0`
- `CHANGELOG.md`: `[Unreleased]` closed as `[0.11.0] — 2026-08-15`, plus the entries that were still missing — docs #452, #453 and #455–#457 under *Documentation*, the formatting pass #450 and the lint fixes #451 under *Internal*
- `README.md`: the "What's New" section names the release instead of saying "Unreleased, since v0.10.0"

## After this merges

1. `dev` → `main`
2. Tag `v0.11.0` on `main` and publish the release — that triggers `docker-publish.yml`, which pushes the image as `latest`

Worth checking before the tag, since neither is covered by CI: the **install wizard on a fresh deployment** (empty `content/`, no credentials) and a local **`docker build`** — a Dockerfile problem would only surface after the release is published.

## Type of change

- [x] 🔖 Release

## Checklist

- [x] Targets the `dev` branch
- [x] `npx tsc --noEmit` passes (0 type errors)
- [x] `npx vitest run` — 435 tests pass
- [x] `npm run build` succeeds
- [x] `npm run lint` — 0 errors
- [x] `npm run format:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)