### PR TITLE
refactor(lightbox): bind the keys from the shortcut catalogue (#473)

### DIFF
--- a/app/admin/components/HelpView.tsx
+++ b/app/admin/components/HelpView.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import DoctorModal from './DoctorModal';
 import * as Icons from './Icons';
 import { en } from '@/lib/i18n/locales/en';
-import { LIGHTBOX_SHORTCUTS, shortcutKeyLabel } from '@/lib/lightboxShortcuts';
+import { LIGHTBOX_SHORTCUTS, shortcutDisplayKeys } from '@/lib/lightboxShortcuts';
 
 /**
  * The admin help section.
@@ -50,9 +50,9 @@ export default function HelpView() {
           {LIGHTBOX_SHORTCUTS.map((shortcut) => (
             <div key={shortcut.labelKey} className="help-shortcuts-row">
               <dt className="help-shortcuts-keys">
-                {shortcut.keys.map((key) => (
+                {shortcutDisplayKeys(shortcut).map((key) => (
                   <kbd key={key} className="help-kbd">
-                    {shortcutKeyLabel(key)}
+                    {key}
                   </kbd>
                 ))}
               </dt>

--- a/components/Lightbox.tsx
+++ b/components/Lightbox.tsx
@@ -28,7 +28,11 @@ import { resolveWatermarkOpacity } from '@/lib/config/schema';
 import { formatCamera } from '@/lib/exif';
 import { buildPhotoPermalink } from '@/lib/photoHash';
 import { nextSlideshowSpeed, type SlideshowSpeed } from '@/lib/slideshow';
-import { LIGHTBOX_SHORTCUTS, shortcutKeyLabel } from '@/lib/lightboxShortcuts';
+import {
+  LIGHTBOX_SHORTCUTS,
+  lightboxActionFor,
+  shortcutDisplayKeys,
+} from '@/lib/lightboxShortcuts';
 
 export interface LightboxWatermark {
   enabled?: boolean;
@@ -286,8 +290,18 @@ export function Lightbox({
       const inTextField = target?.tagName === 'INPUT' || target?.tagName === 'TEXTAREA';
       if (e.key !== 'Escape' && (e.metaKey || e.ctrlKey || e.altKey || inTextField)) return;
 
-      switch (e.key) {
-        case 'Escape':
+      /*
+       * Which keys exist is the catalogue's business, not this handler's — see
+       * lib/lightboxShortcuts.ts. A key it does not list never gets here, and
+       * the switch below is exhaustive over LightboxAction, so an action added
+       * there without a branch here fails to compile rather than silently
+       * doing nothing.
+       */
+      const action = lightboxActionFor(e.key);
+      if (action === null) return;
+
+      switch (action) {
+        case 'close':
           // Innermost layer first: Esc dismisses the shortcut list, then leaves
           // fullscreen, and only closes the viewer once nothing is stacked on
           // top of it. Most browsers swallow this Esc to exit fullscreen
@@ -298,46 +312,41 @@ export function Lightbox({
           else if (document.fullscreenElement) void document.exitFullscreen().catch(() => {});
           else onClose();
           break;
-        case 'ArrowRight':
+        case 'next':
           manualNext();
           break;
-        case 'ArrowLeft':
+        case 'prev':
           manualPrev();
           break;
-        case 'i':
-        case 'I':
+        case 'info':
           if (showExifToggle) handleExifToggle();
           break;
-        // `?` is matched on the produced character, not the physical key:
-        // Shift+/ on a US layout, Shift+ß on a German one. `h` is the escape
-        // hatch for layouts where `?` is awkward — and the one key someone
-        // guesses without having been told.
-        case 's':
-        case 'S':
+        case 'slideshow':
           e.preventDefault();
           cycleSlideshow();
           break;
-        case 'd':
-        case 'D':
+        case 'download':
           if (current?.downloadUrl) {
             e.preventDefault();
             window.location.href = current.downloadUrl;
           }
           break;
-        case 'c':
-        case 'C':
+        case 'copyLink':
           e.preventDefault();
           handleCopyLink();
           break;
-        case '?':
-        case 'h':
-        case 'H':
+        case 'shortcutList':
           toggleShortcuts();
           break;
-        case 'f':
-        case 'F':
+        case 'fullscreen':
           if (canFullscreen) toggleFullscreen();
           break;
+        default: {
+          // Exhaustiveness guard: this only type-checks while every
+          // LightboxAction has a branch above.
+          const unhandled: never = action;
+          void unhandled;
+        }
       }
     };
 
@@ -393,7 +402,7 @@ export function Lightbox({
     if (shortcut.labelKey === 'shortcutSlideshow' && slideshowSeconds !== null) {
       label = t.lightbox.shortcutSlideshowRunning(slideshowSeconds);
     }
-    return { keys: shortcut.keys.map(shortcutKeyLabel), label };
+    return { keys: shortcutDisplayKeys(shortcut), label };
   });
 
   const lightboxJsx = (

--- a/lib/__tests__/lightboxShortcuts.test.ts
+++ b/lib/__tests__/lightboxShortcuts.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { LIGHTBOX_SHORTCUTS, shortcutKeyLabel } from '@/lib/lightboxShortcuts';
+import {
+  LIGHTBOX_SHORTCUTS,
+  lightboxActionFor,
+  shortcutDisplayKeys,
+  shortcutKeyLabel,
+} from '@/lib/lightboxShortcuts';
 import { en } from '@/lib/i18n/locales/en';
 import { de } from '@/lib/i18n/locales/de';
 
@@ -24,13 +29,30 @@ describe('LIGHTBOX_SHORTCUTS', () => {
 
   it('gives every shortcut at least one key', () => {
     for (const shortcut of LIGHTBOX_SHORTCUTS) {
-      expect(shortcut.keys.length, shortcut.labelKey).toBeGreaterThan(0);
+      expect(shortcut.bindings.length, shortcut.labelKey).toBeGreaterThan(0);
+      for (const binding of shortcut.bindings) {
+        expect(binding.eventKeys.length, binding.display).toBeGreaterThan(0);
+      }
     }
   });
 
   it('binds no key twice, which would make the list contradict itself', () => {
-    const keys = LIGHTBOX_SHORTCUTS.flatMap((shortcut) => shortcut.keys);
+    const keys = LIGHTBOX_SHORTCUTS.flatMap((shortcut) =>
+      shortcut.bindings.map((binding) => binding.display),
+    );
     expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  /**
+   * Two rows claiming the same physical key would make the viewer's behaviour
+   * depend on the order of this list, and the help would describe one of them
+   * wrongly.
+   */
+  it('binds no KeyboardEvent.key to two actions', () => {
+    const eventKeys = LIGHTBOX_SHORTCUTS.flatMap((shortcut) =>
+      shortcut.bindings.flatMap((binding) => [...binding.eventKeys]),
+    );
+    expect(new Set(eventKeys).size).toBe(eventKeys.length);
   });
 
   it('lists each label once', () => {
@@ -43,6 +65,50 @@ describe('LIGHTBOX_SHORTCUTS', () => {
       if (shortcut.availability !== 'always') {
         expect(shortcut.note, shortcut.labelKey).toBeTruthy();
       }
+    }
+  });
+});
+
+/**
+ * The catalogue is the only route from a keypress to an action (#473), so
+ * these cover the join the viewer relies on.
+ */
+describe('lightboxActionFor', () => {
+  it('resolves every declared key to its action', () => {
+    for (const shortcut of LIGHTBOX_SHORTCUTS) {
+      for (const binding of shortcut.bindings) {
+        for (const key of binding.eventKeys) {
+          expect(lightboxActionFor(key), key).toBe(binding.action);
+        }
+      }
+    }
+  });
+
+  it('resolves the keys a visitor actually presses', () => {
+    expect(lightboxActionFor('ArrowLeft')).toBe('prev');
+    expect(lightboxActionFor('ArrowRight')).toBe('next');
+    expect(lightboxActionFor('Escape')).toBe('close');
+    expect(lightboxActionFor('?')).toBe('shortcutList');
+    expect(lightboxActionFor('h')).toBe('shortcutList');
+    expect(lightboxActionFor('H')).toBe('shortcutList');
+  });
+
+  it('takes both cases of every letter key, since Shift must not matter', () => {
+    for (const [lower, upper] of [
+      ['i', 'I'],
+      ['f', 'F'],
+      ['s', 'S'],
+      ['c', 'C'],
+      ['d', 'D'],
+    ]) {
+      expect(lightboxActionFor(lower), lower).not.toBeNull();
+      expect(lightboxActionFor(upper), upper).toBe(lightboxActionFor(lower));
+    }
+  });
+
+  it('returns null for a key the viewer does not bind', () => {
+    for (const key of ['a', 'Enter', 'Tab', ' ', 'ArrowUp', 'F5']) {
+      expect(lightboxActionFor(key), key).toBeNull();
     }
   });
 });
@@ -61,8 +127,8 @@ describe('shortcutKeyLabel', () => {
 
   it('leaves no placeholder name unrendered', () => {
     for (const shortcut of LIGHTBOX_SHORTCUTS) {
-      for (const key of shortcut.keys) {
-        expect(shortcutKeyLabel(key)).not.toMatch(/^ARROW_/);
+      for (const key of shortcutDisplayKeys(shortcut)) {
+        expect(key).not.toMatch(/^ARROW_/);
       }
     }
   });

--- a/lib/lightboxShortcuts.ts
+++ b/lib/lightboxShortcuts.ts
@@ -1,11 +1,17 @@
 /**
  * The lightbox's keyboard shortcuts, in one place (#473).
  *
- * Two things render this list: the `?` overlay the visitor sees, and the help
- * section in the admin panel, where the site owner finds out these keys exist
- * at all. Spelling the set out twice is how the two would drift — a key added
- * to the viewer and forgotten in the help is exactly as undiscoverable as it
- * was before.
+ * Three things read this list: the `?` overlay the visitor sees, the help
+ * section in the admin panel where the site owner finds out these keys exist
+ * at all, and — since this commit — the viewer's own key handler.
+ *
+ * That last one is the point. The catalogue used to describe the keys while
+ * the handler independently decided which ones it listened for, so a key added
+ * to the viewer and forgotten here stayed exactly as undiscoverable as the
+ * whole set was before, and nothing would have said so. Now a key reaches the
+ * handler only by being declared here, and `LightboxAction` is a closed union
+ * the handler switches over exhaustively: declaring an action the viewer does
+ * not implement is a type error, not a silent gap.
  *
  * The labels stay out of here: they live in the dictionaries, and the two
  * dynamic ones (fullscreen flips, the slideshow names its speed) are resolved
@@ -23,8 +29,39 @@ export type ShortcutAvailability =
   /** Only where the album offers its originals. */
   | 'download';
 
+/**
+ * What a key does. Closed on purpose: the viewer switches over this union
+ * exhaustively, so adding a member without handling it fails to compile.
+ */
+export type LightboxAction =
+  | 'close'
+  | 'prev'
+  | 'next'
+  | 'info'
+  | 'fullscreen'
+  | 'slideshow'
+  | 'copyLink'
+  | 'download'
+  | 'shortcutList';
+
+export interface ShortcutBinding {
+  /**
+   * How the key is written in the two lists. Arrows are stored as names rather
+   * than glyphs so the list survives an editor that mangles them; both
+   * renderers ask for the display form via `shortcutKeyLabel()`.
+   */
+  display: string;
+  /**
+   * The exact `KeyboardEvent.key` values that trigger it, case variants
+   * included. `?` is matched on the produced character, not the physical key:
+   * Shift+/ on a US layout, Shift+ß on a German one.
+   */
+  eventKeys: readonly string[];
+  action: LightboxAction;
+}
+
 export interface LightboxShortcut {
-  keys: string[];
+  bindings: readonly ShortcutBinding[];
   /** Key into the `lightbox` dictionary section. */
   labelKey:
     | 'shortcutNavigate'
@@ -42,47 +79,93 @@ export interface LightboxShortcut {
 
 /** In the order they are worth learning. */
 export const LIGHTBOX_SHORTCUTS: readonly LightboxShortcut[] = [
-  { keys: ['ARROW_LEFT', 'ARROW_RIGHT'], labelKey: 'shortcutNavigate', availability: 'always' },
   {
-    keys: ['I'],
+    // One row, two actions: the arrows are learnt together but do opposite
+    // things, which is why a binding carries the action rather than the row.
+    bindings: [
+      { display: 'ARROW_LEFT', eventKeys: ['ArrowLeft'], action: 'prev' },
+      { display: 'ARROW_RIGHT', eventKeys: ['ArrowRight'], action: 'next' },
+    ],
+    labelKey: 'shortcutNavigate',
+    availability: 'always',
+  },
+  {
+    bindings: [{ display: 'I', eventKeys: ['i', 'I'], action: 'info' }],
     labelKey: 'shortcutInfo',
     availability: 'exifPanel',
     note: 'Hidden where every EXIF group is switched off, and in journal entries.',
   },
   {
-    keys: ['F'],
+    bindings: [{ display: 'F', eventKeys: ['f', 'F'], action: 'fullscreen' }],
     labelKey: 'shortcutFullscreen',
     availability: 'fullscreen',
     note: 'Absent on browsers with no element fullscreen, such as Safari on iPhone.',
   },
   {
-    keys: ['S'],
+    bindings: [{ display: 'S', eventKeys: ['s', 'S'], action: 'slideshow' }],
     labelKey: 'shortcutSlideshow',
     availability: 'always',
     note: 'Cycles off, 3s, 5s, 10s and back to off. Any arrow or swipe stops it.',
   },
   {
-    keys: ['C'],
+    bindings: [{ display: 'C', eventKeys: ['c', 'C'], action: 'copyLink' }],
     labelKey: 'shortcutCopyLink',
     availability: 'always',
     note: 'Copies a link to the photo on screen. Positional: reordering the album moves where it lands.',
   },
   {
-    keys: ['D'],
+    bindings: [{ display: 'D', eventKeys: ['d', 'D'], action: 'download' }],
     labelKey: 'shortcutDownload',
     availability: 'download',
     note: 'Only for albums with download: true in gallery.yaml.',
   },
-  { keys: ['?', 'H'], labelKey: 'shortcutList', availability: 'always' },
-  { keys: ['Esc'], labelKey: 'shortcutClose', availability: 'always' },
+  {
+    // `h` is the escape hatch for layouts where `?` is awkward — and the one
+    // key someone guesses without having been told.
+    bindings: [
+      { display: '?', eventKeys: ['?'], action: 'shortcutList' },
+      { display: 'H', eventKeys: ['h', 'H'], action: 'shortcutList' },
+    ],
+    labelKey: 'shortcutList',
+    availability: 'always',
+  },
+  {
+    bindings: [{ display: 'Esc', eventKeys: ['Escape'], action: 'close' }],
+    labelKey: 'shortcutClose',
+    availability: 'always',
+  },
 ];
 
 /**
- * Arrow keys are stored as names rather than glyphs so the list survives an
- * editor that mangles them; both renderers ask for the display form here.
+ * Arrow names to glyphs. Ordinary keys pass through, so both renderers can map
+ * every display key through this without asking which kind it is.
  */
 export function shortcutKeyLabel(key: string): string {
   if (key === 'ARROW_LEFT') return String.fromCharCode(0x2190);
   if (key === 'ARROW_RIGHT') return String.fromCharCode(0x2192);
   return key;
+}
+
+/** The keys of one shortcut, ready to render. */
+export function shortcutDisplayKeys(shortcut: LightboxShortcut): string[] {
+  return shortcut.bindings.map((binding) => shortcutKeyLabel(binding.display));
+}
+
+const ACTION_BY_EVENT_KEY: ReadonlyMap<string, LightboxAction> = new Map(
+  LIGHTBOX_SHORTCUTS.flatMap((shortcut) =>
+    shortcut.bindings.flatMap((binding) =>
+      binding.eventKeys.map((key) => [key, binding.action] as const),
+    ),
+  ),
+);
+
+/**
+ * What a `KeyboardEvent.key` should do, or null if the viewer does not bind it.
+ *
+ * This is the only route from a keypress to an action, so a key the catalogue
+ * does not list cannot reach the viewer, and one it does list cannot be
+ * silently missing from the help.
+ */
+export function lightboxActionFor(eventKey: string): LightboxAction | null {
+  return ACTION_BY_EVENT_KEY.get(eventKey) ?? null;
 }


### PR DESCRIPTION
Closes the gap left open when the help section landed: `LIGHTBOX_SHORTCUTS` described the keys, while `Lightbox.tsx` independently decided which ones it listened for.

## Why

The two agree today — I checked them key for key. But nothing held them together. A key added to the `switch` and forgotten in the catalogue would have stayed exactly as undiscoverable as the whole set was before the help section existed, and no test would have said so. That is the failure the catalogue was introduced to prevent, and it only ever covered the two *renderers*, never the behaviour.

## What changed

A binding now carries both halves:

```ts
{ display: 'S', eventKeys: ['s', 'S'], action: 'slideshow' }
```

- The handler resolves `e.key` through `lightboxActionFor()` and switches over `LightboxAction`. A key the catalogue does not list cannot reach the handler at all.
- `LightboxAction` is a closed union and the switch ends in a `never` assignment, so an action the catalogue declares but the viewer does not implement **fails to compile**. Demonstrated by adding a `'zoom'` action with no branch:

  ```
  components/Lightbox.tsx(347,17): error TS2322: Type '"zoom"' is not assignable to type 'never'.
  ```

- Both renderers take their keys from `shortcutDisplayKeys()`, so display and behaviour come from one list.

I chose this over a test that parses the `case` labels out of the source. That would have caught the same drift, but broken on any refactor of the handler — a guard that has to be repaired every time the code it guards is touched does not survive long.

## Behaviour is unchanged

That is the risk in this PR, so it was checked in a real browser rather than reasoned about:

```
[navigation]   ArrowRight advances (Photo 1 of 3 -> Photo 2 of 3), ArrowLeft goes back
[info panel]   i toggles it
[slideshow]    s starts it, it advances on its own, an arrow stops it
[copy link]    c copies http://localhost:3000/deutschland/kloster-chorin#photo-1
[panel]        ? opens it, arrows render as glyphs, Esc dismisses the panel
               before the viewer, a second Esc closes the viewer
[unbound]      a / ArrowUp / Tab / F5 leave the viewer alone
```

The repo's own `e2e/lightbox-shortcuts.spec.ts` passes (4/4) against the refactored handler.

One thing worth naming because it looks like a regression and is not: `Enter` and `Space` close the viewer, because focus sits on the close button and the browser activates it. I checked the same keys against unmodified `dev` — identical there. Not touched by this change.

## Verification

- Full suite **801 passed / 61 files** (796 on `dev`, plus 5 new covering the resolver and binding uniqueness).
- `tsc --noEmit` clean, `prettier --check` clean, `next build` succeeds.
- The one eslint error (`SettingsEditor.tsx`) pre-exists on `dev` and is untouched.