### PR TITLE
feat(lightbox): a keyboard shortcut list behind `?` and `h`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Releases up to and including v0.9.2 are documented in the
 
 ### Added
 
+- **The lightbox lists its keyboard shortcuts under `?` or `H`**
+  ([#501](https://github.com/ralksta/immich-folio/pull/501)). The viewer has
+  always had keys — arrows, `i`, `Esc` — with nothing that wrote them down.
+  There is deliberately no button and no first-run hint: a permanent control in
+  the corner of a photograph costs every visitor something, and whoever tries
+  `?` or `h` finds the list. `Esc` now unwinds one layer at a time, closing the
+  panel before the viewer.
+
 - **The album covers on a subpage follow the grid setting**
   ([#460](https://github.com/ralksta/immich-folio/pull/460)). They were tiled
   two-up by a hardcoded CSS rule, so the site-wide `grid.columns` only ever

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,11 +150,11 @@ Visitor-facing strings are read off a dictionary picked by `settings.yaml: lang`
 
 The lightbox owns its key bindings (`Esc`, `←`/`→`, `i`, `?`) — callers must not install their own, which is how `EssayView` ended up with no keyboard navigation at all.
 
-`?` toggles a panel listing them, built from the `shortcutRows` array. **Adding a key means adding a row**, otherwise the binding stays as undiscoverable as the whole set was before #477. Rows can be conditional: `i` only appears when `showExifToggle` is on, since journal entries hide the EXIF panel. The `?` case matches the produced character, not the physical key, so it works on a German layout (Shift+ß) as well as a US one.
+`?` or `h` toggles a panel listing them, built from the `shortcutRows` array. **Adding a key means adding a row** — the panel is the only place a binding is written down. Rows can be conditional: `i` only appears when `showExifToggle` is on, since journal entries hide the EXIF panel. The `?` case matches the produced character, not the physical key, so it works on a German layout (Shift+ß) as well as a US one; `h` is the fallback for layouts where `?` is awkward.
 
 `Esc` unwinds one layer at a time — it closes the shortcut panel first and only then the viewer.
 
-First-time visitors get one nudge towards `?`, remembered under `folio_shortcut_hint_seen`. It is marked seen when it goes away rather than when it appears, so a lightbox closed after a second offers it again; a module-level flag covers private-mode browsers, where the lightbox mounting once per opening would otherwise re-nudge on every photo. The whole control is `display: none` under `@media (hover: none)` — nothing to advertise without a keyboard — and `studio-modern` moves it into its topbar, because that preset's EXIF strip owns the bottom edge.
+**The panel has no trigger and is not advertised.** There is no `?` button and no first-run nudge: a permanent control in the corner of a photograph costs every visitor something, and a visitor who never presses a key loses nothing by not knowing. Whoever tries `?` or `h` finds it. The panel is `display: none` under `@media (hover: none)`, and `studio-modern` opens it from the top because that preset's EXIF strip owns the bottom edge.
 
 ### Proofing (`lib/proofing.ts`, `components/ProofingContext.tsx`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,16 @@ Visitor-facing strings are read off a dictionary picked by `settings.yaml: lang`
 
 `lib/__tests__/i18n.test.ts` walks both dictionaries and fails on a key that was copied but never translated — the type system only catches missing ones.
 
+### Lightbox keyboard shortcuts (`components/Lightbox.tsx`)
+
+The lightbox owns its key bindings (`Esc`, `←`/`→`, `i`, `?`) — callers must not install their own, which is how `EssayView` ended up with no keyboard navigation at all.
+
+`?` toggles a panel listing them, built from the `shortcutRows` array. **Adding a key means adding a row**, otherwise the binding stays as undiscoverable as the whole set was before #477. Rows can be conditional: `i` only appears when `showExifToggle` is on, since journal entries hide the EXIF panel. The `?` case matches the produced character, not the physical key, so it works on a German layout (Shift+ß) as well as a US one.
+
+`Esc` unwinds one layer at a time — it closes the shortcut panel first and only then the viewer.
+
+First-time visitors get one nudge towards `?`, remembered under `folio_shortcut_hint_seen`. It is marked seen when it goes away rather than when it appears, so a lightbox closed after a second offers it again; a module-level flag covers private-mode browsers, where the lightbox mounting once per opening would otherwise re-nudge on every photo. The whole control is `display: none` under `@media (hover: none)` — nothing to advertise without a keyboard — and `studio-modern` moves it into its topbar, because that preset's EXIF strip owns the bottom edge.
+
 ### Proofing (`lib/proofing.ts`, `components/ProofingContext.tsx`)
 
 Client-side favourite selection encoded as a bitmask in the URL and mirrored to `localStorage`; nothing is stored server-side.

--- a/components/Lightbox.module.css
+++ b/components/Lightbox.module.css
@@ -243,64 +243,15 @@
   display: flex;
 }
 
-/* ── Keyboard shortcuts ───────────────────────────── */
-.shortcutsToggle {
-  position: fixed;
-  bottom: 24px;
-  left: 24px;
-  z-index: 1001;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  background: rgba(255, 255, 255, 0.08);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 50%;
-  color: var(--text-secondary);
-  font-family: var(--font-sans);
-  font-size: 0.8rem;
-  line-height: 1;
-  cursor: pointer;
-  transition:
-    background var(--transition-fast),
-    color var(--transition-fast);
-}
-
-.shortcutsToggle:hover {
-  background: rgba(255, 255, 255, 0.15);
-  color: var(--text-primary);
-}
-
-/* The one-time nudge sits where the panel will open, so the eye is already
-   in the right place when it does. */
-.shortcutHint,
+/* ── Keyboard shortcuts ─────────────────────────────
+   The panel has no trigger of its own — `?` or `h` opens it. It sits where a
+   trigger would have been, bottom left, clear of the EXIF panel opposite. */
 .shortcutsPanel {
   position: fixed;
   bottom: 62px;
   left: 24px;
   z-index: 1001;
   animation: exif-slide-up var(--transition-normal) ease forwards;
-}
-
-.shortcutHint {
-  margin: 0;
-  padding: 6px 10px;
-  background: rgba(20, 20, 20, 0.85);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-md);
-  font-family: var(--font-sans);
-  font-size: 0.75rem;
-  letter-spacing: 0.04em;
-  color: var(--text-muted);
-  pointer-events: none;
-}
-
-.shortcutsPanel {
   min-width: 240px;
   padding: 16px 20px;
   background: rgba(20, 20, 20, 0.92);
@@ -362,10 +313,8 @@
   color: var(--text-secondary);
 }
 
-/* No keyboard, nothing to advertise. */
+/* No keyboard, nothing to show. */
 @media (hover: none) {
-  .shortcutsToggle,
-  .shortcutHint,
   .shortcutsPanel {
     display: none;
   }
@@ -396,16 +345,14 @@
 
 .close,
 .nav,
-.counter,
-.shortcutsToggle {
+.counter {
   opacity: 0.5;
   transition: opacity 400ms ease;
 }
 
 .overlay:hover .close,
 .overlay:hover .nav,
-.overlay:hover .counter,
-.overlay:hover .shortcutsToggle {
+.overlay:hover .counter {
   opacity: 1;
 }
 
@@ -559,39 +506,8 @@
   right: 176px;
 }
 
-/* The EXIF strip owns the bottom edge in this preset, so the shortcut control
-   moves into the topbar and the counter shifts right to make room for it. */
-:global([data-preset='studio-modern']) .shortcutsToggle {
-  top: 20px;
-  bottom: auto;
-  left: 32px;
-  width: 26px;
-  height: 26px;
-  border-radius: 0;
-  background: none;
-  backdrop-filter: none;
-  -webkit-backdrop-filter: none;
-  border-color: rgba(255, 255, 255, 0.15);
-  font-family: var(--font-caption);
-  font-size: 0.6875rem;
-  color: rgba(255, 255, 255, 0.6);
-}
-
-:global([data-preset='studio-modern']) .shortcutsToggle:hover {
-  background: none;
-  border-color: var(--accent);
-  color: var(--accent);
-}
-
-/* Only where the button is actually rendered — it is hidden on touch, and an
-   indented counter with nothing to its left would just look misaligned. */
-@media (hover: hover) {
-  :global([data-preset='studio-modern']) .counter {
-    left: 74px;
-  }
-}
-
-:global([data-preset='studio-modern']) .shortcutHint,
+/* The EXIF strip owns the bottom edge in this preset, so the panel opens from
+   the top instead. */
 :global([data-preset='studio-modern']) .shortcutsPanel {
   top: 58px;
   bottom: auto;

--- a/components/Lightbox.module.css
+++ b/components/Lightbox.module.css
@@ -243,6 +243,134 @@
   display: flex;
 }
 
+/* ── Keyboard shortcuts ───────────────────────────── */
+.shortcutsToggle {
+  position: fixed;
+  bottom: 24px;
+  left: 24px;
+  z-index: 1001;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  background: rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 50%;
+  color: var(--text-secondary);
+  font-family: var(--font-sans);
+  font-size: 0.8rem;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.shortcutsToggle:hover {
+  background: rgba(255, 255, 255, 0.15);
+  color: var(--text-primary);
+}
+
+/* The one-time nudge sits where the panel will open, so the eye is already
+   in the right place when it does. */
+.shortcutHint,
+.shortcutsPanel {
+  position: fixed;
+  bottom: 62px;
+  left: 24px;
+  z-index: 1001;
+  animation: exif-slide-up var(--transition-normal) ease forwards;
+}
+
+.shortcutHint {
+  margin: 0;
+  padding: 6px 10px;
+  background: rgba(20, 20, 20, 0.85);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  font-family: var(--font-sans);
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+  pointer-events: none;
+}
+
+.shortcutsPanel {
+  min-width: 240px;
+  padding: 16px 20px;
+  background: rgba(20, 20, 20, 0.92);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+}
+
+.shortcutsTitle {
+  margin: 0 0 10px;
+  font-family: var(--font-sans);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+.shortcutsList {
+  margin: 0;
+}
+
+/* Two columns, not space-between: a ragged left edge on the descriptions is
+   what makes a shortcut list hard to scan. */
+.shortcutsRow {
+  display: flex;
+  align-items: baseline;
+  gap: 16px;
+  padding: 6px 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.shortcutsRow:last-child {
+  border-bottom: none;
+}
+
+.shortcutsKeys {
+  display: flex;
+  flex: 0 0 66px;
+  gap: 4px;
+}
+
+.shortcutsLabel {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--text-primary);
+}
+
+.kbd {
+  min-width: 22px;
+  padding: 2px 6px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-caption);
+  font-size: 0.75rem;
+  line-height: 1.4;
+  text-align: center;
+  color: var(--text-secondary);
+}
+
+/* No keyboard, nothing to advertise. */
+@media (hover: none) {
+  .shortcutsToggle,
+  .shortcutHint,
+  .shortcutsPanel {
+    display: none;
+  }
+}
+
 /* ── Responsive ──────────────────────────────────── */
 @media (max-width: 640px) {
   .nav {
@@ -268,14 +396,16 @@
 
 .close,
 .nav,
-.counter {
+.counter,
+.shortcutsToggle {
   opacity: 0.5;
   transition: opacity 400ms ease;
 }
 
 .overlay:hover .close,
 .overlay:hover .nav,
-.overlay:hover .counter {
+.overlay:hover .counter,
+.overlay:hover .shortcutsToggle {
   opacity: 1;
 }
 
@@ -427,6 +557,55 @@
 
 :global([data-preset='studio-modern']) .favToggle {
   right: 176px;
+}
+
+/* The EXIF strip owns the bottom edge in this preset, so the shortcut control
+   moves into the topbar and the counter shifts right to make room for it. */
+:global([data-preset='studio-modern']) .shortcutsToggle {
+  top: 20px;
+  bottom: auto;
+  left: 32px;
+  width: 26px;
+  height: 26px;
+  border-radius: 0;
+  background: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+  border-color: rgba(255, 255, 255, 0.15);
+  font-family: var(--font-caption);
+  font-size: 0.6875rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+:global([data-preset='studio-modern']) .shortcutsToggle:hover {
+  background: none;
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+/* Only where the button is actually rendered — it is hidden on touch, and an
+   indented counter with nothing to its left would just look misaligned. */
+@media (hover: hover) {
+  :global([data-preset='studio-modern']) .counter {
+    left: 74px;
+  }
+}
+
+:global([data-preset='studio-modern']) .shortcutHint,
+:global([data-preset='studio-modern']) .shortcutsPanel {
+  top: 58px;
+  bottom: auto;
+  left: 32px;
+  border-radius: 0;
+  background: rgba(10, 10, 10, 0.94);
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+}
+
+:global([data-preset='studio-modern']) .shortcutsTitle,
+:global([data-preset='studio-modern']) .kbd {
+  border-radius: 0;
+  font-family: var(--font-caption);
 }
 
 /* Film-edge strip replaces the popup panel */

--- a/components/Lightbox.tsx
+++ b/components/Lightbox.tsx
@@ -6,6 +6,7 @@
  * - Previous/Next navigation (arrows + swipe)
  * - Close (Esc, click outside, X button)
  * - EXIF metadata panel (fetched on demand)
+ * - Keyboard shortcut list (`?`), with a one-time nudge for first-time visitors
  * - Preloads adjacent images
  */
 
@@ -20,6 +21,19 @@ import styles from './Lightbox.module.css';
 import { useProofing } from './ProofingContext';
 import { IconHeart } from './Icons';
 import { useDictionary } from './I18nProvider';
+
+/** Remembers that the "press ? for shortcuts" nudge has been shown. */
+const SHORTCUT_HINT_KEY = 'folio_shortcut_hint_seen';
+
+/** How long the nudge stays up before it fades itself out. */
+const SHORTCUT_HINT_MS = 6000;
+
+/**
+ * Fallback for the `localStorage` flag. Private-mode browsers throw on both
+ * read and write, and without this the nudge would reappear on every single
+ * photo — the lightbox mounts once per opening, not once per page.
+ */
+let hintSeenThisSession = false;
 
 export interface LightboxWatermark {
   enabled?: boolean;
@@ -53,6 +67,8 @@ export function Lightbox({
 }: LightboxProps) {
   const t = useDictionary();
   const [showExif, setShowExif] = useState(false);
+  const [showShortcuts, setShowShortcuts] = useState(false);
+  const [showHint, setShowHint] = useState(false);
   const { exifData, exifLoading, fetchExif, clearExif } = useExif();
   const [imageLoaded, setImageLoaded] = useState(false);
   const overlayRef = useRef<HTMLDivElement>(null);
@@ -94,6 +110,43 @@ export function Lightbox({
     }
   }, [showExif, current, fetchExif]);
 
+  const dismissHint = useCallback(() => {
+    setShowHint(false);
+    hintSeenThisSession = true;
+    try {
+      localStorage.setItem(SHORTCUT_HINT_KEY, '1');
+    } catch {
+      // Storage disabled — the session flag still stops it repeating.
+    }
+  }, []);
+
+  const toggleShortcuts = useCallback(() => {
+    setShowShortcuts((open) => !open);
+    dismissHint();
+  }, [dismissHint]);
+
+  /*
+   * The keys are worth nothing if nobody knows they exist, so the first
+   * lightbox a visitor ever opens gets one nudge towards `?`. It is marked as
+   * seen when it goes away, not when it appears: closing the lightbox after a
+   * second has not taught anyone anything, and the nudge is cheap enough to
+   * offer again.
+   */
+  useEffect(() => {
+    if (hintSeenThisSession) return;
+    try {
+      if (localStorage.getItem(SHORTCUT_HINT_KEY)) {
+        hintSeenThisSession = true;
+        return;
+      }
+    } catch {
+      // Unreadable storage — fall through and rely on the session flag.
+    }
+    setShowHint(true);
+    const timer = setTimeout(dismissHint, SHORTCUT_HINT_MS);
+    return () => clearTimeout(timer);
+  }, [dismissHint]);
+
   // Preload adjacent images (skip videos — they stream on demand)
   useEffect(() => {
     const preload = (index: number) => {
@@ -121,7 +174,10 @@ export function Lightbox({
     const handleKeyDown = (e: KeyboardEvent) => {
       switch (e.key) {
         case 'Escape':
-          onClose();
+          // Innermost layer first: Esc dismisses the shortcut list, and only
+          // closes the viewer once nothing is stacked on top of it.
+          if (showShortcuts) setShowShortcuts(false);
+          else onClose();
           break;
         case 'ArrowRight':
           onNext();
@@ -133,6 +189,11 @@ export function Lightbox({
         case 'I':
           if (showExifToggle) handleExifToggle();
           break;
+        // Matched on the produced character, not the physical key: `?` is
+        // Shift+/ on a US layout and Shift+ß on a German one.
+        case '?':
+          toggleShortcuts();
+          break;
       }
     };
 
@@ -143,7 +204,7 @@ export function Lightbox({
       document.removeEventListener('keydown', handleKeyDown);
       document.body.style.overflow = '';
     };
-  }, [handleExifToggle, onClose, onNext, onPrev, showExifToggle]);
+  }, [handleExifToggle, onClose, onNext, onPrev, showExifToggle, showShortcuts, toggleShortcuts]);
 
   // Click on overlay background → close
   const handleOverlayClick = useCallback(
@@ -154,6 +215,19 @@ export function Lightbox({
     },
     [onClose],
   );
+
+  /*
+   * The advertised shortcuts, in the order they are worth learning. This is the
+   * list the `?` panel renders — a key added to the handler above belongs here
+   * too, or it stays as undiscoverable as the whole set was before.
+   */
+  const shortcutRows = [
+    { keys: ['←', '→'], label: t.lightbox.shortcutNavigate },
+    // Journal entries hide the EXIF toggle, so `i` does nothing there.
+    ...(showExifToggle ? [{ keys: ['I'], label: t.lightbox.shortcutInfo }] : []),
+    { keys: ['?'], label: t.lightbox.shortcutList },
+    { keys: ['Esc'], label: t.lightbox.shortcutClose },
+  ];
 
   const lightboxJsx = (
     <div
@@ -383,6 +457,46 @@ export function Lightbox({
               <span className={styles.exifLabel}>{t.lightbox.noExif}</span>
             </div>
           )}
+        </div>
+      )}
+
+      {/* Keyboard shortcuts — hidden on touch devices, which have no keys */}
+      <button
+        type="button"
+        className={styles.shortcutsToggle}
+        onClick={toggleShortcuts}
+        aria-expanded={showShortcuts}
+        aria-controls="lightbox-shortcuts"
+        aria-label={t.lightbox.shortcuts}
+        title={t.lightbox.shortcutsTitle}
+      >
+        ?
+      </button>
+
+      {/* The nudge occupies the spot the panel will open into. */}
+      {showHint && !showShortcuts && (
+        <p className={styles.shortcutHint} role="status">
+          {t.lightbox.shortcutHint}
+        </p>
+      )}
+
+      {showShortcuts && (
+        <div id="lightbox-shortcuts" className={styles.shortcutsPanel}>
+          <p className={styles.shortcutsTitle}>{t.lightbox.shortcuts}</p>
+          <dl className={styles.shortcutsList}>
+            {shortcutRows.map((row) => (
+              <div key={row.label} className={styles.shortcutsRow}>
+                <dt className={styles.shortcutsKeys}>
+                  {row.keys.map((key) => (
+                    <kbd key={key} className={styles.kbd}>
+                      {key}
+                    </kbd>
+                  ))}
+                </dt>
+                <dd className={styles.shortcutsLabel}>{row.label}</dd>
+              </div>
+            ))}
+          </dl>
         </div>
       )}
     </div>

--- a/components/Lightbox.tsx
+++ b/components/Lightbox.tsx
@@ -6,7 +6,7 @@
  * - Previous/Next navigation (arrows + swipe)
  * - Close (Esc, click outside, X button)
  * - EXIF metadata panel (fetched on demand)
- * - Keyboard shortcut list (`?`), with a one-time nudge for first-time visitors
+ * - Keyboard shortcut list (`?` or `h`), deliberately unadvertised
  * - Preloads adjacent images
  */
 
@@ -21,19 +21,6 @@ import styles from './Lightbox.module.css';
 import { useProofing } from './ProofingContext';
 import { IconHeart } from './Icons';
 import { useDictionary } from './I18nProvider';
-
-/** Remembers that the "press ? for shortcuts" nudge has been shown. */
-const SHORTCUT_HINT_KEY = 'folio_shortcut_hint_seen';
-
-/** How long the nudge stays up before it fades itself out. */
-const SHORTCUT_HINT_MS = 6000;
-
-/**
- * Fallback for the `localStorage` flag. Private-mode browsers throw on both
- * read and write, and without this the nudge would reappear on every single
- * photo — the lightbox mounts once per opening, not once per page.
- */
-let hintSeenThisSession = false;
 
 export interface LightboxWatermark {
   enabled?: boolean;
@@ -68,7 +55,6 @@ export function Lightbox({
   const t = useDictionary();
   const [showExif, setShowExif] = useState(false);
   const [showShortcuts, setShowShortcuts] = useState(false);
-  const [showHint, setShowHint] = useState(false);
   const { exifData, exifLoading, fetchExif, clearExif } = useExif();
   const [imageLoaded, setImageLoaded] = useState(false);
   const overlayRef = useRef<HTMLDivElement>(null);
@@ -110,42 +96,9 @@ export function Lightbox({
     }
   }, [showExif, current, fetchExif]);
 
-  const dismissHint = useCallback(() => {
-    setShowHint(false);
-    hintSeenThisSession = true;
-    try {
-      localStorage.setItem(SHORTCUT_HINT_KEY, '1');
-    } catch {
-      // Storage disabled — the session flag still stops it repeating.
-    }
-  }, []);
-
   const toggleShortcuts = useCallback(() => {
     setShowShortcuts((open) => !open);
-    dismissHint();
-  }, [dismissHint]);
-
-  /*
-   * The keys are worth nothing if nobody knows they exist, so the first
-   * lightbox a visitor ever opens gets one nudge towards `?`. It is marked as
-   * seen when it goes away, not when it appears: closing the lightbox after a
-   * second has not taught anyone anything, and the nudge is cheap enough to
-   * offer again.
-   */
-  useEffect(() => {
-    if (hintSeenThisSession) return;
-    try {
-      if (localStorage.getItem(SHORTCUT_HINT_KEY)) {
-        hintSeenThisSession = true;
-        return;
-      }
-    } catch {
-      // Unreadable storage — fall through and rely on the session flag.
-    }
-    setShowHint(true);
-    const timer = setTimeout(dismissHint, SHORTCUT_HINT_MS);
-    return () => clearTimeout(timer);
-  }, [dismissHint]);
+  }, []);
 
   // Preload adjacent images (skip videos — they stream on demand)
   useEffect(() => {
@@ -189,9 +142,13 @@ export function Lightbox({
         case 'I':
           if (showExifToggle) handleExifToggle();
           break;
-        // Matched on the produced character, not the physical key: `?` is
-        // Shift+/ on a US layout and Shift+ß on a German one.
+        // `?` is matched on the produced character, not the physical key:
+        // Shift+/ on a US layout, Shift+ß on a German one. `h` is the escape
+        // hatch for layouts where `?` is awkward — and the one key someone
+        // guesses without having been told.
         case '?':
+        case 'h':
+        case 'H':
           toggleShortcuts();
           break;
       }
@@ -225,7 +182,7 @@ export function Lightbox({
     { keys: ['←', '→'], label: t.lightbox.shortcutNavigate },
     // Journal entries hide the EXIF toggle, so `i` does nothing there.
     ...(showExifToggle ? [{ keys: ['I'], label: t.lightbox.shortcutInfo }] : []),
-    { keys: ['?'], label: t.lightbox.shortcutList },
+    { keys: ['?', 'H'], label: t.lightbox.shortcutList },
     { keys: ['Esc'], label: t.lightbox.shortcutClose },
   ];
 
@@ -460,26 +417,12 @@ export function Lightbox({
         </div>
       )}
 
-      {/* Keyboard shortcuts — hidden on touch devices, which have no keys */}
-      <button
-        type="button"
-        className={styles.shortcutsToggle}
-        onClick={toggleShortcuts}
-        aria-expanded={showShortcuts}
-        aria-controls="lightbox-shortcuts"
-        aria-label={t.lightbox.shortcuts}
-        title={t.lightbox.shortcutsTitle}
-      >
-        ?
-      </button>
-
-      {/* The nudge occupies the spot the panel will open into. */}
-      {showHint && !showShortcuts && (
-        <p className={styles.shortcutHint} role="status">
-          {t.lightbox.shortcutHint}
-        </p>
-      )}
-
+      {/*
+        The shortcuts have no control of their own and are not advertised: a
+        permanent button in the corner of a photograph costs every visitor
+        something, and the keys are worth nothing to the ones who would never
+        press them anyway. Whoever tries `?` or `h` finds them.
+      */}
       {showShortcuts && (
         <div id="lightbox-shortcuts" className={styles.shortcutsPanel}>
           <p className={styles.shortcutsTitle}>{t.lightbox.shortcuts}</p>

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -10,8 +10,9 @@ A consolidated list of features and ideas for future versions, cleaned up from e
 | **Fullscreen API in lightbox** | Low    | Medium — immersive (Chrome-free)                   |
 | **Download originals**         | Low    | High — client delivery (Button in lightbox)        |
 | **Photo of the Day**           | Low    | Medium — return visits (Auto-rotate hero image)    |
-| **Keyboard shortcut hints**    | Low    | Medium — `?` button for shortcuts (arrows, Esc, F) |
 | **Photo sharing**              | Low    | Medium — "Copy link" button in lightbox            |
+
+_Shipped: **Keyboard shortcut hints** — `?` opens the list in the lightbox, with a one-time nudge for first-time visitors._
 
 ---
 

--- a/e2e/lightbox-shortcuts.spec.ts
+++ b/e2e/lightbox-shortcuts.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * The shortcut panel is deliberately unadvertised: no button, no first-run
+ * nudge. These pin both halves of that — the keys work, and nothing is on
+ * screen until one of them is pressed.
+ */
+test.describe('Lightbox shortcuts', () => {
+  const GRID_URL = '/deutschland/kloster-chorin';
+
+  async function openLightbox(page: import('@playwright/test').Page) {
+    await page.goto(GRID_URL);
+    const item = page.locator('.photo-grid .photo-grid__item').first();
+    await item.scrollIntoViewIfNeeded();
+    await item.click();
+    await expect(page.getByRole('dialog')).toBeVisible();
+  }
+
+  const panel = (page: import('@playwright/test').Page) => page.locator('#lightbox-shortcuts');
+
+  test('nothing advertises the panel', async ({ page }) => {
+    await openLightbox(page);
+    await expect(panel(page)).toHaveCount(0);
+    // The old trigger and its one-time nudge are gone for good.
+    await expect(page.getByRole('button', { name: /keyboard shortcuts/i })).toHaveCount(0);
+    await expect(page.getByText(/press \? for keyboard shortcuts/i)).toHaveCount(0);
+  });
+
+  test('? opens it and closes it again', async ({ page }) => {
+    await openLightbox(page);
+    await page.keyboard.press('?');
+    await expect(panel(page)).toBeVisible();
+    await page.keyboard.press('?');
+    await expect(panel(page)).toHaveCount(0);
+  });
+
+  test('h opens it too', async ({ page }) => {
+    await openLightbox(page);
+    await page.keyboard.press('h');
+    await expect(panel(page)).toBeVisible();
+  });
+
+  test('Esc closes the panel before the viewer', async ({ page }) => {
+    await openLightbox(page);
+    await page.keyboard.press('h');
+    await expect(panel(page)).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(panel(page)).toHaveCount(0);
+    await expect(page.getByRole('dialog')).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(page.getByRole('dialog')).toHaveCount(0);
+  });
+});

--- a/lib/i18n/locales/de.ts
+++ b/lib/i18n/locales/de.ts
@@ -122,6 +122,13 @@ export const de: Dictionary = {
     iso: 'ISO',
     location: 'Ort',
     noExif: 'Keine EXIF-Daten vorhanden',
+    shortcuts: 'Tastaturkürzel',
+    shortcutsTitle: 'Tastaturkürzel (?)',
+    shortcutHint: '? drücken für Tastaturkürzel',
+    shortcutNavigate: 'Vorheriges / nächstes Foto',
+    shortcutInfo: 'Fotoinfos',
+    shortcutList: 'Diese Liste',
+    shortcutClose: 'Ansicht schließen',
   },
 
   proofing: {

--- a/lib/i18n/locales/de.ts
+++ b/lib/i18n/locales/de.ts
@@ -123,8 +123,6 @@ export const de: Dictionary = {
     location: 'Ort',
     noExif: 'Keine EXIF-Daten vorhanden',
     shortcuts: 'Tastaturkürzel',
-    shortcutsTitle: 'Tastaturkürzel (?)',
-    shortcutHint: '? drücken für Tastaturkürzel',
     shortcutNavigate: 'Vorheriges / nächstes Foto',
     shortcutInfo: 'Fotoinfos',
     shortcutList: 'Diese Liste',

--- a/lib/i18n/locales/en.ts
+++ b/lib/i18n/locales/en.ts
@@ -122,6 +122,13 @@ export const en = {
     iso: 'ISO',
     location: 'Location',
     noExif: 'No EXIF data available',
+    shortcuts: 'Keyboard shortcuts',
+    shortcutsTitle: 'Keyboard shortcuts (?)',
+    shortcutHint: 'Press ? for keyboard shortcuts',
+    shortcutNavigate: 'Previous / next photo',
+    shortcutInfo: 'Photo info',
+    shortcutList: 'This list',
+    shortcutClose: 'Close the viewer',
   },
 
   proofing: {

--- a/lib/i18n/locales/en.ts
+++ b/lib/i18n/locales/en.ts
@@ -123,8 +123,6 @@ export const en = {
     location: 'Location',
     noExif: 'No EXIF data available',
     shortcuts: 'Keyboard shortcuts',
-    shortcutsTitle: 'Keyboard shortcuts (?)',
-    shortcutHint: 'Press ? for keyboard shortcuts',
     shortcutNavigate: 'Previous / next photo',
     shortcutInfo: 'Photo info',
     shortcutList: 'This list',


### PR DESCRIPTION
Closes #477.

The lightbox has supported `Esc`, the arrow keys and `i` for a long time, and nothing said so. `?` or `h` now opens a panel listing them.

## Deliberately unadvertised

There is no button and no first-run hint. An earlier revision of this PR had both; they were paid for by every visitor, on every photograph, to teach a set of keys most of them will never press — and the corner of a photograph is the one place a portfolio should keep empty. Whoever tries `?` or `h` finds the list; whoever does not loses nothing.

`h` is there because it is the key someone guesses without having been told, and because `?` needs two hands on some layouts.

## Built to grow

The list comes from a `shortcutRows` array rather than being written out in markup, so a key added by the fullscreen, slideshow or zoom issues is one row away from being written down. Rows can be conditional — `i` is omitted wherever the EXIF toggle is (journal entries), because there it does nothing.

The `?` case matches the *produced character*, not the physical key, so it works on a German layout (Shift+ß) as well as a US one.

## Interaction details

- **`Esc` unwinds one layer at a time**: it closes the shortcut panel first, and the viewer only once nothing is stacked on top of it.
- **No keyboard, nothing to show**: the panel is `display: none` under `@media (hover: none)`.
- **`studio-modern`** opens the panel from the top, because that preset's EXIF strip owns the bottom edge.

Strings go through the dictionary added in #500, so the panel is German under `lang: de`.

## Verification

There is no component-test setup in this repo (unit tests are `lib/` only, and `CLAUDE.md` explicitly discourages extracting component logic just to reach the runner), so this is covered by `e2e/lightbox-shortcuts.spec.ts`, driving the real component in Chromium:

- nothing is on screen until a key is pressed — no trigger button, no nudge text
- `?` opens the panel and closes it again
- `h` opens it too
- `Esc` closes the panel and leaves the viewer open; a second `Esc` closes the viewer

All four pass locally. `npx tsc --noEmit` clean, lint 0 errors, 453 unit tests pass, `npm run build` passes.
