### PR TITLE
feat(i18n): translate the visitor UI (DE/EN)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,21 @@ Fixed routes outside the catch-all: `/about`, `/map`, `/impressum`, `/journal`, 
 - Author markdown is escaped, never filtered — `sanitizeHtml` runs first and the renderer only emits tags it builds itself.
 - Drafts (`draft: true`) are hidden from the index and the nav check, but remain visible to an authenticated admin. Entry passwords use the `lb_auth_journal_<slug>` cookie.
 
+### Internationalisation (`lib/i18n/`)
+
+Visitor-facing strings are read off a dictionary picked by `settings.yaml: lang`. No framework, no route prefixes — a self-hosted portfolio serves one language.
+
+- `lib/i18n/locales/en.ts` is the reference locale; `Dictionary = typeof en`, so `de.ts` (typed as `Dictionary`) fails the type-check when a key is added and not translated. Values are plain strings, or functions when a count or name is interpolated — pluralisation belongs to the locale ("Alben", not "Albums").
+- `lib/i18n/index.ts` — **client-safe** (no `fs`): `resolveLocale()` (drops the region subtag, falls back to `en`), `getDictionary()`, `SUPPORTED_LOCALES`.
+- `lib/i18n/server.ts` — server only; reaches into `lib/config` and therefore `fs`. Same split as `lib/journal.ts` vs `lib/admin/journal-service.ts`: importing it from a client component breaks the build.
+- Server components call `getServerDictionary()`. Client components take the locale from `components/I18nProvider.tsx` (mounted in the root layout) and call `useDictionary()` — only the locale string crosses the boundary, since dictionaries hold functions and would not serialise.
+
+`<html lang>` keeps the raw configured value, so a `lang: fr` deployment is marked French and shows the English interface rather than lying about its language. The admin panel is deliberately untranslated, and `app/global-error.tsx` stays English because it replaces the root layout and therefore has no provider.
+
+`/impressum` is no longer hardcoded German: the headings come from the dictionary and the footer link reads "Impressum" only under `lang: de`.
+
+`lib/__tests__/i18n.test.ts` walks both dictionaries and fails on a key that was copied but never translated — the type system only catches missing ones.
+
 ### Proofing (`lib/proofing.ts`, `components/ProofingContext.tsx`)
 
 Client-side favourite selection encoded as a bitmask in the URL and mirrored to `localStorage`; nothing is stored server-side.
@@ -199,3 +214,13 @@ Next.js 16 renamed the `middleware` file convention to `proxy`: the file is `pro
 - **Rate-limit all expensive endpoints** — apply `checkRateLimit` from `lib/rate-limit.ts` to any route doing heavy computation or upstream API calls.
 - **Commit style** — Conventional Commits: `feat:`, `fix:`, `security:`, `docs:`, `chore:`.
 - **Route handlers are testable** — `vitest.config.ts` includes `app/**/__tests__/**/*.test.ts`. Logic that lives in a route (auth guards, header sanitisation) belongs in a route-level test; do not extract it into `lib/` purely to make it reachable by the test runner.
+
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/app/[...path]/AlbumDetailView.tsx
+++ b/app/[...path]/AlbumDetailView.tsx
@@ -6,6 +6,7 @@ import type { GridConfig } from '@/lib/config';
 import type { LightboxWatermark } from '@/components/Lightbox';
 import Image from 'next/image';
 import React from 'react';
+import { getServerDictionary } from '@/lib/i18n/server';
 
 interface AlbumDetailViewProps {
   album: ImmichAlbum;
@@ -64,6 +65,7 @@ export function AlbumDetailView({
   allowMailto,
 }: AlbumDetailViewProps) {
   const metaDetail = albumMetaDetail(album);
+  const t = getServerDictionary();
 
   return (
     <>
@@ -95,9 +97,7 @@ export function AlbumDetailView({
           {album.description && <p className="album-header__description">{album.description}</p>}
         </div>
         <p className="album-header__meta">
-          <span className="album-header__meta-count">
-            {images.length} {images.length === 1 ? 'photo' : 'photos'}
-          </span>
+          <span className="album-header__meta-count">{t.common.photos(images.length)}</span>
           {metaDetail.date && <span className="album-header__meta-date"> · {metaDetail.date}</span>}
           {metaDetail.gear && <span className="album-header__meta-gear">{metaDetail.gear}</span>}
         </p>

--- a/app/[...path]/EssayView.tsx
+++ b/app/[...path]/EssayView.tsx
@@ -9,6 +9,7 @@ import { FadeIn } from '@/components/FadeIn';
 import type { ParsedEssay, EssayBlock } from '@/lib/essay';
 import type { PhotoItem } from './PhotoGrid';
 import './essay.css';
+import { useDictionary } from '@/components/I18nProvider';
 
 interface EssayViewProps {
   essay: ParsedEssay;
@@ -34,6 +35,7 @@ function EssayViewContent({
   watermark,
   proofing: proofingEnabled = false,
 }: EssayViewProps) {
+  const t = useDictionary();
   const proofing = useProofing();
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
 
@@ -122,7 +124,7 @@ function EssayViewContent({
                       e.stopPropagation();
                       proofing.toggleFavorite(item.id);
                     }}
-                    aria-label={isFav ? 'Remove favorite' : 'Add favorite'}
+                    aria-label={isFav ? t.proofing.removeFavorite : t.proofing.addFavorite}
                     style={{
                       position: 'absolute',
                       top: '12px',
@@ -205,7 +207,7 @@ function EssayViewContent({
                             e.stopPropagation();
                             proofing.toggleFavorite(item.id);
                           }}
-                          aria-label={isFav ? 'Remove favorite' : 'Add favorite'}
+                          aria-label={isFav ? t.proofing.removeFavorite : t.proofing.addFavorite}
                           style={{
                             position: 'absolute',
                             top: '12px',
@@ -333,7 +335,9 @@ function EssayViewContent({
               cursor: 'pointer',
             }}
           >
-            {proofing.isFilterActive ? 'Show All' : `❤️ ${proofing.favorites.size} Selected`}
+            {proofing.isFilterActive
+              ? t.proofing.showAll
+              : t.proofing.selected(proofing.favorites.size)}
           </button>
           <button
             type="button"
@@ -348,7 +352,7 @@ function EssayViewContent({
               textDecoration: 'underline',
             }}
           >
-            Share & Export
+            {t.proofing.shareExport}
           </button>
         </div>
       )}

--- a/app/[...path]/PhotoGrid.tsx
+++ b/app/[...path]/PhotoGrid.tsx
@@ -14,6 +14,7 @@ import { Lightbox, type LightboxWatermark } from '@/components/Lightbox';
 import { FadeIn } from '@/components/FadeIn';
 import { ProofingProvider, useProofing } from '@/components/ProofingContext';
 import { ProofingModal } from '@/components/ProofingModal';
+import { useDictionary } from '@/components/I18nProvider';
 
 export interface PhotoItem {
   id: string;
@@ -62,6 +63,7 @@ function buildPhotoHash(index: number): string {
 }
 
 function PhotoGridInner({ assets, layout = 'masonry', gridStyle, watermark }: PhotoGridProps) {
+  const t = useDictionary();
   const proofing = useProofing();
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
 
@@ -190,8 +192,8 @@ function PhotoGridInner({ assets, layout = 'masonry', gridStyle, watermark }: Ph
                   e.stopPropagation();
                   proofing.toggleFavorite(asset.id);
                 }}
-                aria-label={isFav ? 'Remove favorite' : 'Add favorite'}
-                title={isFav ? 'Remove favorite' : 'Add favorite'}
+                aria-label={isFav ? t.proofing.removeFavorite : t.proofing.addFavorite}
+                title={isFav ? t.proofing.removeFavorite : t.proofing.addFavorite}
                 style={{
                   position: 'absolute',
                   top: '8px',
@@ -240,7 +242,7 @@ function PhotoGridInner({ assets, layout = 'masonry', gridStyle, watermark }: Ph
         </FadeIn>
       );
     });
-  }, [displayedAssets, layout, openLightbox, proofing]);
+  }, [displayedAssets, layout, openLightbox, proofing, t]);
 
   return (
     <>
@@ -284,7 +286,9 @@ function PhotoGridInner({ assets, layout = 'masonry', gridStyle, watermark }: Ph
               cursor: 'pointer',
             }}
           >
-            {proofing.isFilterActive ? 'Show All' : `❤️ ${proofing.favorites.size} Selected`}
+            {proofing.isFilterActive
+              ? t.proofing.showAll
+              : t.proofing.selected(proofing.favorites.size)}
           </button>
           <button
             type="button"
@@ -299,7 +303,7 @@ function PhotoGridInner({ assets, layout = 'masonry', gridStyle, watermark }: Ph
               textDecoration: 'underline',
             }}
           >
-            Share & Export
+            {t.proofing.shareExport}
           </button>
         </div>
       )}

--- a/app/[...path]/SubpageGridView.tsx
+++ b/app/[...path]/SubpageGridView.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { imageUrl } from '@/lib/urls';
 import { SubpageSectionConfig } from '@/lib/config';
+import { getServerDictionary } from '@/lib/i18n/server';
 
 interface SubpageAlbum {
   id: string;
@@ -32,7 +33,7 @@ interface SubpageGridViewProps {
 }
 
 const pad2 = (n: number) => String(n).padStart(2, '0');
-const photoCount = (n: number) => `${n} ${n === 1 ? 'photo' : 'photos'}`;
+const photoCount = (n: number) => getServerDictionary().common.photos(n);
 
 function AlbumGrid({
   albums,
@@ -55,7 +56,10 @@ function AlbumGrid({
             href={`/${slug}/${album.slug}`}
             className="subpage-grid__item"
             style={ph?.dominantColor ? { backgroundColor: ph.dominantColor } : undefined}
-            aria-label={`${album.albumName}, ${photoCount(album.assetCount)}`}
+            aria-label={getServerDictionary().subpage.coverAria(
+              album.albumName,
+              photoCount(album.assetCount),
+            )}
           >
             <span className="subpage-grid__item-media">
               {album.albumThumbnailAssetId ? (
@@ -115,6 +119,7 @@ export function SubpageGridView({
   const albumMap = new Map(albums.map((a) => [a.id, a]));
   const placeholderMap = new Map(albums.map((a, i) => [a.id, coverPlaceholders[i] ?? null]));
 
+  const t = getServerDictionary();
   const hasSections = sections && sections.length > 0;
   const totalPhotos = albums.reduce((sum, a) => sum + a.assetCount, 0);
 
@@ -125,21 +130,21 @@ export function SubpageGridView({
           <div className="subpage-header__main">
             {index !== undefined && (
               <p className="subpage-header__kicker" aria-hidden="true">
-                {pad2(index)} — Collection
+                {t.subpage.collectionKicker(pad2(index))}
               </p>
             )}
             {title && <h1 className="subpage-title">{title}</h1>}
             {subtitle && <p className="subpage-subtitle">{subtitle}</p>}
           </div>
           <p className="subpage-header__meta" aria-hidden="true">
-            {albums.length} {albums.length === 1 ? 'album' : 'albums'} · {photoCount(totalPhotos)}
+            {t.common.albums(albums.length)} · {photoCount(totalPhotos)}
           </p>
         </header>
       )}
 
       {/* Typographic Table of Contents */}
       {hasSections && (
-        <nav className="subpage-toc" aria-label="Sections">
+        <nav className="subpage-toc" aria-label={t.subpage.sectionsNav}>
           {sections.map((sec, i) => (
             <span key={sec.slug} className="subpage-toc__entry">
               <a href={`#${sec.slug}`} className="subpage-toc__link">

