### PR TITLE
chore: catch a failing root layout, fix the package name, correct CLAUDE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,20 @@ Releases up to and including v0.9.2 are documented in the
   will see its subpage cover grids change on upgrade.** That is the point of the
   change; to keep two-up covers, set `grid.columns: 2` on the subpage.
 
+### Fixed
+
+- **A failing site no longer renders a blank page.** `app/error.tsx` is rendered
+  _inside_ the root layout, so it could never catch the layout itself throwing —
+  and the layout is what reads the configuration and the request headers. The
+  new `app/global-error.tsx` replaces the whole document with a readable
+  message and a retry, self-contained so it works without the stylesheet or the
+  theme variables.
+
+### Changed
+
+- The package is named `immich-folio` instead of `immich-lightbox`, which it had
+  kept from before the rename. Only visible when working on the source.
+
 ## [0.11.0] — 2026-08-15
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,9 @@ Fixed routes outside the catch-all: `/about`, `/map`, `/impressum`, `/journal`, 
 
 ### Proofing (`lib/proofing.ts`, `components/ProofingContext.tsx`)
 
-Client-side favourite selection encoded as a bitmask in the URL and mirrored to `localStorage`; nothing is stored server-side. Note that `PhotoGrid` mounts `ProofingProvider` unconditionally — the `proofing.enabled` / per-subpage `proofing` config keys are parsed but not consulted, so the feature is currently always on for grids.
+Client-side favourite selection encoded as a bitmask in the URL and mirrored to `localStorage`; nothing is stored server-side.
+
+Whether it is offered is resolved server-side: `resolveProofing()` (`lib/config/index.ts`) treats `proofing.enabled` in `settings.yaml` as the default and lets a subpage's own `proofing:` flag override it in either direction; albums reached without a subpage follow the global setting (`lib/__tests__/proofing-resolution.test.ts`). The resolved boolean is passed down as a prop — `PhotoGrid` only mounts `ProofingProvider` when it is true, and without the provider `useProofing()` returns null and every proofing control disappears. `EssayView` takes the same prop but defaults it to **off**: proofing is a delivery workflow for album handovers, and hearts interrupt a story.
 
 ### Analytics
 

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useEffect } from 'react';
+
+/**
+ * The last resort: rendered when the root layout itself throws, which
+ * `app/error.tsx` cannot catch — it is rendered *inside* that layout. The
+ * layout reads the config and the request headers, so this is not a theoretical
+ * case; without this file such a failure renders a blank page.
+ *
+ * Everything here is deliberately self-contained: it replaces the whole
+ * document, so `globals.css` and the theme custom properties are not
+ * guaranteed to be in scope. No config lookup, no `next/link` (there is no
+ * router shell to speak of), no shared components. Same wording as
+ * `app/error.tsx`, which explains why it does not name a cause: production
+ * builds replace the message with a digest, so the component genuinely cannot
+ * tell an Immich outage from anything else.
+ */
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('[Folio] Root layout render failed:', error);
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body
+        style={{
+          margin: 0,
+          minHeight: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: '#0c0c0c',
+          color: '#ededed',
+          colorScheme: 'dark',
+          fontFamily: 'system-ui, -apple-system, Segoe UI, Roboto, sans-serif',
+          padding: '24px',
+        }}
+      >
+        <main style={{ maxWidth: '32rem', textAlign: 'center' }}>
+          <h1 style={{ fontSize: '1.5rem', fontWeight: 500, margin: '0 0 12px' }}>
+            Something went wrong
+          </h1>
+          <p style={{ margin: '0 0 24px', lineHeight: 1.6, opacity: 0.75 }}>
+            This site could not be loaded right now. It is usually temporary — try again in a
+            moment.
+          </p>
+          <div style={{ display: 'flex', gap: '12px', justifyContent: 'center' }}>
+            <button
+              type="button"
+              onClick={reset}
+              style={{
+                padding: '10px 20px',
+                border: '1px solid #ededed',
+                borderRadius: '4px',
+                background: 'transparent',
+                color: 'inherit',
+                font: 'inherit',
+                cursor: 'pointer',
+              }}
+            >
+              Try again
+            </button>
+            {/* A plain <a>, not next/link: a full document request is exactly
+                what is wanted here — a client-side transition would stay inside
+                the tree whose root layout just failed. */}
+            {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+            <a
+              href="/"
+              style={{
+                padding: '10px 20px',
+                border: '1px solid transparent',
+                borderRadius: '4px',
+                color: 'inherit',
+                textDecoration: 'none',
+                opacity: 0.6,
+              }}
+            >
+              Back to the gallery
+            </a>
+          </div>
+          {error.digest && (
+            <p style={{ marginTop: '24px', fontSize: '0.8rem', opacity: 0.4 }}>
+              Reference: {error.digest}
+            </p>
+          )}
+        </main>
+      </body>
+    </html>
+  );
+}

--- a/docs/brainstorm-2026-08-05.md
+++ b/docs/brainstorm-2026-08-05.md
@@ -271,10 +271,11 @@ gibt, überhaupt PRs zu stellen.
 
 ---
 
-### B8. Kleinigkeit: Projektname in `package.json` — **XS**
+### B8. Kleinigkeit: Projektname in `package.json` — **XS** — ✅ erledigt
 
 `"name": "immich-lightbox"` bei einem Projekt namens Immich Folio. Fällt jedem
-Contributor beim ersten `npm install` auf.
+Contributor beim ersten `npm install` auf. Heißt seit dem Housekeeping-PR
+`immich-folio`.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "immich-lightbox",
+  "name": "immich-folio",
   "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "immich-lightbox",
+      "name": "immich-folio",
       "version": "0.11.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "immich-lightbox",
+  "name": "immich-folio",
   "version": "0.11.0",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
## Why

Three loose ends that had outlived their release, none of them worth a PR on its own.

## What changed

**1. `app/global-error.tsx` — a failing root layout no longer renders a blank page**

`app/error.tsx` is rendered *inside* the root layout, so it can never catch that layout throwing. And the layout is the part that reads the configuration and the request headers, which makes this the failure mode most likely to hit a misconfigured deployment. Until now it produced a blank document.

The new file replaces the whole document: its own `<html>`/`<body>`, inline styles, no config lookup, no `next/link`. None of that is guaranteed to work in a tree whose root just failed — and a plain `<a href="/">` is the right call anyway, since a full document request is what you want, not a client transition inside the broken tree. The wording matches `error.tsx`, including the reason it does not name a cause: production builds replace the message with a digest.

Verified against a production build with a temporary `throw` in the layout: HTTP 500, page renders "Something went wrong", retry button and the digest reference. The throw was removed again.

**2. `package.json` is named `immich-folio`**

It still carried `immich-lightbox` from before the project rename — the first thing a contributor sees on `npm install`. `docs/brainstorm-2026-08-05.md` tracked this as item B8 and ticks it off.

**3. The Proofing section in `CLAUDE.md` was out of date**

It claimed `PhotoGrid` mounts `ProofingProvider` unconditionally and that the `proofing` config keys are parsed but never consulted. Both stopped being true with #454: `resolveProofing()` resolves global setting vs. per-subpage override server-side, the boolean is passed down as a prop, and without it no provider is mounted. Replaced with what the code actually does.

## Testing

- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors
- `npm run test:unit` — 443 passed
- `npm run build` — passes
- `global-error.tsx` verified in a browser against a production build, as described above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
