### PR TITLE
fix(map): reduce the place name with the precision (#469)

### DIFF
--- a/app/api/map/route.ts
+++ b/app/api/map/route.ts
@@ -10,7 +10,12 @@ import { getConfig } from '@/lib/config';
 import { imageUrl } from '@/lib/urls';
 import { isAuthenticated, siteLockResponse } from '@/lib/auth';
 import { getMapData } from '@/lib/mapService';
-import { applyPrecision, strictestPrecision, type LocationPrecision } from '@/lib/mapPrecision';
+import {
+  applyPrecision,
+  placeLabel,
+  strictestPrecision,
+  type LocationPrecision,
+} from '@/lib/mapPrecision';
 import { ImmichUnavailableError } from '@/lib/immich';
 import { checkRateLimit, getClientIp, retryAfterSeconds } from '@/lib/rate-limit';
 
@@ -117,15 +122,21 @@ export async function GET(request: NextRequest) {
        * Quantised here, server-side: coordinates are never sent exact for the
        * client to round.
        */
+      const level = strictestPrecision(allowedAlbums.map((a) => precisionOf(a.id)));
       const position = applyPrecision(
         { lat: latSum / photoCount, lng: lngSum / photoCount },
-        strictestPrecision(allowedAlbums.map((a) => precisionOf(a.id))),
+        level,
       );
       if (!position) return null;
 
+      // The name has to follow the coordinates down. Rounding the position to
+      // a 100 km cell while still calling the marker "Chorin" left the label
+      // more precise than the position it was meant to blur.
+      const place = placeLabel(level, { city: loc.city, country: loc.country });
+
       return {
-        city: loc.city,
-        country: loc.country,
+        city: place.city,
+        country: place.country,
         lat: position.lat,
         lng: position.lng,
         photoCount,

--- a/components/MapView.tsx
+++ b/components/MapView.tsx
@@ -103,12 +103,20 @@ export function MapView() {
           )
           .join('');
 
+        /*
+         * An album set to `location: country` has no city name to show — the
+         * API withholds it rather than naming a village inside a 100 km cell
+         * (#469). The country then carries the heading on its own.
+         */
+        const heading = loc.city || loc.country;
+        const subheading = loc.city ? loc.country : '';
+
         const popupHtml = `
           <div class="map-popup">
-            <img src="${escapeHtml(loc.coverUrl)}" alt="${escapeHtml(loc.city)}" class="map-popup__cover" loading="lazy" />
+            <img src="${escapeHtml(loc.coverUrl)}" alt="${escapeHtml(heading)}" class="map-popup__cover" loading="lazy" />
             <div class="map-popup__body">
-              <h3 class="map-popup__city">${escapeHtml(loc.city)}</h3>
-              <p class="map-popup__country">${escapeHtml(loc.country)}</p>
+              <h3 class="map-popup__city">${escapeHtml(heading)}</h3>
+              ${subheading ? `<p class="map-popup__country">${escapeHtml(subheading)}</p>` : ''}
               <p class="map-popup__count">${escapeHtml(t.common.photos(loc.photoCount))}</p>
               <div class="map-popup__albums">${albumLinks}</div>
             </div>

--- a/lib/__tests__/mapPrecision.test.ts
+++ b/lib/__tests__/mapPrecision.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
+  placeLabel,
   isLocationPrecision,
   strictestPrecision,
   quantiseCoordinate,
@@ -102,5 +103,30 @@ describe('applyPrecision', () => {
   /** Not {0,0} — the caller must drop the marker, not place it in the Atlantic. */
   it('returns null for hidden', () => {
     expect(applyPrecision(berlin, 'hidden')).toBeNull();
+  });
+});
+
+/**
+ * Quantising the coordinates while still naming the city left the label more
+ * precise than the position it was meant to blur: a 1° grid cell is ~100 km,
+ * and "Kloster Chorin" is a village.
+ */
+describe('placeLabel', () => {
+  const place = { city: 'Chorin', country: 'Germany' };
+
+  it('keeps the city at exact', () => {
+    expect(placeLabel('exact', place)).toEqual({ city: 'Chorin', country: 'Germany' });
+  });
+
+  it('keeps the city at city precision, which is roughly what a city name says', () => {
+    expect(placeLabel('city', place)).toEqual({ city: 'Chorin', country: 'Germany' });
+  });
+
+  it('drops the city at country precision', () => {
+    expect(placeLabel('country', place)).toEqual({ city: '', country: 'Germany' });
+  });
+
+  it('drops both when the marker is hidden, so a caller cannot leak one by accident', () => {
+    expect(placeLabel('hidden', place)).toEqual({ city: '', country: '' });
   });
 });

--- a/lib/mapPrecision.ts
+++ b/lib/mapPrecision.ts
@@ -84,3 +84,24 @@ export function applyPrecision(
     lng: quantiseCoordinate(position.lng, level),
   };
 }
+
+/**
+ * The place name a marker may carry at this precision.
+ *
+ * Quantising the coordinates is only half of withholding a position: the
+ * marker is also *named*, and a city name is far more precise than the 1° grid
+ * `country` snaps to. At `country` the name is reduced to the country, which
+ * is what the coordinates already say. `city` keeps it — a 0.05° cell is
+ * roughly what naming a city discloses anyway.
+ *
+ * `hidden` returns neither, so a caller that forgets to drop the marker
+ * entirely cannot leak the place through its label.
+ */
+export function placeLabel(
+  level: LocationPrecision,
+  place: { city: string; country: string },
+): { city: string; country: string } {
+  if (level === 'hidden') return { city: '', country: '' };
+  if (level === 'country') return { city: '', country: place.country };
+  return { city: place.city, country: place.country };
+}


### PR DESCRIPTION
Follow-up from reviewing `379681e`.

## The gap

The quantisation itself is sound — fixed global grid rather than per-request jitter, strictest setting governs a merged marker, `hidden` drops the album before aggregation, an unknown value throws. But the marker is not only positioned, it is also *named*, and the name was passed through untouched:

```ts
return {
  city: loc.city,        // ← straight from Immich's reverse geocoding
  country: loc.country,
  lat: position.lat,     // ← quantised
```

So `location: country` rounds the position to a 1° cell — about 100 km — and then labels it "Chorin". The label is far more precise than the coordinates it accompanies, which is the thing the setting exists to prevent. `lib/mapPrecision.ts` names this exact failure in its own header: *"the marker is named after the city and stands on the property"*.

## The fix

`placeLabel(level, place)` reduces the name alongside the position:

| level | city | country |
| --- | --- | --- |
| `exact` | kept | kept |
| `city` | kept | kept |
| `country` | **dropped** | kept |
| `hidden` | dropped | dropped |

`city` keeps the name on purpose: a 0.05° cell is roughly what naming a city discloses anyway, so removing it would cost information without buying privacy. `hidden` returns neither, so a caller that forgets to drop the marker cannot leak the place through its label — the route already drops it, this is the belt.

`MapView` lets the country carry the popup heading when there is no city, instead of rendering an empty `<h3>`.

## Verification

- 4 new cases in `mapPrecision.test.ts`, confirmed failing before the change.
- Full suite 805 passed / 61 files; `tsc --noEmit`, `prettier --check`, `next build` clean.

## Related, not fixed here

While tracing this I found the lightbox EXIF panel names `city` and `country` per photo (`app/api/exif/[id]/route.ts:92`). It is gated on the **global** `exifDisplay` `location` group, not on this per-album setting — so an album set to `location: hidden` still has its city named there, as long as that group is on. Two settings with almost the same name disagreeing about the same fact. Left alone deliberately: it is a separate decision about what `location:` is meant to govern.
