### PR TITLE
fix(seo): percent-encode paths in absolute URLs (#472)

### DIFF
--- a/lib/__tests__/siteUrl.test.ts
+++ b/lib/__tests__/siteUrl.test.ts
@@ -109,3 +109,42 @@ describe('absoluteUrl', () => {
     expect(absoluteUrl(null, '/travel')).toBeNull();
   });
 });
+
+/**
+ * A sitemap, a canonical link and a JSON-LD block all want a URI, not an IRI.
+ * Non-Latin album slugs only became possible with #522, so this surfaced with
+ * them.
+ */
+describe('absoluteUrl encoding', () => {
+  it('percent-encodes a non-ASCII path', () => {
+    expect(absoluteUrl('https://example.com', '/家族相册')).toBe(
+      'https://example.com/%E5%AE%B6%E6%97%8F%E7%9B%B8%E5%86%8C',
+    );
+  });
+
+  it('leaves an ASCII path exactly as it was', () => {
+    expect(absoluteUrl('https://example.com', '/kloster-chorin')).toBe(
+      'https://example.com/kloster-chorin',
+    );
+  });
+
+  it('keeps a query string intact', () => {
+    expect(absoluteUrl('https://example.com', '/api/image/abc?size=preview')).toBe(
+      'https://example.com/api/image/abc?size=preview',
+    );
+  });
+
+  // A portfolio may live under a sub-path, which normaliseSiteUrl keeps.
+  it('preserves a sub-path in the site URL', () => {
+    expect(absoluteUrl('https://example.com/folio', '/家族相册')).toBe(
+      'https://example.com/folio/%E5%AE%B6%E6%97%8F%E7%9B%B8%E5%86%8C',
+    );
+  });
+
+  // Encoding blindly would turn a '%' into '%25' and corrupt the URL.
+  it('does not encode an already-encoded path a second time', () => {
+    expect(absoluteUrl('https://example.com', '/%E5%AE%B6%E6%97%8F%E7%9B%B8%E5%86%8C')).toBe(
+      'https://example.com/%E5%AE%B6%E6%97%8F%E7%9B%B8%E5%86%8C',
+    );
+  });
+});

--- a/lib/siteUrl.ts
+++ b/lib/siteUrl.ts
@@ -74,6 +74,21 @@ export function resolveSiteUrl(
  */
 export function absoluteUrl(siteUrl: string | null, path: string): string | null {
   if (!siteUrl) return null;
-  const suffix = path.startsWith('/') ? path : `/${path}`;
-  return `${siteUrl}${suffix === '/' ? '/' : suffix.replace(/\/+$/, '')}`;
+  const raw = path.startsWith('/') ? path : `/${path}`;
+  const suffix = raw === '/' ? '/' : raw.replace(/\/+$/, '');
+  return `${siteUrl}${encodePathBytes(suffix)}`;
+}
+
+/**
+ * Percent-encode exactly what a URI may not carry: anything outside printable
+ * ASCII. Album slugs keep their own script since #522, so a path can now hold
+ * characters a sitemap, a canonical link or a JSON-LD block must not.
+ *
+ * Deliberately not `encodeURI()`, which would also re-encode the `%` of an
+ * already-encoded path and corrupt it, and deliberately not `new URL(path,
+ * siteUrl)`, which would drop the sub-path a portfolio may be published under
+ * — the one thing `normaliseSiteUrl()` goes out of its way to keep.
+ */
+function encodePathBytes(path: string): string {
+  return path.replace(/[^\x20-\x7E]/g, (character) => encodeURIComponent(character));
 }


### PR DESCRIPTION
Follow-up from reviewing `368f90d`.

## The gap

`lib/publicPages.ts` is the strong part of that commit — inheritance is handled (a public album under a protected subpage is not listed), drafts, `hidden`, `enabled: false`, the site lock, dedup, all as a pure function with tests. Nothing to add there.

`absoluteUrl()` joined the site URL and the path by plain concatenation:

```js
https://example.com + /家族相册  →  https://example.com/家族相册
```

That is an IRI, not a URI. The sitemap protocol wants URLs percent-encoded, and the same value feeds the canonical link, the OG tags and the JSON-LD block.

This only became reachable with #522: before that fix, an album whose name was not written in Latin script had no slug at all, so no such path could exist.

## The fix

Only characters outside printable ASCII are encoded:

- **not** `encodeURI()` — it would also re-encode the `%` of an already-encoded path and corrupt it;
- **not** `new URL(path, siteUrl)` — it would drop the sub-path a portfolio may be published under, which is the one thing `normaliseSiteUrl()` goes out of its way to keep.

## Verification

- 5 new cases in `siteUrl.test.ts`, 2 confirmed failing before the change: non-ASCII encoding, ASCII untouched, query string intact, sub-path preserved, and no double-encoding of an already-encoded path.
- Full suite 806 passed / 61 files; `tsc --noEmit`, `prettier --check`, eslint and `next build` clean.
