### PR TITLE
fix(admin): reject a release tag that is not a version (#496)

### DIFF
--- a/lib/__tests__/updateCheck.test.ts
+++ b/lib/__tests__/updateCheck.test.ts
@@ -68,7 +68,23 @@ describe('parseLatestTag', () => {
     ['an error object served with 200', { message: 'API rate limit exceeded' }],
     ['a non-string tag', { tag_name: 42 }],
     ['a tag that is not a version', { tag_name: 'nightly' }],
+    // The check only guarded the *start* of the tag, so anything beginning
+    // with a digit slipped through and was then compared as a version. A
+    // date-style tag reads as version 2024 and leaves every instance showing
+    // an update that does not exist, permanently.
+    ['a date-style tag', { tag_name: '2024-01-05' }],
+    ['a tag with a digit and then rubbish', { tag_name: '1abc' }],
   ])('returns null for %s', (_label, payload) => {
     expect(parseLatestTag(payload)).toBeNull();
+  });
+
+  it('still accepts the shapes the project actually tags', () => {
+    expect(parseLatestTag({ tag_name: 'v0.13.0' })).toBe('v0.13.0');
+    expect(parseLatestTag({ tag_name: '0.13.0' })).toBe('0.13.0');
+    expect(parseLatestTag({ tag_name: 'v1.0' })).toBe('v1.0');
+    expect(parseLatestTag({ tag_name: 'v1.2.3-rc1' })).toBe('v1.2.3-rc1');
+    // Build metadata is ignorable for ordering, so rejecting it would mean
+    // never mentioning a release that is genuinely newer.
+    expect(parseLatestTag({ tag_name: 'v1.2.3+build.7' })).toBe('v1.2.3+build.7');
   });
 });

--- a/lib/updateCheck.ts
+++ b/lib/updateCheck.ts
@@ -41,6 +41,7 @@ export function compareVersions(a: string, b: string): number {
     version
       .trim()
       .replace(/^v/i, '')
+      .split('+')[0]
       .split('-')[0]
       .split('.')
       .map((part) => Number.parseInt(part, 10) || 0);
@@ -74,8 +75,13 @@ export function parseLatestTag(payload: unknown): string | null {
   if (typeof tag !== 'string') return null;
   const trimmed = tag.trim();
   // A tag that is not a version cannot be compared, and guessing would be
-  // worse than saying nothing.
-  return /^v?\d+(\.\d+)*/.test(trimmed) ? trimmed : null;
+  // worse than saying nothing. Anchored at both ends: guarding only the start
+  // let anything beginning with a digit through, and a date-style tag then
+  // read as version 2024 and left every instance showing an update that does
+  // not exist. A pre-release suffix is allowed but may not itself contain a
+  // '-', which is what keeps "2024-01-05" out; build metadata is allowed and
+  // ignored when ordering, as semver says.
+  return /^v?\d+(\.\d+)*(-[0-9A-Za-z.]+)?(\+[0-9A-Za-z.]+)?$/.test(trimmed) ? trimmed : null;
 }
 
 let cached: { latest: string | null; at: number } | null = null;


### PR DESCRIPTION
Found while reviewing the two admin features on `dev`. One real defect, in the update check.

## The defect

`parseLatestTag()` anchored its validation only at the *start* of the tag:

```js
return /^v?\d+(\.\d+)*/.test(trimmed) ? trimmed : null;
```

So anything beginning with a digit passed. `compareVersions()` then read the leading number as a major version:

| tag_name | accepted before | compared as | result against 0.12.0 |
| --- | --- | --- | --- |
| `2024-01-05` | yes | `2024` | **update available**, forever |
| `1abc` | yes | `1` | **update available**, forever |
| `nightly` | no | — | correctly ignored |

A single date-style or otherwise non-semver release tag would put an update notice on every instance's dashboard, on every load, with nothing the operator can do about it. The function's own comment says a tag that is not a version should yield null rather than be guessed at — these were being guessed at.

## The fix

The regex is anchored at both ends. A pre-release suffix is still allowed but may not itself contain a `-`, which is exactly what keeps a date out. Build metadata is allowed and dropped before comparing, since semver says it does not affect precedence — rejecting it would have meant staying silent about a release that really is newer.

```js
/^v?\d+(\.\d+)*(-[0-9A-Za-z.]+)?(\+[0-9A-Za-z.]+)?$/
```

Still accepted: `v0.13.0`, `0.13.0`, `v1.0`, `v1.2.3-rc1`, `v1.2.3+build.7`.

## Verification

- 4 new cases in `updateCheck.test.ts`, confirmed failing before the change.
- Full suite 729 passed / 58 files; `tsc --noEmit`, `prettier --check`, `next build` clean.
- The check was also exercised against the live releases API exactly as the module calls it — HTTP 200, `tag_name: "v0.12.0"` — so the feature works as shipped; this only hardens what it accepts.

## The rest of the review

The update check is otherwise sound: it sits behind the admin auth gate (`isAdminEnabled` + `isAdminAuthenticated`) so it discloses no version to the public, it fails quietly in every direction, and failures are cached like successes so an outage is not retried per load.

The help section (`72d7d08`) came out clean — labels resolve in both locales, the dynamic labels are correctly kept out of the shared catalogue, and the shortcut list matches the viewer's key handler key for key, which I checked by hand.

One gap noted but deliberately **not** fixed here: nothing binds `LIGHTBOX_SHORTCUTS` to the actual `keydown` handler in `Lightbox.tsx`. The two agree today, but a key added to the handler and forgotten in the catalogue would still pass every test — the drift the catalogue exists to prevent. Closing it properly needs either a rendering test or source parsing; the latter would break on any refactor of the switch, so it seemed worth raising rather than shipping.