### PR TITLE
fix: keep non-Latin album names in their slug (#522)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,15 @@ Releases up to and including v0.9.2 are documented in the
   letter or digit, whatever the script, and fold Latin diacritics as before
   (`Café` still becomes `cafe`). An album whose name has no letters at all — one
   written purely in emoji — falls back to its id, so it stays reachable and two
-  of them no longer collide. A slug typed into the address bar is matched in
-  both its composed and decomposed Unicode form.
+  of them no longer collide.
+
+  Generating a usable slug was only half of it: Next hands a catch-all route
+  segment to the page still percent-encoded, so `/家族相册` arrived as
+  `%E5%AE%B6...` and matched no album even once the slug was right — the album
+  link rendered, and opening it produced an empty page. Incoming slugs are now
+  decoded once at the route boundary, and matched in both their composed and
+  decomposed Unicode form, so a slug typed or pasted into the address bar
+  resolves too.
 
 ## [0.12.0] — 2026-08-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Releases up to and including v0.9.2 are documented in the
 [GitHub releases](https://github.com/ralksta/immich-folio/releases).
 
+## [Unreleased]
+
+### Fixed
+
+- **Albums whose name is written in CJK are reachable again**
+  ([#522](https://github.com/ralksta/immich-folio/issues/522)). The slug was
+  built by dropping every character outside `[a-z0-9]`, so a Chinese, Japanese,
+  Korean, Cyrillic or Greek name was reduced to nothing at all. The album's link
+  then pointed at `/`, clicking it went nowhere, and because no album lookup was
+  ever attempted there was nothing in the log to explain it. Slugs now keep any
+  letter or digit, whatever the script, and fold Latin diacritics as before
+  (`Café` still becomes `cafe`). An album whose name has no letters at all — one
+  written purely in emoji — falls back to its id, so it stays reachable and two
+  of them no longer collide. A slug typed into the address bar is matched in
+  both its composed and decomposed Unicode form.
+
 ## [0.12.0] — 2026-08-23
 
 ### Added

--- a/app/[...path]/page.tsx
+++ b/app/[...path]/page.tsx
@@ -30,6 +30,7 @@ import {
   buildCoverGridVars,
   getConfig,
   hasExifPanelContent,
+  normalizeSlug,
   resolveProofing,
   type GridConfig,
 } from '@/lib/config';
@@ -54,7 +55,11 @@ interface PathPageProps {
 }
 
 export async function generateMetadata({ params }: PathPageProps): Promise<Metadata> {
-  const { path } = await params;
+  // Next hands catch-all segments over percent-encoded, so a non-ASCII slug
+  // ("/家族相册") would never match a stored one. Decode once, here, and every
+  // comparison downstream works on the same form (#522).
+  const { path: rawPath } = await params;
+  const path = rawPath?.map(normalizeSlug);
   if (!path || path.length === 0) return {};
 
   const slug = path[0];
@@ -190,7 +195,11 @@ async function getAlbumHeroData(
 }
 
 export default async function PathPage({ params, searchParams }: PathPageProps) {
-  const { path } = await params;
+  // Next hands catch-all segments over percent-encoded, so a non-ASCII slug
+  // ("/家族相册") would never match a stored one. Decode once, here, and every
+  // comparison downstream works on the same form (#522).
+  const { path: rawPath } = await params;
+  const path = rawPath?.map(normalizeSlug);
   const sParams = (await searchParams) || {};
   const forceFresh = sParams.fresh === '1' || sParams.preview === 'true';
 

--- a/app/admin/components/PageBuilder.tsx
+++ b/app/admin/components/PageBuilder.tsx
@@ -35,6 +35,7 @@ import {
   COVER_GRID_COLUMNS_MAX,
   COVER_GRID_COLUMNS_MIN,
   COVER_GRID_GAP_MAX,
+  slugify,
   type AlbumEntryObject,
 } from '@/lib/config/schema';
 import {
@@ -908,13 +909,6 @@ export default function PageBuilder() {
       }
     }
     return null;
-  }
-
-  function slugify(str: string): string {
-    return str
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/^-|-$/g, '');
   }
 
   // ── Render ───────────────────────────────────────────────────

--- a/lib/__tests__/config.test.ts
+++ b/lib/__tests__/config.test.ts
@@ -12,7 +12,7 @@ vi.mock('@/lib/env', () => ({
   },
 }));
 
-import { slugify, buildSubpageGrid, sanitizeNavLinks } from '@/lib/config';
+import { slugify, albumSlug, buildSubpageGrid, sanitizeNavLinks } from '@/lib/config';
 
 // EXPERIMENTAL: external navigation links — rendered as <a href> in the
 // header, so only http(s) URLs may survive sanitisation.
@@ -80,6 +80,42 @@ describe('slugify', () => {
 
   it('preserves numbers', () => {
     expect(slugify('Album 2024')).toBe('album-2024');
+  });
+
+  // #522: stripping every non-ASCII character left CJK names with an empty
+  // slug, so their links pointed at "/" and clicking an album did nothing.
+  it('preserves CJK characters', () => {
+    expect(slugify('家族相册')).toBe('家族相册');
+    expect(slugify('写真')).toBe('写真');
+    expect(slugify('旅行 2024')).toBe('旅行-2024');
+  });
+
+  it('preserves Hangul in composed (NFC) form', () => {
+    const slug = slugify('가족 앨범');
+    expect(slug).toBe('가족-앨범');
+    expect(slug).toBe(slug.normalize('NFC'));
+  });
+
+  it('preserves other non-Latin scripts', () => {
+    expect(slugify('Москва 2024')).toBe('москва-2024');
+  });
+
+  it('still returns empty when nothing letter-like remains', () => {
+    expect(slugify('🎉🎉')).toBe('');
+  });
+});
+
+describe('albumSlug', () => {
+  it('uses the slugified name when it yields something', () => {
+    expect(albumSlug('Kloster Chorin', 'abc-123')).toBe('kloster-chorin');
+    expect(albumSlug('家族相册', 'abc-123')).toBe('家族相册');
+  });
+
+  // Without a fallback two emoji-only albums would both slugify to '' and
+  // collide on the same (unreachable) URL.
+  it('falls back to the album id when the name slugifies to nothing', () => {
+    expect(albumSlug('🎉', 'abc-123')).toBe('abc-123');
+    expect(albumSlug('', 'abc-123')).toBe('abc-123');
   });
 });
 

--- a/lib/__tests__/config.test.ts
+++ b/lib/__tests__/config.test.ts
@@ -12,7 +12,13 @@ vi.mock('@/lib/env', () => ({
   },
 }));
 
-import { slugify, albumSlug, buildSubpageGrid, sanitizeNavLinks } from '@/lib/config';
+import {
+  slugify,
+  albumSlug,
+  normalizeSlug,
+  buildSubpageGrid,
+  sanitizeNavLinks,
+} from '@/lib/config';
 
 // EXPERIMENTAL: external navigation links — rendered as <a href> in the
 // header, so only http(s) URLs may survive sanitisation.
@@ -116,6 +122,28 @@ describe('albumSlug', () => {
   it('falls back to the album id when the name slugifies to nothing', () => {
     expect(albumSlug('🎉', 'abc-123')).toBe('abc-123');
     expect(albumSlug('', 'abc-123')).toBe('abc-123');
+  });
+});
+
+describe('normalizeSlug', () => {
+  // Next hands catch-all route segments over percent-encoded, so this is the
+  // half of #522 that fixing slugify() alone did not cure.
+  it('percent-decodes an encoded slug', () => {
+    expect(normalizeSlug('%E5%AE%B6%E6%97%8F%E7%9B%B8%E5%86%8C')).toBe('家族相册');
+  });
+
+  it('leaves an already decoded slug alone', () => {
+    expect(normalizeSlug('家族相册')).toBe('家族相册');
+    expect(normalizeSlug('kloster-chorin')).toBe('kloster-chorin');
+  });
+
+  it('composes decomposed (NFD) input', () => {
+    expect(normalizeSlug('가족-앨범'.normalize('NFD'))).toBe('가족-앨범');
+  });
+
+  it('survives a malformed percent sequence instead of throwing', () => {
+    expect(() => normalizeSlug('%E5%AE')).not.toThrow();
+    expect(normalizeSlug('100%-real')).toBe('100%-real');
   });
 });
 

--- a/lib/__tests__/immich.test.ts
+++ b/lib/__tests__/immich.test.ts
@@ -418,6 +418,16 @@ describe('ImmichClient', () => {
       expect(album?.id).toBe('album-2');
     });
 
+    it('resolves a slug that arrives percent-encoded from the route', async () => {
+      mockList('家族相册');
+      await immich.getAlbums();
+
+      const encoded = encodeURIComponent('家族相册');
+      expect(encoded).not.toBe('家族相册');
+      const album = await immich.getAlbumBySlug(encoded);
+      expect(album?.id).toBe('album-2');
+    });
+
     it('falls back to the album id when the name has no letters at all', async () => {
       mockList('🎉');
       const albums = await immich.getAlbums();

--- a/lib/__tests__/immich.test.ts
+++ b/lib/__tests__/immich.test.ts
@@ -381,6 +381,53 @@ describe('ImmichClient', () => {
     });
   });
 
+  // #522: a CJK album name slugified to '', so its link was "/" and the album
+  // was unreachable — no URL segment can ever be the empty string.
+  describe('getAlbumBySlug() with non-Latin names', () => {
+    function mockList(albumName: string) {
+      const json = (body: unknown) => ({
+        ok: true,
+        headers: { get: () => 'application/json' },
+        json: async () => body,
+      });
+      mockFetch.mockImplementation(async (url: string) => {
+        if (url.includes('/search/metadata')) {
+          return json({ assets: { items: [], nextPage: null, total: 0 } });
+        }
+        if (/\/albums\/album-2/.test(url)) {
+          return json({ id: 'album-2', albumName, assetCount: 0, assets: [], order: 'desc' });
+        }
+        return json([{ id: 'album-2', albumName, assetCount: 0 }]);
+      });
+    }
+
+    it('gives a CJK album a non-empty slug and resolves it', async () => {
+      mockList('家族相册');
+      const albums = await immich.getAlbums();
+      expect(albums[0].slug).toBe('家族相册');
+
+      const album = await immich.getAlbumBySlug('家族相册');
+      expect(album?.id).toBe('album-2');
+    });
+
+    it('resolves a Hangul slug that arrives decomposed (NFD) from the URL', async () => {
+      mockList('가족 앨범');
+      await immich.getAlbums();
+
+      const album = await immich.getAlbumBySlug('가족-앨범'.normalize('NFD'));
+      expect(album?.id).toBe('album-2');
+    });
+
+    it('falls back to the album id when the name has no letters at all', async () => {
+      mockList('🎉');
+      const albums = await immich.getAlbums();
+      expect(albums[0].slug).toBe('album-2');
+
+      const album = await immich.getAlbumBySlug('album-2');
+      expect(album?.id).toBe('album-2');
+    });
+  });
+
   describe('getStandaloneAlbums()', () => {
     it('orders albums by gallery.yaml order, not Immich API order', async () => {
       // The Immich API returns albums in its own (creation/update) order;

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -8,6 +8,9 @@
 
 import crypto from 'crypto';
 import { getConfig, SubpageConfig } from './config';
+// From the pure schema module, not the config barrel: tests that stub out
+// '@/lib/config' wholesale would otherwise lose this helper.
+import { normalizeSlug } from './config/schema';
 import { verifyScrypt, generateScryptHash, isScryptHash } from './password';
 
 const TOKEN_EXPIRY_HOURS = 24;
@@ -96,7 +99,8 @@ export const SITE_AUTH_COOKIE = 'lb_site_auth';
  * Find the SubpageConfig for a given slug.
  */
 export function findSubpageBySlug(slug: string): SubpageConfig | undefined {
-  return getConfig().subpages.find((sp) => sp.slug === slug);
+  const wanted = normalizeSlug(slug);
+  return getConfig().subpages.find((sp) => sp.slug === wanted);
 }
 
 /**
@@ -108,7 +112,8 @@ function findPassword(key: string, type: ProtectedType): string | undefined {
     return config.sitePassword || undefined;
   }
   if (type === 'subpage') {
-    return config.subpages.find((sp) => sp.slug === key)?.password;
+    const wanted = normalizeSlug(key);
+    return config.subpages.find((sp) => sp.slug === wanted)?.password;
   }
   if (type === 'album') {
     return config.albumPasswords[key];

--- a/lib/config/schema.ts
+++ b/lib/config/schema.ts
@@ -482,11 +482,44 @@ export function resolveWatermarkOpacity(raw?: number): number {
   return Math.min(1, Math.max(0, fraction));
 }
 
+/**
+ * URL slug for a display name.
+ *
+ * NFD + combining-mark removal folds Latin diacritics ("Café" -> "cafe"), but
+ * everything else keeps its letters: the separator class is \p{L}\p{N}, not
+ * [a-z0-9]. The ASCII-only version stripped CJK, Hangul and Cyrillic names down
+ * to an empty slug, which turned their links into "/" (#522). NFC at the end
+ * recomposes what NFD split — Hangul syllables decompose into jamo, and only
+ * the composed form matches what a browser sends back in the URL.
+ *
+ * Can still return '' for a name made purely of symbols or emoji; callers that
+ * need a routable slug must supply a fallback (see albumSlug).
+ */
 export function slugify(name: string): string {
   return name
     .toLowerCase()
     .normalize('NFD')
     .replace(/[\u0300-\u036f]/g, '')
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
+    .replace(/[^\p{L}\p{N}]+/gu, '-')
+    .replace(/^-+|-+$/g, '')
+    .normalize('NFC');
+}
+
+/**
+ * Routable slug for an album. Falls back to the album id when the name has no
+ * letters or digits at all, so an emoji-only album is still reachable — and so
+ * two of them do not collide on the same empty slug.
+ */
+export function albumSlug(name: string, id: string): string {
+  return slugify(name) || id;
+}
+
+/**
+ * Normalize a slug that came in from a URL before comparing it to a stored one.
+ * Slugs are stored NFC; a non-Latin slug typed or pasted on macOS can arrive
+ * NFD, and the two forms are different strings even though they render the
+ * same. ASCII slugs are unaffected.
+ */
+export function normalizeSlug(slug: string): string {
+  return slug.normalize('NFC');
 }

--- a/lib/config/schema.ts
+++ b/lib/config/schema.ts
@@ -516,10 +516,26 @@ export function albumSlug(name: string, id: string): string {
 
 /**
  * Normalize a slug that came in from a URL before comparing it to a stored one.
- * Slugs are stored NFC; a non-Latin slug typed or pasted on macOS can arrive
- * NFD, and the two forms are different strings even though they render the
- * same. ASCII slugs are unaffected.
+ *
+ * Two things can differ even when the slug is "the same":
+ *
+ *   - Percent-encoding. A non-ASCII path segment reaches the route handler
+ *     still encoded ("%E5%AE%B6..."), so comparing it raw against the stored
+ *     slug never matches — the half of #522 that survived fixing slugify().
+ *   - Unicode form. Slugs are stored NFC; a non-Latin slug typed or pasted on
+ *     macOS can arrive NFD, and the two are different strings that render the
+ *     same.
+ *
+ * ASCII slugs are unaffected by either step. No stored slug can contain a '%',
+ * since slugify() drops it, so decoding cannot collide with a real slug.
  */
 export function normalizeSlug(slug: string): string {
-  return slug.normalize('NFC');
+  let decoded = slug;
+  try {
+    decoded = decodeURIComponent(slug);
+  } catch {
+    // Malformed percent sequence — compare what we were actually given rather
+    // than throwing a 500 on a hand-mangled URL.
+  }
+  return decoded.normalize('NFC');
 }

--- a/lib/immich.ts
+++ b/lib/immich.ts
@@ -7,7 +7,7 @@
  * requests go through our proxy route.
  */
 
-import { getConfig, slugify, type SubpageConfig } from './config';
+import { getConfig, albumSlug, normalizeSlug, type SubpageConfig } from './config';
 import { cache } from './cache';
 import { compareByCaptureTime, sortAlbumAssets, DEFAULT_ALBUM_SORT } from './albumSort';
 
@@ -423,7 +423,7 @@ class ImmichClient {
               ...album,
               albumName: name,
               description,
-              slug: slugify(name),
+              slug: albumSlug(name, album.id),
             };
           });
 
@@ -530,9 +530,8 @@ class ImmichClient {
     subpageSlug: string,
     forceFresh = false,
   ): Promise<{ subpage: SubpageConfig; albums: ImmichAlbum[] } | null> {
-    const subpage = this.config.subpages.find(
-      (sp) => sp.slug === subpageSlug && sp.enabled !== false,
-    );
+    const wanted = normalizeSlug(subpageSlug);
+    const subpage = this.config.subpages.find((sp) => sp.slug === wanted && sp.enabled !== false);
     if (!subpage) return null;
 
     const allAlbums = await this.getAlbums(forceFresh);
@@ -700,7 +699,7 @@ class ImmichClient {
         const description = this.config.albumDescriptions[album.id] ?? album.description ?? '';
         album.albumName = name;
         album.description = description;
-        album.slug = slugify(name);
+        album.slug = albumSlug(name, album.id);
 
         this.cacheSet(cacheKey, album);
         return album;
@@ -728,13 +727,15 @@ class ImmichClient {
 
     let searchSet = albums;
     if (subpageSlug) {
-      const subpage = this.config.subpages.find((sp) => sp.slug === subpageSlug);
+      const wantedSubpage = normalizeSlug(subpageSlug);
+      const subpage = this.config.subpages.find((sp) => sp.slug === wantedSubpage);
       if (!subpage) return null;
       const subpageIds = new Set(subpage.albumIds);
       searchSet = albums.filter((a) => subpageIds.has(a.id));
     }
 
-    const match = searchSet.find((a) => a.slug === slug);
+    const wanted = normalizeSlug(slug);
+    const match = searchSet.find((a) => a.slug === wanted);
     if (!match) return null;
     return this.getAlbum(match.id, forceFresh);
   }
@@ -743,7 +744,8 @@ class ImmichClient {
    * Check if a slug corresponds to a subpage.
    */
   isSubpageSlug(slug: string): boolean {
-    return this.config.subpages.some((sp) => sp.slug === slug && sp.enabled !== false);
+    const wanted = normalizeSlug(slug);
+    return this.config.subpages.some((sp) => sp.slug === wanted && sp.enabled !== false);
   }
 
   /**


### PR DESCRIPTION
Fixes #522.

## The bug

An album named in CJK could not be opened: clicking it did nothing, and nothing appeared in the log. There turned out to be **two** independent faults on that path, the second hidden behind the first.

### 1. The slug collapsed to nothing

`slugify()` in `lib/config/schema.ts` built the slug by replacing everything outside `[a-z0-9]`, then trimming the leftover hyphens:

| name | slug (before) |
| --- | --- |
| 家族相册 | `""` |
| 写真 | `""` |
| 가족 앨범 | `""` |
| 旅行 2024 | `"2024"` |

An empty slug made `href={`/${album.slug}`}` (`components/SubpageNav.tsx`) render as `/`. The click went nowhere, no album lookup was attempted, hence nothing in the log. Two such albums also collided on the same empty slug. Running v0.12.0 against a stubbed Immich, the app's own startup summary prints it plainly:

```
📷 家族相册
   URL: /  •  1 photos  •  ID: 1111...
📷 Kloster Chorin
   URL: /kloster-chorin  •  1 photos  •  ID: 2222...
```

### 2. The route segment arrived percent-encoded

With the slug fixed, the link rendered as `/家族相册` and the click navigated — but the page came up empty. Next hands catch-all segments to the route still encoded, so `path[0]` was `%E5%AE%B6%E6%97%8F%E7%9B%B8%E5%86%8C` and matched no album:

```
[DBG] incoming slug= "%E5%AE%B6%E6%97%8F%E7%9B%B8%E5%86%8C"
      known= ["家族相册","kloster-chorin","3333..."]
```

ASCII slugs are unaffected by encoding, which is why this stayed invisible until the first fault was fixed.

## The fix

- `slugify()` separates on `[^\p{L}\p{N}]+` instead of `[^a-z0-9]+`, so letters and digits survive in any script. Latin diacritics still fold via NFD (`Café` → `cafe`); an NFC pass at the end recomposes Hangul, which NFD splits into jamo — only the composed form matches what a browser sends back.
- New `albumSlug(name, id)` falls back to the album id when a name yields no slug at all (pure emoji), keeping such albums reachable and distinct.
- New `normalizeSlug()` percent-decodes and then composes to NFC. `app/[...path]/page.tsx` applies it to its path segments once, at the boundary, so every comparison downstream sees the same form; `lib/immich.ts` and `lib/auth.ts` use it on the slugs they are handed. A malformed percent sequence is compared as-is rather than throwing a 500. No stored slug can contain a `%`, so decoding cannot collide with a real slug.
- `PageBuilder.tsx` had a second, diverging copy of `slugify()` without the diacritic fold — its admin slug preview showed `sch-ne-aussicht` where the real slug was `schone-aussicht`. It now imports the shared function.

Existing ASCII slugs are unchanged, so no published URL moves.

## Verification

**Unit** — 13 new tests (`config.test.ts`, `immich.test.ts`), each confirmed to fail without the corresponding fix. Full suite 603 passed / 49 files. `tsc --noEmit` clean, `prettier --check` clean on all touched files, `next build` succeeds.

**In a browser** — a stubbed Immich serving three albums (CJK, ASCII control, emoji-only), the real production build, and Playwright clicking the actual links:

```
[CJK album]
  PASS  homepage renders an album link for CJK album (href=/家族相册)
  PASS  clicking navigates to http://localhost:3010/家族相册
  PASS  album header shows "家族相册"
  PASS  album page renders 1 image(s)
[ASCII control]        4/4 PASS
[emoji-only album]     4/4 PASS
```

The same run against `origin/main` reports `href=MISSING` for the CJK and emoji albums, reproducing the report; against the first commit alone it renders the link but shows no album header, reproducing fault 2.

The one remaining eslint error (`SettingsEditor.tsx:1007`) pre-exists on `main` and is untouched here.