--- a/app/[...path]/loading.tsx
+++ b/app/[...path]/loading.tsx
@@ -5,12 +5,14 @@
  */
 
 import styles from '../loading.module.css';
+import { getServerDictionary } from '@/lib/i18n/server';
 
 export default function Loading() {
+  const t = getServerDictionary();
   return (
     <>
       <div className={styles.heading} aria-hidden="true" />
-      <div className={styles.grid} role="status" aria-label="Loading photos">
+      <div className={styles.grid} role="status" aria-label={t.common.loadingPhotos}>
         {Array.from({ length: 9 }).map((_, i) => (
           <div key={i} className={styles.tile} />
         ))}

--- a/app/[...path]/page.tsx
+++ b/app/[...path]/page.tsx
@@ -34,6 +34,7 @@ import { SubpageGridView } from './SubpageGridView';
 import { EssayView } from './EssayView';
 import { parseEssayMarkdown } from '@/lib/essay';
 import { loadEssayFromFile } from '@/lib/admin/journal-service';
+import { getServerDictionary } from '@/lib/i18n/server';
 
 // Render at request time — requires live Immich connection
 export const dynamic = 'force-dynamic';
@@ -378,7 +379,7 @@ export default async function PathPage({ params, searchParams }: PathPageProps) 
           gridStyle={buildGridStyle(mergeAlbumGrid(album.id, result.subpage.grid))}
           subtitle={result.subpage.subtitle}
           backLinkHref="/"
-          backLinkLabel="Back to Gallery"
+          backLinkLabel={getServerDictionary().common.backToGallery}
           watermark={config.watermark}
           proofing={proofingFor(result.subpage)}
           allowMailto={config.proofing.allowMailto}
@@ -458,7 +459,7 @@ export default async function PathPage({ params, searchParams }: PathPageProps) 
       layout={resolveLayout(mergeAlbumGrid(album.id))}
       gridStyle={buildGridStyle(mergeAlbumGrid(album.id))}
       backLinkHref="/"
-      backLinkLabel="Back to Gallery"
+      backLinkLabel={getServerDictionary().common.backToGallery}
       watermark={config.watermark}
       proofing={proofingFor()}
       allowMailto={config.proofing.allowMailto}

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -11,6 +11,7 @@ import type { Metadata } from 'next';
 import { imageUrl, assetPlaceholder } from '@/lib/urls';
 import { immich } from '@/lib/immich';
 import { getConfig } from '@/lib/config';
+import { getServerDictionary } from '@/lib/i18n/server';
 import { notFound } from 'next/navigation';
 import './about.css';
 
@@ -51,7 +52,8 @@ async function getAboutContent() {
 
 export async function generateMetadata(): Promise<Metadata> {
   const { meta, body } = await getAboutContent();
-  const title = meta.name ? `About — ${meta.name}` : 'About';
+  const t = getServerDictionary();
+  const title = meta.name ? t.about.metaTitle(meta.name) : t.about.title;
   const description = body ? body.slice(0, 160).replace(/\s+/g, ' ').trim() : undefined;
 
   return {
@@ -72,6 +74,7 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function AboutPage() {
   const config = getConfig();
   if (!config.aboutEnabled) notFound();
+  const t = getServerDictionary();
 
   const { meta, body } = await getAboutContent();
 
@@ -86,7 +89,7 @@ export default async function AboutPage() {
         {meta.portrait ? (
           <Image
             src={imageUrl(meta.portrait, 'preview')}
-            alt={meta.name || 'Portrait'}
+            alt={meta.name || t.about.portraitAlt}
             className="about__portrait"
             fill
             sizes="(max-width: 768px) 100vw, 40vw"
@@ -102,7 +105,7 @@ export default async function AboutPage() {
       {/* ── Text ─────────────────────────────────────── */}
       <div className="about__text-col">
         <p className="about__kicker" aria-hidden="true">
-          About
+          {t.about.kicker}
         </p>
         {meta.name && <h1 className="about__name">{meta.name}</h1>}
         {meta.location && <p className="about__location">{meta.location}</p>}
@@ -123,7 +126,7 @@ export default async function AboutPage() {
         {meta.gear && meta.gear.length > 0 && (
           <>
             <hr className="about__rule" />
-            <h2 className="about__section-label">Gear</h2>
+            <h2 className="about__section-label">{t.about.gear}</h2>
             <ul className="about__gear">
               {meta.gear.map((item) => (
                 <li key={item}>{item}</li>

--- a/app/admin/components/SettingsEditor.tsx
+++ b/app/admin/components/SettingsEditor.tsx
@@ -8,6 +8,7 @@ import SaveBar from './SaveBar';
 // Direct import from the theme module, not from '@/lib/config': the config
 // index pulls in `fs` and cannot be bundled into a client component.
 import { DEFAULT_PRESET } from '@/lib/config/theme';
+import { SUPPORTED_LOCALES } from '@/lib/i18n';
 
 interface Settings {
   title?: string;
@@ -537,6 +538,11 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
                   <option value="es">Español (ES)</option>
                   <option value="ja">日本語 (JA)</option>
                 </select>
+                <p className="admin-field-hint">
+                  The visitor-facing interface is translated for {SUPPORTED_LOCALES.join(', ')}.
+                  Other languages still set <code>&lt;html lang&gt;</code> and date formatting, but
+                  show the English interface. The admin panel is always English.
+                </p>
               </div>
 
               <div className="settings-section-divider" />

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react';
 import Link from 'next/link';
+import { useDictionary } from '@/components/I18nProvider';
 
 /**
  * Rendered when a page throws — in practice almost always
@@ -22,22 +23,22 @@ export default function Error({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  const t = useDictionary();
+
   useEffect(() => {
     console.error('[Folio] Page render failed:', error);
   }, [error]);
 
   return (
     <div className="empty-state">
-      <h1 className="empty-state__title">Something went wrong</h1>
-      <p className="empty-state__text">
-        This page could not be loaded right now. It is usually temporary — try again in a moment.
-      </p>
+      <h1 className="empty-state__title">{t.error.errorTitle}</h1>
+      <p className="empty-state__text">{t.error.errorText}</p>
       <div className="empty-state__actions">
         <button type="button" onClick={reset} className="empty-state__button">
-          Try again
+          {t.error.tryAgain}
         </button>
         <Link href="/" className="empty-state__button empty-state__button--quiet">
-          Back to the gallery
+          {t.common.backToGallery}
         </Link>
       </div>
       {error.digest && (
@@ -45,7 +46,7 @@ export default function Error({
           className="empty-state__text"
           style={{ marginTop: 24, fontSize: '0.8rem', opacity: 0.5 }}
         >
-          Reference: {error.digest}
+          {t.error.reference(error.digest)}
         </p>
       )}
     </div>

--- a/app/impressum/page.tsx
+++ b/app/impressum/page.tsx
@@ -7,17 +7,21 @@ import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { getConfig } from '@/lib/config';
 import { BackLink } from '@/components/BackLink';
+import { getServerDictionary } from '@/lib/i18n/server';
 import './impressum.css';
 
-export const metadata: Metadata = {
-  title: 'Impressum',
-  robots: { index: false, follow: true }, // Usually no need to index legal pages
-};
+export function generateMetadata(): Metadata {
+  return {
+    title: getServerDictionary().legal.title,
+    robots: { index: false, follow: true }, // Usually no need to index legal pages
+  };
+}
 
 export const dynamic = 'force-dynamic';
 
 export default function ImpressumPage() {
   const { legal } = getConfig();
+  const t = getServerDictionary();
 
   if (!legal.enabled) {
     notFound();
@@ -26,14 +30,14 @@ export default function ImpressumPage() {
   return (
     <div className="subpage-container">
       <header className="subpage-header">
-        <BackLink href="/" label="Home" />
-        <h1 className="subpage-title">Impressum</h1>
-        <p className="subpage-subtitle">Angaben gemäß § 5 TMG</p>
+        <BackLink href="/" label={t.common.home} />
+        <h1 className="subpage-title">{t.legal.title}</h1>
+        <p className="subpage-subtitle">{t.legal.subtitle}</p>
       </header>
 
       <main className="subpage-content">
         <section className="legal-section">
-          <h2 className="legal-section__title">Anschrift</h2>
+          <h2 className="legal-section__title">{t.legal.address}</h2>
           <p className="legal-section__text">
             {legal.name}
             <br />
@@ -47,43 +51,51 @@ export default function ImpressumPage() {
 
         {(legal.email || legal.phone) && (
           <section className="legal-section">
-            <h2 className="legal-section__title">Kontakt</h2>
+            <h2 className="legal-section__title">{t.legal.contact}</h2>
             <p className="legal-section__text">
               {legal.email && (
                 <>
-                  E-Mail: {legal.email}
+                  {t.legal.email}: {legal.email}
                   <br />
                 </>
               )}
-              {legal.phone && <>Telefon: {legal.phone}</>}
+              {legal.phone && (
+                <>
+                  {t.legal.phone}: {legal.phone}
+                </>
+              )}
             </p>
           </section>
         )}
 
         {(legal.taxId || legal.vatId) && (
           <section className="legal-section">
-            <h2 className="legal-section__title">Steuernummer</h2>
+            <h2 className="legal-section__title">{t.legal.taxSection}</h2>
             <p className="legal-section__text">
               {legal.taxId && (
                 <>
-                  Steuernummer: {legal.taxId}
+                  {t.legal.taxId}: {legal.taxId}
                   <br />
                 </>
               )}
-              {legal.vatId && <>Umsatzsteuer-ID: {legal.vatId}</>}
+              {legal.vatId && (
+                <>
+                  {t.legal.vatId}: {legal.vatId}
+                </>
+              )}
             </p>
           </section>
         )}
 
         {legal.extraInfo && (
           <section className="legal-section">
-            <h2 className="legal-section__title">Weitere Informationen</h2>
+            <h2 className="legal-section__title">{t.legal.extraInfo}</h2>
             <p className="legal-section__text legal-section__text--pre">{legal.extraInfo}</p>
           </section>
         )}
 
         <section className="legal-source">
-          <p>Quelle: Erstellt mit dem Impressum-Generator von eRecht24.</p>
+          <p>{t.legal.source}</p>
         </section>
       </main>
     </div>

--- a/app/journal/[slug]/page.tsx
+++ b/app/journal/[slug]/page.tsx
@@ -19,6 +19,7 @@ import type { PhotoItem } from '@/app/[...path]/PhotoGrid';
 import type { ImmichAsset } from '@/lib/immich';
 import PasswordGate from '@/components/PasswordGate';
 import { BackLink } from '@/components/BackLink';
+import { getServerDictionary } from '@/lib/i18n/server';
 import crypto from 'crypto';
 
 export const dynamic = 'force-dynamic';
@@ -30,11 +31,12 @@ interface JournalDetailPageProps {
 export async function generateMetadata({ params }: JournalDetailPageProps): Promise<Metadata> {
   const { slug } = await params;
   const entry = await readJournalEntry(slug);
-  if (!entry) return { title: 'Not Found' };
+  const t = getServerDictionary();
+  if (!entry) return { title: t.journal.notFound };
 
   const { frontmatter } = entry.parsed;
   const title = frontmatter.title || slug;
-  const description = frontmatter.subtitle || 'Journal entry on Immich Folio';
+  const description = frontmatter.subtitle || t.journal.entryDescription;
 
   const ogImages = frontmatter.coverAssetId
     ? [{ url: imageUrl(frontmatter.coverAssetId, 'preview') }]
@@ -188,7 +190,7 @@ export default async function JournalDetailPage({ params }: JournalDetailPagePro
   return (
     <div style={{ paddingTop: '2rem' }}>
       <div style={{ maxWidth: '1100px', margin: '0 auto', padding: '0 1.5rem 1rem' }}>
-        <BackLink href="/journal" label="Back to Journal" />
+        <BackLink href="/journal" label={getServerDictionary().common.backToJournal} />
       </div>
       <EssayView
         essay={essayForClient}

--- a/app/journal/page.tsx
+++ b/app/journal/page.tsx
@@ -8,14 +8,15 @@ import { immich } from '@/lib/immich';
 import { imageUrl, assetPlaceholder } from '@/lib/urls';
 import { BackLink } from '@/components/BackLink';
 import { IconBook } from '@/components/Icons';
+import { getServerDictionary } from '@/lib/i18n/server';
 import './journal.css';
 
 export const dynamic = 'force-dynamic';
 
-export const metadata: Metadata = {
-  title: 'Journal',
-  description: 'Photo essays, travel stories, and behind-the-scenes journals.',
-};
+export function generateMetadata(): Metadata {
+  const t = getServerDictionary();
+  return { title: t.journal.title, description: t.journal.description };
+}
 
 interface EnrichedJournalEntry extends JournalEntrySummary {
   coverUrl?: string;
@@ -24,6 +25,7 @@ interface EnrichedJournalEntry extends JournalEntrySummary {
 }
 
 export default async function JournalIndexPage() {
+  const t = getServerDictionary();
   const isAuthedAdmin = await isAdminAuthenticated();
   const allEntries = await listJournalEntries();
 
@@ -60,25 +62,23 @@ export default async function JournalIndexPage() {
   return (
     <div className="journal-index-container">
       <div className="journal-index-header">
-        <BackLink href="/" label="Back to Gallery" />
+        <BackLink href="/" label={t.common.backToGallery} />
         <p className="journal-index-header__kicker" aria-hidden="true">
-          Stories &amp; Essays
+          {t.journal.kicker}
         </p>
-        <h1 className="journal-index-header__title">Journal</h1>
-        <p className="journal-index-header__subtitle">
-          Photo essays, visual stories, and field notes.
-        </p>
+        <h1 className="journal-index-header__title">{t.journal.title}</h1>
+        <p className="journal-index-header__subtitle">{t.journal.subtitle}</p>
       </div>
 
       {enrichedEntries.length === 0 ? (
         <div className="journal-empty-state">
-          <p>No journal entries published yet.</p>
+          <p>{t.journal.empty}</p>
         </div>
       ) : (
         <div className="journal-grid">
           {enrichedEntries.map((entry) => {
             const dateStr = entry.frontmatter.date
-              ? new Date(entry.frontmatter.date).toLocaleDateString('en-US', {
+              ? new Date(entry.frontmatter.date).toLocaleDateString(t.dateLocale, {
                   year: 'numeric',
                   month: 'short',
                   day: 'numeric',
@@ -113,9 +113,11 @@ export default async function JournalIndexPage() {
                   <div className="journal-card__meta">
                     {dateStr && <span>{dateStr}</span>}
                     {dateStr && entry.readingTimeMinutes && <span>•</span>}
-                    {entry.readingTimeMinutes && <span>{entry.readingTimeMinutes} min read</span>}
+                    {entry.readingTimeMinutes && (
+                      <span>{t.journal.minRead(entry.readingTimeMinutes)}</span>
+                    )}
                     {entry.frontmatter.draft && (
-                      <span className="journal-card__draft-badge">Draft</span>
+                      <span className="journal-card__draft-badge">{t.journal.draft}</span>
                     )}
                   </div>
 
@@ -134,9 +136,11 @@ export default async function JournalIndexPage() {
                   )}
 
                   <div className="journal-card__footer">
-                    <span className="journal-card__read-more">Read Story →</span>
+                    <span className="journal-card__read-more">{t.journal.readStory}</span>
                     {entry.frontmatter.author && (
-                      <span style={{ opacity: 0.65 }}>by {entry.frontmatter.author}</span>
+                      <span style={{ opacity: 0.65 }}>
+                        {t.journal.by(entry.frontmatter.author)}
+                      </span>
                     )}
                   </div>
                 </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,6 +20,8 @@ import { isInstallPath } from '@/lib/install';
 import { DevToolbarLoader } from '@/components/DevToolbarLoader';
 import AssetProtection from '@/components/AssetProtection';
 import AnalyticsTracker from '@/components/AnalyticsTracker';
+import { I18nProvider } from '@/components/I18nProvider';
+import { resolveLocale, getDictionary } from '@/lib/i18n';
 
 export async function generateMetadata(): Promise<Metadata> {
   const config = getConfigOrNull();
@@ -114,6 +116,8 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   }
 
   const isAdmin = isAdminPath(pathname);
+  const locale = resolveLocale(config.lang);
+  const t = getDictionary(locale);
 
   return (
     <html
@@ -132,49 +136,51 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         <link rel="stylesheet" href={fontsUrl} />
       </head>
       <body>
-        {isAdmin ? (
-          children
-        ) : (
-          <>
-            <a href="#main-content" className="skip-link">
-              Skip to content
-            </a>
-            <header className="header">
-              <nav className="header__nav">
-                {/* Brand wordmark — presets that show it pair it with the dot. */}
-                <span className="header__wordmark" aria-hidden="true">
-                  {config.siteTitle}
-                </span>
-                <Link href="/" className="header__nav-link">
-                  Home
-                </Link>
-                <SubpageNav />
-                {config.aboutEnabled && (
-                  <Link href="/about" className="header__nav-link">
-                    About
+        <I18nProvider locale={locale}>
+          {isAdmin ? (
+            children
+          ) : (
+            <>
+              <a href="#main-content" className="skip-link">
+                {t.nav.skipToContent}
+              </a>
+              <header className="header">
+                <nav className="header__nav">
+                  {/* Brand wordmark — presets that show it pair it with the dot. */}
+                  <span className="header__wordmark" aria-hidden="true">
+                    {config.siteTitle}
+                  </span>
+                  <Link href="/" className="header__nav-link">
+                    {t.nav.home}
                   </Link>
-                )}
-                {config.map && (
-                  <Link href="/map" className="header__nav-link">
-                    Map
-                  </Link>
-                )}
-                <ThemeToggle />
-              </nav>
-            </header>
-            <main id="main-content" tabIndex={-1} className="main">
-              {children}
-            </main>
-            <Footer />
-            {config.scrollToTop && <ScrollToTop />}
-            <AssetProtection
-              disableRightClick={config.protection?.disableRightClick}
-              disableImageDrag={config.protection?.disableImageDrag}
-            />
-            <AnalyticsTracker />
-            {process.env.NODE_ENV === 'development' && <DevToolbarLoader />}
-          </>
-        )}
+                  <SubpageNav />
+                  {config.aboutEnabled && (
+                    <Link href="/about" className="header__nav-link">
+                      {t.nav.about}
+                    </Link>
+                  )}
+                  {config.map && (
+                    <Link href="/map" className="header__nav-link">
+                      {t.nav.map}
+                    </Link>
+                  )}
+                  <ThemeToggle />
+                </nav>
+              </header>
+              <main id="main-content" tabIndex={-1} className="main">
+                {children}
+              </main>
+              <Footer />
+              {config.scrollToTop && <ScrollToTop />}
+              <AssetProtection
+                disableRightClick={config.protection?.disableRightClick}
+                disableImageDrag={config.protection?.disableImageDrag}
+              />
+              <AnalyticsTracker />
+              {process.env.NODE_ENV === 'development' && <DevToolbarLoader />}
+            </>
+          )}
+        </I18nProvider>
       </body>
     </html>
   );

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -3,10 +3,12 @@
  */
 
 import styles from './loading.module.css';
+import { getServerDictionary } from '@/lib/i18n/server';
 
 export default function Loading() {
+  const t = getServerDictionary();
   return (
-    <div className={styles.grid} role="status" aria-label="Loading gallery">
+    <div className={styles.grid} role="status" aria-label={t.common.loadingGallery}>
       {Array.from({ length: 6 }).map((_, i) => (
         <div key={i} className={styles.tile} />
       ))}

--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -8,16 +8,18 @@ import { notFound } from 'next/navigation';
 import { MapView } from '@/components/MapView';
 import { BackLink } from '@/components/BackLink';
 import type { Metadata } from 'next';
+import { getServerDictionary } from '@/lib/i18n/server';
 import './map.css';
 
 export const dynamic = 'force-dynamic';
 
-export const metadata: Metadata = {
-  title: 'Map',
-};
+export function generateMetadata(): Metadata {
+  return { title: getServerDictionary().map.title };
+}
 
 export default function MapPage() {
   const config = getConfig();
+  const t = getServerDictionary();
 
   if (!config.map) {
     notFound();
@@ -42,16 +44,15 @@ export default function MapPage() {
       <div className="map-page">
         <div className="map-page__header">
           <div className="map-page__header-main">
-            <BackLink href="/" label="Back to Gallery" />
+            <BackLink href="/" label={t.common.backToGallery} />
             <p className="map-page__kicker" aria-hidden="true">
-              Where
+              {t.map.kicker}
             </p>
-            <h1 className="map-page__title">Map</h1>
-            <p className="map-page__subtitle">Where the photos were taken</p>
+            <h1 className="map-page__title">{t.map.title}</h1>
+            <p className="map-page__subtitle">{t.map.subtitle}</p>
           </div>
           <p className="map-page__meta" aria-hidden="true">
-            {collectionCount} {collectionCount === 1 ? 'collection' : 'collections'} · {albumCount}{' '}
-            {albumCount === 1 ? 'album' : 'albums'}
+            {t.common.collections(collectionCount)} · {t.common.albums(albumCount)}
           </p>
         </div>
         <MapView />

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { getServerDictionary } from '@/lib/i18n/server';
 
 /**
  * Rendered when a page calls notFound() — i.e. Immich answered and the album
@@ -10,15 +11,14 @@ import Link from 'next/link';
  * crawler) that their content is gone.
  */
 export default function NotFound() {
+  const t = getServerDictionary();
   return (
     <div className="empty-state">
-      <h1 className="empty-state__title">Not found</h1>
-      <p className="empty-state__text">
-        This page does not exist, or the album is no longer published.
-      </p>
+      <h1 className="empty-state__title">{t.error.notFoundTitle}</h1>
+      <p className="empty-state__text">{t.error.notFoundText}</p>
       <div className="empty-state__actions">
         <Link href="/" className="empty-state__button">
-          Back to the gallery
+          {t.common.backToGallery}
         </Link>
       </div>
     </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,6 +11,8 @@ import { getConfig } from '@/lib/config';
 import { imageUrl, assetPlaceholder } from '@/lib/urls';
 import { HeroCarousel } from '@/components/HeroCarousel';
 import { FadeIn } from '@/components/FadeIn';
+import { getServerDictionary } from '@/lib/i18n/server';
+import type { Dictionary } from '@/lib/i18n';
 
 // Render at request time — requires live Immich connection
 export const dynamic = 'force-dynamic';
@@ -19,25 +21,24 @@ type HeroSubpage = { slug: string; name: string; albumCount: number };
 type HeroAlbum = { id: string; slug: string; albumName: string; assetCount: number };
 
 const pad2 = (n: number) => String(n).padStart(2, '0');
-const plural = (n: number, word: string) => `${n} ${word}${n === 1 ? '' : 's'}`;
 
 /**
  * Flatten subpages + standalone albums into one indexed nav list.
  * Every entry carries an index and a count; presets decide what to show.
  */
-function heroNavEntries(subpages: HeroSubpage[], albums: HeroAlbum[]) {
+function heroNavEntries(subpages: HeroSubpage[], albums: HeroAlbum[], t: Dictionary) {
   return [
     ...subpages.map((sp) => ({
       key: `sp-${sp.slug}`,
       href: `/${sp.slug}`,
       label: sp.name,
-      count: plural(sp.albumCount, 'album'),
+      count: t.common.albums(sp.albumCount),
     })),
     ...albums.map((a) => ({
       key: `al-${a.id}`,
       href: `/${a.slug}`,
       label: a.albumName,
-      count: plural(a.assetCount, 'photo'),
+      count: t.common.photos(a.assetCount),
     })),
   ];
 }
@@ -61,9 +62,10 @@ function heroExifLine(asset: ImmichAsset): string | undefined {
 
 /** Shared nav links for hero sections. */
 function HeroNavLinks({ subpages, albums }: { subpages: HeroSubpage[]; albums: HeroAlbum[] }) {
+  const t = getServerDictionary();
   return (
     <>
-      {heroNavEntries(subpages, albums).map((entry, i) => (
+      {heroNavEntries(subpages, albums, t).map((entry, i) => (
         <Link key={entry.key} href={entry.href} className="hero__nav-link">
           <span className="hero__nav-index" aria-hidden="true">
             {pad2(i + 1)}
@@ -111,6 +113,7 @@ function HeroTextContent({
 
 export default async function HomePage() {
   const config = getConfig();
+  const t = getServerDictionary();
 
   if (config.needsSetup) {
     return null;
@@ -141,7 +144,7 @@ export default async function HomePage() {
   // Welcome-page splash: one fullbleed image, the site
   // title, and one link into the portfolio (the first nav entry).
   if (heroStyle === 'cover') {
-    const entries = heroNavEntries(subpages, albums);
+    const entries = heroNavEntries(subpages, albums, t);
     const enterHref = entries[0]?.href ?? '/about';
 
     return (
@@ -158,7 +161,7 @@ export default async function HomePage() {
           )}
           <FadeIn delay={250}>
             <Link href={enterHref} className="hero__cover-enter">
-              Enter
+              {t.home.enter}
               <span className="hero__cover-enter-arrow" aria-hidden="true">
                 →
               </span>
@@ -197,7 +200,7 @@ export default async function HomePage() {
 
   // ── Stacked: fullbleed image + text at bottom + thumbnail strip ─
   if (heroStyle === 'stacked') {
-    const allEntries = heroNavEntries(subpages, albums);
+    const allEntries = heroNavEntries(subpages, albums, t);
 
     return (
       <div className="hero hero--stacked">

--- a/components/BackLink.tsx
+++ b/components/BackLink.tsx
@@ -4,6 +4,7 @@
  */
 
 import Link from 'next/link';
+import { getServerDictionary } from '@/lib/i18n/server';
 
 interface BackLinkProps {
   href: string;
@@ -11,8 +12,9 @@ interface BackLinkProps {
 }
 
 export function BackLink({ href, label }: BackLinkProps) {
+  const t = getServerDictionary();
   return (
-    <Link href={href} className="album-header__back" aria-label={`Back to ${label}`}>
+    <Link href={href} className="album-header__back" aria-label={t.common.backTo(label)}>
       <svg
         aria-hidden="true"
         viewBox="0 0 24 24"

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -5,10 +5,12 @@
 
 import Link from 'next/link';
 import { getConfig } from '@/lib/config';
+import { getServerDictionary } from '@/lib/i18n/server';
 
 export function Footer() {
   const config = getConfig();
   const { footer, legal } = config;
+  const t = getServerDictionary();
 
   // Don't render if no footer config AND no legal config
   if (
@@ -25,7 +27,7 @@ export function Footer() {
           {footer?.name && <span className="footer__name">{footer.name}</span>}
           {legal.enabled && (
             <Link href="/impressum" className="footer__legal-link">
-              Impressum
+              {t.legal.navLabel}
             </Link>
           )}
         </div>

--- a/components/I18nProvider.tsx
+++ b/components/I18nProvider.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+/**
+ * Carries the resolved locale to client components.
+ *
+ * Only the locale string crosses the server/client boundary — dictionaries
+ * contain functions and would not serialise, so `useDictionary()` looks the
+ * object up on the client instead of receiving it as a prop.
+ */
+
+import { createContext, useContext, useMemo } from 'react';
+import { DEFAULT_LOCALE, getDictionary, type Dictionary, type Locale } from '@/lib/i18n';
+
+const LocaleContext = createContext<Locale>(DEFAULT_LOCALE);
+
+export function I18nProvider({ locale, children }: { locale: Locale; children: React.ReactNode }) {
+  return <LocaleContext.Provider value={locale}>{children}</LocaleContext.Provider>;
+}
+
+/** Resolved locale — `DEFAULT_LOCALE` outside a provider. */
+export function useLocale(): Locale {
+  return useContext(LocaleContext);
+}
+
+/** Dictionary for the current locale. */
+export function useDictionary(): Dictionary {
+  const locale = useLocale();
+  return useMemo(() => getDictionary(locale), [locale]);
+}

--- a/components/Lightbox.tsx
+++ b/components/Lightbox.tsx
@@ -19,6 +19,7 @@ import { useSwipe } from '@/hooks/useSwipe';
 import styles from './Lightbox.module.css';
 import { useProofing } from './ProofingContext';
 import { IconHeart } from './Icons';
+import { useDictionary } from './I18nProvider';
 
 export interface LightboxWatermark {
   enabled?: boolean;
@@ -50,6 +51,7 @@ export function Lightbox({
   watermark,
   showExifToggle = true,
 }: LightboxProps) {
+  const t = useDictionary();
   const [showExif, setShowExif] = useState(false);
   const { exifData, exifLoading, fetchExif, clearExif } = useExif();
   const [imageLoaded, setImageLoaded] = useState(false);
@@ -162,15 +164,15 @@ export function Lightbox({
       onTouchEnd={handleTouchEnd}
       role="dialog"
       aria-modal="true"
-      aria-label="Image viewer"
+      aria-label={t.lightbox.viewer}
     >
       {/* Close button */}
       <button
         ref={closeBtnRef}
         className={styles.close}
         onClick={onClose}
-        aria-label="Close"
-        title="Close (Esc)"
+        aria-label={t.lightbox.close}
+        title={t.lightbox.closeTitle}
       >
         <svg
           aria-hidden="true"
@@ -190,8 +192,8 @@ export function Lightbox({
       <button
         className={`${styles.nav} ${styles.navPrev}`}
         onClick={onPrev}
-        aria-label="Previous photo"
-        title="Previous photo (Left arrow)"
+        aria-label={t.lightbox.previous}
+        title={t.lightbox.previousTitle}
       >
         <svg
           aria-hidden="true"
@@ -262,8 +264,8 @@ export function Lightbox({
       <button
         className={`${styles.nav} ${styles.navNext}`}
         onClick={onNext}
-        aria-label="Next photo"
-        title="Next photo (Right arrow)"
+        aria-label={t.lightbox.next}
+        title={t.lightbox.nextTitle}
       >
         <svg
           aria-hidden="true"
@@ -297,11 +299,11 @@ export function Lightbox({
             fontWeight: isFav ? 600 : 400,
           }}
           onClick={() => proofing.toggleFavorite(current.id)}
-          aria-label={isFav ? 'Remove from favorites' : 'Add to favorites'}
-          title={isFav ? 'Remove from favorites' : 'Add to favorites'}
+          aria-label={isFav ? t.proofing.removeFromFavorites : t.proofing.addToFavorites}
+          title={isFav ? t.proofing.removeFromFavorites : t.proofing.addToFavorites}
         >
           <IconHeart size={14} fill={isFav ? 'currentColor' : 'none'} aria-hidden="true" />
-          {isFav ? 'Saved' : 'Favorite'}
+          {isFav ? t.proofing.saved : t.proofing.favorite}
         </button>
       )}
 
@@ -312,10 +314,10 @@ export function Lightbox({
           onClick={handleExifToggle}
           aria-expanded={showExif}
           aria-controls="exif-panel"
-          aria-label="Toggle photo info"
-          title="Toggle photo info (i)"
+          aria-label={t.lightbox.toggleInfo}
+          title={t.lightbox.toggleInfoTitle}
         >
-          {showExif ? 'Hide Info' : 'Info'}
+          {showExif ? t.lightbox.hideInfo : t.lightbox.info}
         </button>
       )}
 
@@ -324,14 +326,14 @@ export function Lightbox({
         <div id="exif-panel" className={styles.exifPanel}>
           {exifLoading ? (
             <div className={styles.exifRow}>
-              <span className={styles.exifLabel}>Loading...</span>
+              <span className={styles.exifLabel}>{t.lightbox.loading}</span>
             </div>
           ) : exifData ? (
             <>
               {exifData.description && <p className={styles.exifCaption}>{exifData.description}</p>}
               {exifData.model && (
                 <div className={styles.exifRow}>
-                  <span className={styles.exifLabel}>Camera</span>
+                  <span className={styles.exifLabel}>{t.lightbox.camera}</span>
                   <span className={styles.exifValue}>
                     {[exifData.make, exifData.model].filter(Boolean).join(' ')}
                   </span>
@@ -339,37 +341,37 @@ export function Lightbox({
               )}
               {exifData.lensModel && (
                 <div className={styles.exifRow}>
-                  <span className={styles.exifLabel}>Lens</span>
+                  <span className={styles.exifLabel}>{t.lightbox.lens}</span>
                   <span className={styles.exifValue}>{exifData.lensModel}</span>
                 </div>
               )}
               {exifData.focalLength && (
                 <div className={styles.exifRow}>
-                  <span className={styles.exifLabel}>Focal Length</span>
+                  <span className={styles.exifLabel}>{t.lightbox.focalLength}</span>
                   <span className={styles.exifValue}>{exifData.focalLength}mm</span>
                 </div>
               )}
               {exifData.fNumber && (
                 <div className={styles.exifRow}>
-                  <span className={styles.exifLabel}>Aperture</span>
+                  <span className={styles.exifLabel}>{t.lightbox.aperture}</span>
                   <span className={styles.exifValue}>ƒ/{exifData.fNumber}</span>
                 </div>
               )}
               {exifData.exposureTime && (
                 <div className={styles.exifRow}>
-                  <span className={styles.exifLabel}>Shutter</span>
+                  <span className={styles.exifLabel}>{t.lightbox.shutter}</span>
                   <span className={styles.exifValue}>{exifData.exposureTime}s</span>
                 </div>
               )}
               {exifData.iso && (
                 <div className={`${styles.exifRow} ${styles.exifRowIso}`}>
-                  <span className={styles.exifLabel}>ISO</span>
+                  <span className={styles.exifLabel}>{t.lightbox.iso}</span>
                   <span className={styles.exifValue}>{exifData.iso}</span>
                 </div>
               )}
               {(exifData.city || exifData.country) && (
                 <div className={styles.exifRow}>
-                  <span className={styles.exifLabel}>Location</span>
+                  <span className={styles.exifLabel}>{t.lightbox.location}</span>
                   <span className={styles.exifValue}>
                     {[exifData.city, exifData.country].filter(Boolean).join(', ')}
                   </span>
@@ -378,7 +380,7 @@ export function Lightbox({
             </>
           ) : (
             <div className={styles.exifRow}>
-              <span className={styles.exifLabel}>No EXIF data available</span>
+              <span className={styles.exifLabel}>{t.lightbox.noExif}</span>
             </div>
           )}
         </div>

--- a/components/MapView.tsx
+++ b/components/MapView.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useEffect, useRef, useState } from 'react';
+import { useDictionary } from './I18nProvider';
 
 /** Escapes special HTML characters to prevent XSS in Leaflet popup templates. */
 function escapeHtml(str: string): string {
@@ -28,6 +29,7 @@ interface MapLocationPublic {
 }
 
 export function MapView() {
+  const t = useDictionary();
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<unknown>(null);
   const [loading, setLoading] = useState(true);
@@ -52,7 +54,7 @@ export function MapView() {
           /* ignore */
         }
         console.error('[Map] API error', res.status, detail);
-        setError(`Failed to load map data (${res.status})`);
+        setError(t.map.loadFailed(res.status));
         setLoading(false);
         return;
       }
@@ -107,7 +109,7 @@ export function MapView() {
             <div class="map-popup__body">
               <h3 class="map-popup__city">${escapeHtml(loc.city)}</h3>
               <p class="map-popup__country">${escapeHtml(loc.country)}</p>
-              <p class="map-popup__count">${loc.photoCount} photo${loc.photoCount === 1 ? '' : 's'}</p>
+              <p class="map-popup__count">${escapeHtml(t.common.photos(loc.photoCount))}</p>
               <div class="map-popup__albums">${albumLinks}</div>
             </div>
           </div>
@@ -135,7 +137,7 @@ export function MapView() {
     init().catch((err) => {
       console.error('[Map] Init error:', err);
       if (!cancelled) {
-        setError('Failed to initialize map');
+        setError(t.map.initFailed);
         setLoading(false);
       }
     });
@@ -147,7 +149,7 @@ export function MapView() {
         mapRef.current = null;
       }
     };
-  }, []);
+  }, [t]);
 
   if (error) {
     return (
@@ -194,7 +196,7 @@ export function MapView() {
             <circle cx="12" cy="12" r="10" strokeOpacity="0.25"></circle>
             <path d="M12 2a10 10 0 0 1 10 10"></path>
           </svg>
-          <p>Loading map…</p>
+          <p>{t.map.loading}</p>
           <style>{`
             @keyframes spin {
               from { transform: rotate(0deg); }

--- a/components/PasswordGate.tsx
+++ b/components/PasswordGate.tsx
@@ -7,6 +7,7 @@
 
 import { useState } from 'react';
 import styles from './PasswordGate.module.css';
+import { useDictionary } from './I18nProvider';
 
 interface PasswordGateProps {
   slug: string;
@@ -15,6 +16,7 @@ interface PasswordGateProps {
 }
 
 export default function PasswordGate({ slug, title, type = 'subpage' }: PasswordGateProps) {
+  const t = useDictionary();
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
@@ -34,11 +36,11 @@ export default function PasswordGate({ slug, title, type = 'subpage' }: Password
       if (res.ok) {
         window.location.reload();
       } else {
-        setError('Incorrect password. Please try again.');
+        setError(t.password.incorrect);
         setPassword('');
       }
     } catch {
-      setError('Unable to verify password. Please try again later.');
+      setError(t.password.failed);
     } finally {
       setLoading(false);
     }
@@ -48,7 +50,7 @@ export default function PasswordGate({ slug, title, type = 'subpage' }: Password
     <div className={styles.gate}>
       <div className={styles.card}>
         <h2 className={styles.title}>{title}</h2>
-        <p className={styles.subtitle}>This gallery is password-protected.</p>
+        <p className={styles.subtitle}>{t.password.subtitle}</p>
 
         <form onSubmit={handleSubmit} className={styles.form}>
           <input
@@ -56,8 +58,8 @@ export default function PasswordGate({ slug, title, type = 'subpage' }: Password
             type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            placeholder="Enter password"
-            aria-label="Enter password"
+            placeholder={t.password.placeholder}
+            aria-label={t.password.placeholder}
             className={styles.input}
             autoFocus
             required
@@ -83,10 +85,10 @@ export default function PasswordGate({ slug, title, type = 'subpage' }: Password
                   <circle cx="12" cy="12" r="10" strokeOpacity="0.25"></circle>
                   <path d="M12 2a10 10 0 0 1 10 10"></path>
                 </svg>
-                Verifying…
+                {t.password.verifying}
               </>
             ) : (
-              'Enter'
+              t.password.submit
             )}
           </button>
         </form>

--- a/components/ProofingContext.tsx
+++ b/components/ProofingContext.tsx
@@ -2,6 +2,7 @@
 
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import { encodeProofBitmask, decodeProofBitmask } from '@/lib/proofing';
+import { useDictionary } from './I18nProvider';
 
 interface ProofingContextType {
   favorites: Set<string>;
@@ -30,6 +31,7 @@ export function ProofingProvider({
   albumName?: string;
   allowMailto?: boolean;
 }) {
+  const t = useDictionary();
   const [favorites, setFavorites] = useState<Set<string>>(new Set());
   const [isFilterActive, setIsFilterActive] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -126,8 +128,12 @@ export function ProofingProvider({
         selectedIndices.push(index + 1);
       }
     });
-    if (selectedIndices.length === 0) return `${albumName}: No photos selected.`;
-    return `${albumName} — Selected Photos (${selectedIndices.length}): #${selectedIndices.join(', #')}`;
+    if (selectedIndices.length === 0) return t.proofing.listEmpty(albumName);
+    return t.proofing.listSummary(
+      albumName,
+      selectedIndices.length,
+      `#${selectedIndices.join(', #')}`,
+    );
   };
 
   return (

--- a/components/ProofingModal.tsx
+++ b/components/ProofingModal.tsx
@@ -3,8 +3,10 @@
 import React, { useState } from 'react';
 import { useProofing } from './ProofingContext';
 import { IconCheck, IconCopy, IconLink } from './Icons';
+import { useDictionary } from './I18nProvider';
 
 export function ProofingModal() {
+  const t = useDictionary();
   const proofing = useProofing();
   const [copiedState, setCopiedState] = useState<'none' | 'link' | 'list'>('none');
 
@@ -36,10 +38,8 @@ export function ProofingModal() {
   };
 
   const handleMailto = () => {
-    const subject = encodeURIComponent(`Photo Selection (${favorites.size} items)`);
-    const body = encodeURIComponent(
-      `Hello,\n\nHere is my photo selection:\n\n${getFormattedList()}\n\nShare Link: ${getProofingUrl()}\n\nBest regards,`,
-    );
+    const subject = encodeURIComponent(t.proofing.mailSubject(favorites.size));
+    const body = encodeURIComponent(t.proofing.mailBody(getFormattedList(), getProofingUrl()));
     window.location.href = `mailto:?subject=${subject}&body=${body}`;
   };
 
@@ -82,12 +82,12 @@ export function ProofingModal() {
           }}
         >
           <h3 style={{ margin: 0, fontSize: '1.2rem', fontWeight: 600 }}>
-            ❤️ Selection ({favorites.size})
+            {t.proofing.modalTitle(favorites.size)}
           </h3>
           <button
             type="button"
             onClick={() => setIsModalOpen(false)}
-            aria-label="Close modal"
+            aria-label={t.proofing.closeModal}
             style={{
               background: 'none',
               border: 'none',
@@ -103,8 +103,7 @@ export function ProofingModal() {
         </div>
 
         <p style={{ fontSize: '0.9rem', opacity: 0.8, marginBottom: '1rem' }}>
-          You have selected {favorites.size} photo{favorites.size === 1 ? '' : 's'}. Choose an
-          export option below to share your selection:
+          {t.proofing.intro(favorites.size)}
         </p>
 
         <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
@@ -127,11 +126,11 @@ export function ProofingModal() {
           >
             {copiedState === 'link' ? (
               <>
-                <IconCheck size={15} aria-hidden="true" /> Link Copied!
+                <IconCheck size={15} aria-hidden="true" /> {t.proofing.linkCopied}
               </>
             ) : (
               <>
-                <IconLink size={15} aria-hidden="true" /> Copy Shareable Link
+                <IconLink size={15} aria-hidden="true" /> {t.proofing.copyLink}
               </>
             )}
           </button>
@@ -155,11 +154,11 @@ export function ProofingModal() {
           >
             {copiedState === 'list' ? (
               <>
-                <IconCheck size={15} aria-hidden="true" /> List Copied!
+                <IconCheck size={15} aria-hidden="true" /> {t.proofing.listCopied}
               </>
             ) : (
               <>
-                <IconCopy size={15} aria-hidden="true" /> Copy Text List (#1, #2...)
+                <IconCopy size={15} aria-hidden="true" /> {t.proofing.copyList}
               </>
             )}
           </button>
@@ -182,14 +181,14 @@ export function ProofingModal() {
                 cursor: 'pointer',
               }}
             >
-              ✉️ Send Email to Photographer
+              {t.proofing.sendEmail}
             </button>
           )}
 
           <button
             type="button"
             onClick={() => {
-              if (confirm('Clear all selected favorites?')) {
+              if (confirm(t.proofing.confirmClear)) {
                 clearFavorites();
                 setIsModalOpen(false);
               }
@@ -204,7 +203,7 @@ export function ProofingModal() {
               opacity: 0.8,
             }}
           >
-            Clear Selection
+            {t.proofing.clearSelection}
           </button>
         </div>
       </div>

--- a/components/ScrollToTop.tsx
+++ b/components/ScrollToTop.tsx
@@ -6,10 +6,12 @@
 'use client';
 
 import { useState, useEffect, useRef } from 'react';
+import { useDictionary } from './I18nProvider';
 
 const SHOW_THRESHOLD = 300;
 
 export function ScrollToTop() {
+  const t = useDictionary();
   const [visible, setVisible] = useState(false);
   const frame = useRef<number | null>(null);
 
@@ -41,8 +43,8 @@ export function ScrollToTop() {
     <button
       className={`scroll-to-top ${visible ? 'scroll-to-top--visible' : ''}`}
       onClick={scrollToTop}
-      aria-label="Scroll to top"
-      title="Scroll to top"
+      aria-label={t.theme.scrollToTop}
+      title={t.theme.scrollToTop}
       type="button"
       tabIndex={visible ? 0 : -1}
       aria-hidden={!visible}

--- a/components/SubpageNav.tsx
+++ b/components/SubpageNav.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link';
 import { immich } from '@/lib/immich';
 import { getConfig } from '@/lib/config';
 import { listJournalEntries } from '@/lib/admin/journal-service';
+import { getServerDictionary } from '@/lib/i18n/server';
 
 export async function SubpageNav() {
   const [subpages, standaloneAlbums, journalEntries] = await Promise.all([
@@ -17,6 +18,7 @@ export async function SubpageNav() {
   // EXPERIMENTAL: external nav links from settings.yaml, appended after the
   // internal entries. Sanitised to http(s) in getConfig().
   const navLinks = getConfig().navLinks;
+  const t = getServerDictionary();
 
   const hasPublicJournal = journalEntries.some((e) => !e.frontmatter.draft);
 
@@ -29,7 +31,7 @@ export async function SubpageNav() {
       ))}
       {hasPublicJournal && (
         <Link href="/journal" className="header__nav-link">
-          Journal
+          {t.nav.journal}
         </Link>
       )}
       {standaloneAlbums.map((album) => (

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -9,6 +9,7 @@
 'use client';
 
 import { useSyncExternalStore, useCallback } from 'react';
+import { useDictionary } from './I18nProvider';
 
 type Theme = 'dark' | 'light';
 
@@ -47,6 +48,8 @@ if (typeof window !== 'undefined') {
 
 export function ThemeToggle() {
   const theme = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+  const t = useDictionary();
+  const label = theme === 'dark' ? t.theme.switchToLight : t.theme.switchToDark;
 
   const toggle = useCallback(() => {
     applyTheme(theme === 'dark' ? 'light' : 'dark');
@@ -56,9 +59,9 @@ export function ThemeToggle() {
     <button
       className="theme-toggle"
       onClick={toggle}
-      aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+      aria-label={label}
       type="button"
-      title={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+      title={label}
     >
       {theme === 'dark' ? (
         // Sun icon

--- a/content/settings.yaml.example
+++ b/content/settings.yaml.example
@@ -6,6 +6,11 @@
 title: "My Portfolio"
 subtitle: "A visual journal"
 
+# Interface language of the visitor-facing site: "en" or "de".
+# Any other value still sets <html lang> and date formatting, but the
+# interface stays English. The admin panel is always English.
+lang: "en"
+
 # ── SEO & Metadata ───────────────────────────────────────────────
 # Optional: Overrides global title/subtitle for search engines and social cards
 # seo:

--- a/docs/gallery-config.md
+++ b/docs/gallery-config.md
@@ -393,13 +393,45 @@ about:
 
 | Key             | Default | Notes                                       |
 | --------------- | ------- | ------------------------------------------- |
-| `lang`          | `en`    | `<html lang>` and date formatting           |
+| `lang`          | `en`    | Interface language, `<html lang>`, dates    |
 | `exifOnHover`   | on      |                                             |
 | `map`           | **off** | Opt-in: must be set to `true` explicitly    |
 | `transitions`   | on      |                                             |
 | `scrollToTop`   | on      |                                             |
 | `analytics`     | on      |                                             |
 | `about.enabled` | on      | Needs a `content/about.md` to show anything |
+
+### Interface language
+
+`lang` picks the language of the visitor-facing interface — navigation, the
+lightbox, the password gate, the proofing dialog, the legal notice, error pages
+— and is also emitted as `<html lang>` and used for date formatting.
+
+| Value | Interface         |
+| ----- | ----------------- |
+| `en`  | English (default) |
+| `de`  | German            |
+
+Any other value (`fr`, `ja`, …) still reaches `<html lang>` and
+`toLocaleDateString`, but the interface stays English: there is no dictionary
+for it yet. That is deliberate — claiming `lang="en"` on a French site would be
+worse for screen readers than an English interface on a page correctly marked
+as French.
+
+Two things stay in one language by design:
+
+- **The admin panel** is always English, whatever `lang` says.
+- **`/impressum`** keeps its German headings when `lang: de` and the § 5 TMG
+  citation in both, because that is what the statute names. Under `lang: en`
+  the footer link reads "Legal Notice" rather than "Impressum" — the page is
+  optional (`legal.enabled`), and an unexplained German word in the footer of
+  an English site is what drove this out of the backlog.
+
+Adding a language means adding one file under `lib/i18n/locales/` and listing
+it in `SUPPORTED_LOCALES` (`lib/i18n/index.ts`). The dictionary is typed
+against the English one, so a missing key fails the type-check rather than
+falling back silently, and `lib/__tests__/i18n.test.ts` additionally catches
+keys that were copied over but never translated.
 
 ### Analytics
 

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -23,7 +23,7 @@ A consolidated list of features and ideas for future versions, cleaned up from e
 - **EXIF analytics page** — Visual breakdown of shooting patterns: most-used focal lengths, aperture distribution.
 - **Before/After slider** — Drag-to-reveal comparison component for retouching showcases.
 - **Watermarking** — Server-side watermark overlay on proxied images.
-- **Internationalization (i18n)** — Multi-language UI support (DE/EN).
+- ~~**Internationalization (i18n)** — Multi-language UI support (DE/EN).~~ Shipped for the visitor UI; the admin panel is still English-only.
 
 ---
 

--- a/lib/__tests__/i18n.test.ts
+++ b/lib/__tests__/i18n.test.ts
@@ -1,0 +1,110 @@
+/**
+ * i18n — locale resolution and dictionary parity.
+ *
+ * The parity walk is the point: `de.ts` is typed as `Dictionary`, so a *missing*
+ * key is already a compile error. What the type cannot catch is a key that was
+ * copied over but never translated, or a plural function that ignores its
+ * argument — both of which ship an English string on a German site.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolveLocale, getDictionary, dictionaryFor, SUPPORTED_LOCALES } from '../i18n';
+import { en } from '../i18n/locales/en';
+import { de } from '../i18n/locales/de';
+
+describe('resolveLocale', () => {
+  it('accepts the supported locales', () => {
+    expect(resolveLocale('en')).toBe('en');
+    expect(resolveLocale('de')).toBe('de');
+  });
+
+  it('drops the region subtag', () => {
+    expect(resolveLocale('de-DE')).toBe('de');
+    expect(resolveLocale('de-AT')).toBe('de');
+    expect(resolveLocale('en_GB')).toBe('en');
+  });
+
+  it('is case- and whitespace-insensitive', () => {
+    expect(resolveLocale('  DE  ')).toBe('de');
+    expect(resolveLocale('De-Ch')).toBe('de');
+  });
+
+  it('falls back to English for languages without a dictionary', () => {
+    expect(resolveLocale('fr')).toBe('en');
+    expect(resolveLocale('ja-JP')).toBe('en');
+    expect(resolveLocale('')).toBe('en');
+    expect(resolveLocale(undefined)).toBe('en');
+    expect(resolveLocale(null)).toBe('en');
+  });
+});
+
+describe('getDictionary', () => {
+  it('returns a dictionary for every supported locale', () => {
+    for (const locale of SUPPORTED_LOCALES) {
+      expect(getDictionary(locale)).toBeDefined();
+    }
+  });
+
+  it('dictionaryFor resolves and looks up in one step', () => {
+    expect(dictionaryFor('de-DE')).toBe(de);
+    expect(dictionaryFor('fr')).toBe(en);
+  });
+});
+
+/** Every leaf of a dictionary, as `['nav.home', 'Home']` pairs. */
+function leaves(obj: object, prefix = ''): [string, unknown][] {
+  return Object.entries(obj).flatMap(([key, value]) => {
+    const path = prefix ? `${prefix}.${key}` : key;
+    return value !== null && typeof value === 'object'
+      ? leaves(value, path)
+      : ([[path, value]] as [string, unknown][]);
+  });
+}
+
+/** Call a dictionary function with plausible arguments for its arity. */
+function invoke(fn: (...args: never[]) => string): string {
+  const args = Array.from({ length: fn.length }, (_, i) => (i === 0 ? 2 : `arg${i}`));
+  return (fn as (...a: unknown[]) => string)(...args);
+}
+
+describe('dictionary parity', () => {
+  const enLeaves = leaves(en);
+  const deLeaves = new Map(leaves(de));
+
+  it('German covers every English key', () => {
+    expect([...deLeaves.keys()].sort()).toEqual(enLeaves.map(([k]) => k).sort());
+  });
+
+  it('matches value kinds — a string never stands in for an interpolator', () => {
+    for (const [path, value] of enLeaves) {
+      expect(typeof deLeaves.get(path), path).toBe(typeof value);
+    }
+  });
+
+  it('leaves no English string untranslated', () => {
+    // Proper nouns and units read the same in both languages; `coverAria` is
+    // pure interpolation with no words of its own.
+    const shared = new Set(['nav.journal', 'journal.title', 'lightbox.iso', 'subpage.coverAria']);
+
+    const identical = enLeaves
+      .filter(([path]) => !shared.has(path))
+      .filter(([path, value]) => {
+        const other = deLeaves.get(path);
+        if (typeof value === 'function') {
+          return invoke(other as (...a: never[]) => string) === invoke(value as never);
+        }
+        return other === value;
+      })
+      .map(([path]) => path);
+
+    expect(identical).toEqual([]);
+  });
+
+  it('plural helpers actually vary on their count', () => {
+    for (const dict of [en, de]) {
+      expect(dict.common.photos(1)).not.toBe(dict.common.photos(2));
+      expect(dict.common.albums(1)).not.toBe(dict.common.albums(2));
+      expect(dict.common.collections(1)).not.toBe(dict.common.collections(2));
+    }
+  });
+});

--- a/lib/i18n/index.ts
+++ b/lib/i18n/index.ts
@@ -1,0 +1,55 @@
+/**
+ * Visitor-facing internationalisation.
+ *
+ * Deliberately not a framework: `settings.yaml: lang` picks one of the
+ * dictionaries in `lib/i18n/locales/`, and every visitor-facing string is read
+ * off that object. No message extraction, no runtime loader, no route prefixes
+ * — a self-hosted portfolio is served in exactly one language.
+ *
+ * This module is **client-safe** (no `fs`). Server components read the language
+ * from the config via `lib/i18n/server.ts`; client components take the resolved
+ * locale from `components/I18nProvider.tsx` and look the dictionary up here.
+ * Both dictionaries are small enough that shipping them together beats a
+ * dynamic import.
+ */
+
+import { en } from './locales/en';
+import { de } from './locales/de';
+
+/** Locales with a dictionary. Anything else falls back to English. */
+export const SUPPORTED_LOCALES = ['en', 'de'] as const;
+
+export type Locale = (typeof SUPPORTED_LOCALES)[number];
+
+export const DEFAULT_LOCALE: Locale = 'en';
+
+/** The shape every dictionary must implement — English is the reference. */
+export type Dictionary = typeof en;
+
+const DICTIONARIES: Record<Locale, Dictionary> = { en, de };
+
+/**
+ * Map a `settings.yaml: lang` value onto a locale we have strings for.
+ *
+ * Region subtags are accepted (`de-AT` → `de`), unknown languages fall back to
+ * English. The raw value still reaches `<html lang>` — a French deployment gets
+ * `lang="fr"` for screen readers and an English UI, which beats claiming to be
+ * English.
+ */
+export function resolveLocale(lang?: string | null): Locale {
+  if (!lang) return DEFAULT_LOCALE;
+  const base = lang.trim().toLowerCase().split(/[-_]/)[0];
+  return (SUPPORTED_LOCALES as readonly string[]).includes(base)
+    ? (base as Locale)
+    : DEFAULT_LOCALE;
+}
+
+/** Dictionary for a locale (already resolved). */
+export function getDictionary(locale: Locale): Dictionary {
+  return DICTIONARIES[locale] ?? DICTIONARIES[DEFAULT_LOCALE];
+}
+
+/** Convenience: resolve a raw `lang` string and return its dictionary. */
+export function dictionaryFor(lang?: string | null): Dictionary {
+  return getDictionary(resolveLocale(lang));
+}

--- a/lib/i18n/locales/de.ts
+++ b/lib/i18n/locales/de.ts
@@ -1,0 +1,170 @@
+/**
+ * German dictionary.
+ *
+ * Typed as `Dictionary` (derived from `en.ts`), so a key added to English but
+ * forgotten here fails the type-check rather than falling through to English
+ * at runtime.
+ */
+
+import type { Dictionary } from '../index';
+
+const plural = (n: number, one: string, other: string) => `${n} ${n === 1 ? one : other}`;
+
+export const de: Dictionary = {
+  dateLocale: 'de-DE',
+
+  nav: {
+    home: 'Start',
+    about: 'Über mich',
+    map: 'Karte',
+    journal: 'Journal',
+    skipToContent: 'Zum Inhalt springen',
+  },
+
+  common: {
+    backTo: (label: string) => `Zurück zu ${label}`,
+    backToGallery: 'Zurück zur Galerie',
+    backToJournal: 'Zurück zum Journal',
+    home: 'Start',
+    photos: (n: number) => plural(n, 'Foto', 'Fotos'),
+    albums: (n: number) => plural(n, 'Album', 'Alben'),
+    collections: (n: number) => plural(n, 'Sammlung', 'Sammlungen'),
+    loadingGallery: 'Galerie wird geladen',
+    loadingPhotos: 'Fotos werden geladen',
+  },
+
+  home: {
+    enter: 'Eintreten',
+  },
+
+  error: {
+    notFoundTitle: 'Nicht gefunden',
+    notFoundText: 'Diese Seite existiert nicht, oder das Album ist nicht mehr veröffentlicht.',
+    errorTitle: 'Etwas ist schiefgelaufen',
+    errorText:
+      'Diese Seite konnte gerade nicht geladen werden. Das ist meist vorübergehend — bitte gleich noch einmal versuchen.',
+    siteErrorText:
+      'Diese Website konnte gerade nicht geladen werden. Das ist meist vorübergehend — bitte gleich noch einmal versuchen.',
+    tryAgain: 'Erneut versuchen',
+    reference: (digest: string) => `Referenz: ${digest}`,
+  },
+
+  theme: {
+    switchToLight: 'Zum hellen Modus wechseln',
+    switchToDark: 'Zum dunklen Modus wechseln',
+    scrollToTop: 'Nach oben',
+  },
+
+  password: {
+    subtitle: 'Diese Galerie ist passwortgeschützt.',
+    placeholder: 'Passwort eingeben',
+    submit: 'Öffnen',
+    verifying: 'Wird geprüft…',
+    incorrect: 'Falsches Passwort. Bitte erneut versuchen.',
+    failed: 'Passwort konnte nicht geprüft werden. Bitte später erneut versuchen.',
+  },
+
+  about: {
+    kicker: 'Über mich',
+    title: 'Über mich',
+    metaTitle: (name: string) => `Über mich — ${name}`,
+    portraitAlt: 'Porträt',
+    gear: 'Ausrüstung',
+  },
+
+  map: {
+    title: 'Karte',
+    kicker: 'Wo',
+    subtitle: 'Wo die Fotos entstanden sind',
+    loading: 'Karte wird geladen…',
+    loadFailed: (status: number) => `Kartendaten konnten nicht geladen werden (${status})`,
+    initFailed: 'Karte konnte nicht initialisiert werden',
+  },
+
+  subpage: {
+    collectionKicker: (index: string) => `${index} — Sammlung`,
+    sectionsNav: 'Abschnitte',
+    coverAria: (albumName: string, count: string) => `${albumName}, ${count}`,
+  },
+
+  journal: {
+    title: 'Journal',
+    kicker: 'Geschichten & Essays',
+    subtitle: 'Fotoessays, visuelle Geschichten und Notizen von unterwegs.',
+    description: 'Fotoessays, Reisegeschichten und Journale hinter den Kulissen.',
+    entryDescription: 'Journal-Eintrag',
+    empty: 'Noch keine Journal-Einträge veröffentlicht.',
+    readStory: 'Geschichte lesen →',
+    minRead: (n: number) => `${n} Min. Lesezeit`,
+    draft: 'Entwurf',
+    by: (author: string) => `von ${author}`,
+    notFound: 'Nicht gefunden',
+  },
+
+  lightbox: {
+    viewer: 'Bildansicht',
+    close: 'Schließen',
+    closeTitle: 'Schließen (Esc)',
+    previous: 'Vorheriges Foto',
+    previousTitle: 'Vorheriges Foto (Pfeil links)',
+    next: 'Nächstes Foto',
+    nextTitle: 'Nächstes Foto (Pfeil rechts)',
+    toggleInfo: 'Fotoinfos ein-/ausblenden',
+    toggleInfoTitle: 'Fotoinfos ein-/ausblenden (i)',
+    hideInfo: 'Infos ausblenden',
+    info: 'Infos',
+    loading: 'Wird geladen...',
+    camera: 'Kamera',
+    lens: 'Objektiv',
+    focalLength: 'Brennweite',
+    aperture: 'Blende',
+    shutter: 'Belichtungszeit',
+    iso: 'ISO',
+    location: 'Ort',
+    noExif: 'Keine EXIF-Daten vorhanden',
+  },
+
+  proofing: {
+    addFavorite: 'Zur Auswahl hinzufügen',
+    removeFavorite: 'Aus Auswahl entfernen',
+    addToFavorites: 'Zur Auswahl hinzufügen',
+    removeFromFavorites: 'Aus Auswahl entfernen',
+    saved: 'Gemerkt',
+    favorite: 'Merken',
+    showAll: 'Alle anzeigen',
+    selected: (n: number) => `❤️ ${n} ausgewählt`,
+    shareExport: 'Teilen & Export',
+    modalTitle: (n: number) => `❤️ Auswahl (${n})`,
+    closeModal: 'Dialog schließen',
+    intro: (n: number) =>
+      `Du hast ${plural(n, 'Foto', 'Fotos')} ausgewählt. Wähle unten eine Export-Option, um deine Auswahl zu teilen:`,
+    copyLink: 'Teilbaren Link kopieren',
+    linkCopied: 'Link kopiert!',
+    copyList: 'Textliste kopieren (#1, #2...)',
+    listCopied: 'Liste kopiert!',
+    sendEmail: '✉️ E-Mail an den Fotografen',
+    clearSelection: 'Auswahl löschen',
+    confirmClear: 'Die gesamte Auswahl löschen?',
+    listEmpty: (albumName: string) => `${albumName}: Keine Fotos ausgewählt.`,
+    listSummary: (albumName: string, count: number, indices: string) =>
+      `${albumName} — Ausgewählte Fotos (${count}): ${indices}`,
+    mailSubject: (n: number) => `Fotoauswahl (${n} Fotos)`,
+    mailBody: (list: string, url: string) =>
+      `Hallo,\n\nhier ist meine Fotoauswahl:\n\n${list}\n\nLink zur Auswahl: ${url}\n\nViele Grüße,`,
+  },
+
+  legal: {
+    navLabel: 'Impressum',
+    title: 'Impressum',
+    subtitle: 'Angaben gemäß § 5 TMG',
+    address: 'Anschrift',
+    contact: 'Kontakt',
+    email: 'E-Mail',
+    phone: 'Telefon',
+    taxSection: 'Steuernummer',
+    taxId: 'Steuernummer',
+    vatId: 'Umsatzsteuer-ID',
+    extraInfo: 'Weitere Informationen',
+    source: 'Quelle: Erstellt mit dem Impressum-Generator von eRecht24.',
+  },
+};

--- a/lib/i18n/locales/en.ts
+++ b/lib/i18n/locales/en.ts
@@ -1,0 +1,170 @@
+/**
+ * English dictionary — the reference locale.
+ *
+ * Every other locale implements the `Dictionary` type derived from this file,
+ * so adding a key here is a type error in `de.ts` until it is translated.
+ * Values are plain strings, or functions when a count or a name is interpolated
+ * (a locale is free to pluralise differently — German "Alben" is not "Albums").
+ */
+
+const plural = (n: number, one: string, other: string) => `${n} ${n === 1 ? one : other}`;
+
+export const en = {
+  /** Passed to `toLocaleDateString` for visitor-facing dates. */
+  dateLocale: 'en-US',
+
+  nav: {
+    home: 'Home',
+    about: 'About',
+    map: 'Map',
+    journal: 'Journal',
+    skipToContent: 'Skip to content',
+  },
+
+  common: {
+    backTo: (label: string) => `Back to ${label}`,
+    backToGallery: 'Back to Gallery',
+    backToJournal: 'Back to Journal',
+    home: 'Home',
+    photos: (n: number) => plural(n, 'photo', 'photos'),
+    albums: (n: number) => plural(n, 'album', 'albums'),
+    collections: (n: number) => plural(n, 'collection', 'collections'),
+    loadingGallery: 'Loading gallery',
+    loadingPhotos: 'Loading photos',
+  },
+
+  home: {
+    enter: 'Enter',
+  },
+
+  error: {
+    notFoundTitle: 'Not found',
+    notFoundText: 'This page does not exist, or the album is no longer published.',
+    errorTitle: 'Something went wrong',
+    errorText:
+      'This page could not be loaded right now. It is usually temporary — try again in a moment.',
+    siteErrorText:
+      'This site could not be loaded right now. It is usually temporary — try again in a moment.',
+    tryAgain: 'Try again',
+    reference: (digest: string) => `Reference: ${digest}`,
+  },
+
+  theme: {
+    switchToLight: 'Switch to light mode',
+    switchToDark: 'Switch to dark mode',
+    scrollToTop: 'Scroll to top',
+  },
+
+  password: {
+    subtitle: 'This gallery is password-protected.',
+    placeholder: 'Enter password',
+    submit: 'Enter',
+    verifying: 'Verifying…',
+    incorrect: 'Incorrect password. Please try again.',
+    failed: 'Unable to verify password. Please try again later.',
+  },
+
+  about: {
+    kicker: 'About',
+    title: 'About',
+    metaTitle: (name: string) => `About — ${name}`,
+    portraitAlt: 'Portrait',
+    gear: 'Gear',
+  },
+
+  map: {
+    title: 'Map',
+    kicker: 'Where',
+    subtitle: 'Where the photos were taken',
+    loading: 'Loading map…',
+    loadFailed: (status: number) => `Failed to load map data (${status})`,
+    initFailed: 'Failed to initialize map',
+  },
+
+  subpage: {
+    collectionKicker: (index: string) => `${index} — Collection`,
+    sectionsNav: 'Sections',
+    coverAria: (albumName: string, count: string) => `${albumName}, ${count}`,
+  },
+
+  journal: {
+    title: 'Journal',
+    kicker: 'Stories & Essays',
+    subtitle: 'Photo essays, visual stories, and field notes.',
+    description: 'Photo essays, travel stories, and behind-the-scenes journals.',
+    entryDescription: 'Journal entry',
+    empty: 'No journal entries published yet.',
+    readStory: 'Read Story →',
+    minRead: (n: number) => `${n} min read`,
+    draft: 'Draft',
+    by: (author: string) => `by ${author}`,
+    notFound: 'Not Found',
+  },
+
+  lightbox: {
+    viewer: 'Image viewer',
+    close: 'Close',
+    closeTitle: 'Close (Esc)',
+    previous: 'Previous photo',
+    previousTitle: 'Previous photo (Left arrow)',
+    next: 'Next photo',
+    nextTitle: 'Next photo (Right arrow)',
+    toggleInfo: 'Toggle photo info',
+    toggleInfoTitle: 'Toggle photo info (i)',
+    hideInfo: 'Hide Info',
+    info: 'Info',
+    loading: 'Loading...',
+    camera: 'Camera',
+    lens: 'Lens',
+    focalLength: 'Focal Length',
+    aperture: 'Aperture',
+    shutter: 'Shutter',
+    iso: 'ISO',
+    location: 'Location',
+    noExif: 'No EXIF data available',
+  },
+
+  proofing: {
+    addFavorite: 'Add favorite',
+    removeFavorite: 'Remove favorite',
+    addToFavorites: 'Add to favorites',
+    removeFromFavorites: 'Remove from favorites',
+    saved: 'Saved',
+    favorite: 'Favorite',
+    showAll: 'Show All',
+    selected: (n: number) => `❤️ ${n} Selected`,
+    shareExport: 'Share & Export',
+    modalTitle: (n: number) => `❤️ Selection (${n})`,
+    closeModal: 'Close modal',
+    intro: (n: number) =>
+      `You have selected ${plural(n, 'photo', 'photos')}. Choose an export option below to share your selection:`,
+    copyLink: 'Copy Shareable Link',
+    linkCopied: 'Link Copied!',
+    copyList: 'Copy Text List (#1, #2...)',
+    listCopied: 'List Copied!',
+    sendEmail: '✉️ Send Email to Photographer',
+    clearSelection: 'Clear Selection',
+    confirmClear: 'Clear all selected favorites?',
+    listEmpty: (albumName: string) => `${albumName}: No photos selected.`,
+    listSummary: (albumName: string, count: number, indices: string) =>
+      `${albumName} — Selected Photos (${count}): ${indices}`,
+    mailSubject: (n: number) => `Photo Selection (${n} items)`,
+    mailBody: (list: string, url: string) =>
+      `Hello,\n\nHere is my photo selection:\n\n${list}\n\nShare Link: ${url}\n\nBest regards,`,
+  },
+
+  legal: {
+    navLabel: 'Legal Notice',
+    title: 'Legal Notice',
+    subtitle: 'Information pursuant to § 5 TMG',
+    address: 'Address',
+    contact: 'Contact',
+    email: 'Email',
+    phone: 'Phone',
+    taxSection: 'Tax Information',
+    taxId: 'Tax number',
+    vatId: 'VAT ID',
+    extraInfo: 'Additional Information',
+    source: 'Source: Created with the Impressum generator by eRecht24.',
+  },
+};

--- a/lib/i18n/server.ts
+++ b/lib/i18n/server.ts
@@ -1,0 +1,19 @@
+/**
+ * Server-side entry point for i18n. Separate from `lib/i18n/index.ts` because
+ * it reaches into `lib/config`, which pulls in `fs` — importing this from a
+ * client component breaks the build (same split as `lib/journal.ts` vs
+ * `lib/admin/journal-service.ts`).
+ */
+
+import { getConfigOrNull } from '@/lib/config';
+import { resolveLocale, getDictionary, type Dictionary, type Locale } from './index';
+
+/** Locale of the current deployment, resolved from `settings.yaml: lang`. */
+export function getLocale(): Locale {
+  return resolveLocale(getConfigOrNull()?.lang);
+}
+
+/** Dictionary for the current deployment. */
+export function getServerDictionary(): Dictionary {
+  return getDictionary(getLocale());
+}


### PR DESCRIPTION
Closes #482.

All visitor-facing strings were hardcoded English except `/impressum`, which was hardcoded German. `settings.yaml: lang` set `<html lang>` and translated nothing. It now picks the interface language.

## Approach

A dictionary lookup, no framework — matching the vanilla-CSS, no-framework line of the project. No message extraction, no runtime loader, no route prefixes: a self-hosted portfolio is served in exactly one language.

- **`lib/i18n/locales/en.ts`** is the reference locale. `Dictionary = typeof en`, and `de.ts` is typed as `Dictionary`, so a key added to English and forgotten in German is a compile error. Values are plain strings, or functions where a count or name is interpolated — pluralisation belongs to the locale ("Alben", not "Albums").
- **`lib/i18n/index.ts`** is client-safe: `resolveLocale()` (drops the region subtag, `de-AT` → `de`, unknown → `en`), `getDictionary()`, `SUPPORTED_LOCALES`.
- **`lib/i18n/server.ts`** reads `settings.yaml: lang` via the config and therefore `fs` — the same client/server split as `lib/journal.ts` vs `lib/admin/journal-service.ts`.
- **`components/I18nProvider.tsx`** sits in the root layout. Only the locale *string* crosses the server/client boundary; dictionaries hold functions and would not serialise, so `useDictionary()` looks the object up on the client.

## What is translated

Layout nav and skip link, hero (`Enter`, album/photo counts), album and subpage headers, photo grid, lightbox including every EXIF label, password gate, proofing bar/modal/mail body, map page and marker popups, journal index and detail (dates now use the locale's `dateLocale`), about, and the error/not-found/loading shells.

## `/impressum`

No longer hardcoded German: the headings come from the dictionary, and the footer link reads "Impressum" only under `lang: de`. The § 5 TMG citation stays in both, because that is what the statute is called. An unexplained German word in the footer of an English site is what put this on the list in the first place.

## Deliberately left English

Both documented in `CLAUDE.md`:

- **The admin panel** — the issue orders visitor UI first, admin second. The language field now states that the interface is translated for `en`/`de` only and that the admin panel is always English.
- **`app/global-error.tsx`** — it replaces the root layout, so there is no provider to read from.

A `lang` value without a dictionary (`fr`, `ja` — the admin select still offers them) keeps its `<html lang>` and date formatting and falls back to the English interface. Claiming `lang="en"` on a French site would be worse for screen readers than an English interface on a page correctly marked as French.

## Verification

- `npx tsc --noEmit` clean, `npm run lint` 0 errors, `npm run build` passes.
- 453 unit tests pass, 10 of them new in `lib/__tests__/i18n.test.ts`. Beyond locale resolution, it walks both dictionaries and fails on a key that was copied over but never translated — the type system only catches *missing* keys, not untranslated ones.
- Ran the dev server against a temporary `lang: "de"` config and confirmed the live render: `<html lang="de">`, nav `Start / Über mich / Karte`, `Zum Inhalt springen`, `Zurück zur Galerie`, German Impressum headings; then restored the file byte-identical.

## Docs

`CLAUDE.md`, a new "Interface language" section in `docs/gallery-config.md` (including how to add a locale), `content/settings.yaml.example`, and `docs/ideas.md` marked shipped for the visitor UI.
