### PR TITLE
fix(download): check every gate on the route to the album (#475)

### DIFF
--- a/app/api/download/[album]/[id]/route.ts
+++ b/app/api/download/[album]/[id]/route.ts
@@ -9,7 +9,8 @@
  *
  *   - the album must be on the allowlist,
  *   - the album must have opted in with `download: true`,
- *   - the album's password gate must be satisfied, and
+ *   - every password gate on a route to it must be satisfied — the album's own
+ *     and, where that is the only way to it, the subpage's, and
  *   - the asset must actually belong to that album.
  *
  * The last one is what stops one enabled album's URL being edited into a
@@ -22,7 +23,7 @@ import { immich, ImmichUnavailableError } from '@/lib/immich';
 import { decodeAssetId } from '@/lib/tokens';
 import { getConfig } from '@/lib/config';
 import { checkRateLimit, getClientIp, retryAfterSeconds } from '@/lib/rate-limit';
-import { isAuthenticated, siteLockResponse } from '@/lib/auth';
+import { isAlbumReachable, siteLockResponse } from '@/lib/auth';
 import { contentDisposition } from '@/lib/downloadName';
 
 export const dynamic = 'force-dynamic';
@@ -74,11 +75,14 @@ export async function GET(
   if (!config.albums.includes(albumId)) return notFound();
   if (!config.albumDownloads[albumId]) return notFound();
 
-  // The album's own password gate. The page checks this before rendering; a
-  // route handler is reached without ever passing through the page.
+  // Every gate on every route to the album, not just its own: an album with no
+  // password of its own, reachable only through a subpage that has one, was
+  // downloadable without that subpage ever being unlocked. The page checks
+  // this before rendering; a route handler is reached without passing through
+  // the page at all.
   const cookieStore = await cookies();
   const getCookie = (name: string) => cookieStore.get(name)?.value;
-  if (!isAuthenticated(albumId, getCookie, 'album')) return notFound();
+  if (!isAlbumReachable(albumId, getCookie)) return notFound();
 
   let album;
   try {

--- a/lib/__tests__/auth.test.ts
+++ b/lib/__tests__/auth.test.ts
@@ -6,11 +6,17 @@ vi.mock('@/lib/config', () => ({
   getConfig: () => ({
     immich: { apiKey: 'test-api-key-for-auth-tests' },
     authSecret: 'test-auth-secret-32-chars-long-min',
+    standaloneAlbums: ['00000000-0000-0000-0000-000000000004'],
+    albumPasswords: { '00000000-0000-0000-0000-000000000005': 'albumpass' },
     subpages: [
       {
         name: 'Private',
         slug: 'private',
-        albumIds: ['00000000-0000-0000-0000-000000000001'],
+        albumIds: [
+          '00000000-0000-0000-0000-000000000001',
+          '00000000-0000-0000-0000-000000000004',
+          '00000000-0000-0000-0000-000000000005',
+        ],
         password: 'secret123',
       },
       {
@@ -32,7 +38,13 @@ vi.mock('@/lib/config', () => ({
   }),
 }));
 
-import { isProtected, authenticate, isAuthenticated, findSubpageBySlug } from '@/lib/auth';
+import {
+  isProtected,
+  authenticate,
+  isAuthenticated,
+  isAlbumReachable,
+  findSubpageBySlug,
+} from '@/lib/auth';
 
 describe('findSubpageBySlug', () => {
   it('returns the subpage config for a known slug', () => {
@@ -195,5 +207,54 @@ describe('token expiry', () => {
     const maxAge = Number(cookie.match(/Max-Age=(\d+)/)![1]);
     const exp = Number(cookie.split('=')[1].split(';')[0].split('.')[0]);
     expect(Math.abs(exp - (Date.now() + maxAge * 1000))).toBeLessThan(2000);
+  });
+});
+
+/**
+ * A route handler is reached without ever passing through the page that would
+ * have asked for the subpage password, so it has to ask the same question
+ * itself (#475).
+ */
+describe('isAlbumReachable', () => {
+  const IN_PRIVATE = '00000000-0000-0000-0000-000000000001';
+  const IN_PUBLIC = '00000000-0000-0000-0000-000000000002';
+  const ALSO_STANDALONE = '00000000-0000-0000-0000-000000000004';
+  const OWN_PASSWORD = '00000000-0000-0000-0000-000000000005';
+  const none = () => undefined;
+
+  async function cookieFor(key: string, password: string, type: 'subpage' | 'album' = 'subpage') {
+    const header = (await authenticate(key, password, type))!;
+    const token = header.split('=')[1].split(';')[0];
+    const name = header.split('=')[0];
+    return (asked: string) => (asked === name ? token : undefined);
+  }
+
+  it('allows an album in a subpage that asks for nothing', () => {
+    expect(isAlbumReachable(IN_PUBLIC, none)).toBe(true);
+  });
+
+  it('refuses an album whose only route is a protected subpage', () => {
+    expect(isAlbumReachable(IN_PRIVATE, none)).toBe(false);
+  });
+
+  it('allows it once that subpage has been unlocked', async () => {
+    const getCookie = await cookieFor('private', 'secret123');
+    expect(isAlbumReachable(IN_PRIVATE, getCookie)).toBe(true);
+  });
+
+  // Listing an album on the home page publishes it, whatever else it is in.
+  it('allows a standalone album even when a protected subpage also lists it', () => {
+    expect(isAlbumReachable(ALSO_STANDALONE, none)).toBe(true);
+  });
+
+  it('still refuses an album that carries its own password', async () => {
+    const subpageOnly = await cookieFor('private', 'secret123');
+    expect(isAlbumReachable(OWN_PASSWORD, subpageOnly)).toBe(false);
+  });
+
+  it('allows that one once its own password is given too', async () => {
+    const subpage = await cookieFor('private', 'secret123');
+    const album = await cookieFor(OWN_PASSWORD, 'albumpass', 'album');
+    expect(isAlbumReachable(OWN_PASSWORD, (n) => subpage(n) ?? album(n))).toBe(true);
   });
 });

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -96,6 +96,37 @@ function cookieName(key: string, type: ProtectedType): string {
 export const SITE_AUTH_COOKIE = 'lb_site_auth';
 
 /**
+ * Whether this visitor may have the album at all — every gate on every route
+ * to it, not just the album's own (#475).
+ *
+ * A page checks the subpage's password before it renders anything; a route
+ * handler is reached without ever passing through that page, so it has to ask
+ * the same question itself. Checking only the album's own password let an
+ * album that carries none through, even when the sole way to it was a subpage
+ * that does.
+ *
+ * An album listed on the home page is published there whatever else lists it,
+ * so it stays reachable. Where the only routes are subpages, one of them has
+ * to be open — which mirrors what the visitor could actually have clicked.
+ */
+export function isAlbumReachable(
+  albumId: string,
+  getCookie: (name: string) => string | undefined,
+): boolean {
+  if (!isAuthenticated(albumId, getCookie, 'album')) return false;
+
+  const config = getConfig();
+  if (config.standaloneAlbums?.includes(albumId)) return true;
+
+  const routes = config.subpages.filter(
+    (sp) => sp.enabled !== false && sp.albumIds.includes(albumId),
+  );
+  if (routes.length === 0) return true;
+
+  return routes.some((sp) => isAuthenticated(sp.slug, getCookie, 'subpage'));
+}
+
+/**
  * Find the SubpageConfig for a given slug.
  */
 export function findSubpageBySlug(slug: string): SubpageConfig | undefined {


### PR DESCRIPTION
Follow-up from reviewing `8106741`.

## The gap

The route is otherwise thorough — rate limit, site lock, allowlist, opt-in, uniform 404 for every refusal, and the check that the asset really belongs to the album that authorised the download. But the password check was:

```ts
if (!isAuthenticated(albumId, getCookie, 'album')) return notFound();
```

`isAuthenticated` returns `true` when the key carries no password at all (`lib/auth.ts:208`, *"not protected"*). So an album with `download: true` and no password of its own, reachable **only** through a subpage that does have one, was downloadable without that subpage ever being unlocked.

The route's own header states the principle it missed:

> Originals are the deliverable a client pays for, so this route re-checks everything rather than inheriting that assumption

The map route already asks both questions (`isSubpageAllowed(a.subpageSlug) && isAlbumAllowed(a.id)`). Downloads did not.

## Severity, honestly

Not a wide-open door: the URL carries opaque tokens that come from the rendered page, so an attacker cannot simply enumerate albums. What it does mean is that **the tokens outlive access** — a client removed from a protected subpage keeps working download links to the originals, which is exactly the case the opt-in was built for.

## The fix

`isAlbumReachable(albumId, getCookie)` walks the routes to an album instead of looking only at the album:

- the album's own gate must be satisfied, always;
- an album listed on the home page is published there whatever else lists it, so it stays reachable;
- otherwise at least one subpage carrying it must be unlocked — which mirrors what the visitor could actually have clicked.

## Verification

- 6 new cases in `auth.test.ts`, confirmed failing before the change, covering: public subpage, protected subpage locked and unlocked, an album that is standalone *and* inside a protected subpage, and an album carrying its own password on top.
- Full suite 807 passed / 61 files; `tsc --noEmit`, `prettier --check`, `next build` clean.
