### PR TITLE
fix(exif): let the album's location precision govern the info panel (#469)

### DIFF
--- a/app/api/exif/[id]/route.ts
+++ b/app/api/exif/[id]/route.ts
@@ -11,6 +11,8 @@ import { decodeAssetId } from '@/lib/tokens';
 import { getConfig } from '@/lib/config';
 import { checkRateLimit, getClientIp, retryAfterSeconds } from '@/lib/rate-limit';
 import { siteLockResponse } from '@/lib/auth';
+import { assetLocationPrecision } from '@/lib/assetLocation';
+import { placeLabel } from '@/lib/mapPrecision';
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const config = getConfig();
@@ -73,6 +75,13 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
   const exif = asset.exifInfo;
   const caption = show.caption ? exif.description?.trim() || undefined : undefined;
 
+  const place = show.location
+    ? placeLabel(await assetLocationPrecision(assetId), {
+        city: exif.city ?? '',
+        country: exif.country ?? '',
+      })
+    : { city: '', country: '' };
+
   const payload = {
     ...(show.camera
       ? {
@@ -89,7 +98,15 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
           iso: exif.iso,
         }
       : {}),
-    ...(show.location ? { city: exif.city, country: exif.country } : {}),
+    // Two gates, not one. `exifDisplay.location` decides whether this site
+    // publishes places at all; the album's `location:` decides how precisely
+    // this photograph may be placed — the same setting the map obeys, which
+    // used to stop at the map (#469).
+    // Emitted only when there is something to say. An empty string is not
+    // null, so keeping the keys would defeat the "no data" check below and
+    // render the blank panel it exists to prevent.
+    ...(place.city ? { city: place.city } : {}),
+    ...(place.country ? { country: place.country } : {}),
     ...(caption ? { description: caption } : {}),
   };
 

--- a/app/api/exif/__tests__/exif-route.test.ts
+++ b/app/api/exif/__tests__/exif-route.test.ts
@@ -13,7 +13,7 @@ vi.mock('@/lib/config', () => ({
 }));
 
 vi.mock('@/lib/immich', () => ({
-  immich: { getAssetInfo: vi.fn() },
+  immich: { getAssetInfo: vi.fn(), getAlbum: vi.fn() },
   ImmichUnavailableError: class ImmichUnavailableError extends Error {},
 }));
 
@@ -36,6 +36,7 @@ import { NextRequest } from 'next/server';
 
 const mockConfig = getConfig as unknown as ReturnType<typeof vi.fn>;
 const mockAssetInfo = immich.getAssetInfo as unknown as ReturnType<typeof vi.fn>;
+const mockGetAlbum = immich.getAlbum as unknown as ReturnType<typeof vi.fn>;
 
 const EXIF_ASSET = {
   exifInfo: {
@@ -64,6 +65,9 @@ function configWith(raw?: ExifDisplayYaml, exifOnHover?: boolean) {
     exifOnHover: exifOnHover !== false,
     exif: resolveExifDisplay(raw, exifOnHover),
     rateLimitRpm: 120,
+    // No album restricts its location, so the place comes through as the
+    // asset carries it — the shape getConfig() always builds (#469).
+    albumLocationPrecision: {},
   };
 }
 
@@ -150,5 +154,42 @@ describe('GET /api/exif/[id] captions', () => {
 
     const res = await GET(makeRequest(), params);
     expect(res.status).toBe(404);
+  });
+});
+
+/**
+ * `location:` used to govern the map and nothing else, so an album asking to
+ * be absent from it still named its city here (#469).
+ */
+describe('GET /api/exif/[id] album location precision', () => {
+  /** The album that carries the asset the mocked token decodes to. */
+  const carrying = { id: 'album-a', assets: [{ id: 'asset-uuid' }] };
+
+  async function respond(precision: Record<string, string>) {
+    mockConfig.mockReturnValue({ ...configWith(), albumLocationPrecision: precision });
+    mockAssetInfo.mockResolvedValue(EXIF_ASSET);
+    mockGetAlbum.mockResolvedValue(carrying);
+    const res = await GET(new NextRequest('http://localhost/api/exif/token'), {
+      params: Promise.resolve({ id: 'token' }),
+    });
+    return res.json();
+  }
+
+  it('names the city when nothing restricts it', async () => {
+    expect(await respond({})).toMatchObject({ city: 'Vienna', country: 'Austria' });
+  });
+
+  it('drops the city but keeps the country at country precision', async () => {
+    const body = await respond({ 'album-a': 'country' });
+    expect(body.country).toBe('Austria');
+    expect(body).not.toHaveProperty('city');
+  });
+
+  it('names no place at all when the album is hidden', async () => {
+    const body = await respond({ 'album-a': 'hidden' });
+    expect(body).not.toHaveProperty('city');
+    expect(body).not.toHaveProperty('country');
+    // The rest of the panel is untouched.
+    expect(body.model).toBe('X-T5');
   });
 });

--- a/content/gallery.yaml.example
+++ b/content/gallery.yaml.example
@@ -80,18 +80,21 @@ subpages:
           #   album, so an edited URL cannot reach anything else.
           #
           # location: city
-          #   How precisely this album may be placed on the map.
+          #   How precisely this album's photographs may be placed — on the
+          #   map, and in the info panel of the viewer, which names the city
+          #   and country of each photo.
           #     exact    (default) the mean of the photographs' own coordinates
-          #     city     rounded to 0.05° — roughly 5 km
-          #     country  rounded to 1° — roughly 100 km
-          #     hidden   the album does not appear on the map at all
+          #     city     rounded to 0.05° — roughly 5 km, city still named
+          #     country  rounded to 1° — roughly 100 km, only the country named
+          #     hidden   no marker on the map, and no place in the info panel
           #   Worth setting for an album shot in one place — a garden, a
           #   studio, a client's home, a fragile site — where the mean of the
           #   coordinates is that place, and the marker stands on the property.
           #   May also be set once on a subpage, where it applies to every
           #   album on it unless the album says otherwise.
           #   Where one marker merges several albums, the most cautious of
-          #   them governs the whole marker.
+          #   them governs the whole marker. A photograph that is in several
+          #   albums likewise follows the most cautious of them.
 
   # ── Subpage with Sections ────────────────────────────────────────
   # Use sections to group albums by location, theme, or any other logic.

--- a/lib/__tests__/assetLocation.test.ts
+++ b/lib/__tests__/assetLocation.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { LocationPrecision } from '@/lib/mapPrecision';
+
+/**
+ * The per-album `location:` setting governed the map and nothing else, so an
+ * album asking to be absent from it still had its city named in the lightbox
+ * info panel. These pin the join: an asset inherits the setting of the albums
+ * that carry it.
+ */
+const albumLocationPrecision: Record<string, LocationPrecision> = {};
+
+vi.mock('@/lib/config', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/config')>('@/lib/config');
+  return {
+    ...actual,
+    getConfig: () => ({ albumLocationPrecision }),
+  };
+});
+
+const getAlbum = vi.fn();
+vi.mock('@/lib/immich', () => ({
+  immich: { getAlbum: (id: string) => getAlbum(id) },
+}));
+
+import { assetLocationPrecision } from '@/lib/assetLocation';
+
+const ASSET = 'asset-1';
+const OTHER = 'asset-2';
+
+/** An album whose assets are just ids. */
+const album = (id: string, assetIds: string[]) => ({
+  id,
+  assets: assetIds.map((a) => ({ id: a })),
+});
+
+beforeEach(() => {
+  for (const key of Object.keys(albumLocationPrecision)) delete albumLocationPrecision[key];
+  getAlbum.mockReset();
+});
+
+describe('assetLocationPrecision', () => {
+  it('is exact when no album restricts anything, without asking Immich at all', async () => {
+    await expect(assetLocationPrecision(ASSET)).resolves.toBe('exact');
+    // The common case must not cost a single album fetch.
+    expect(getAlbum).not.toHaveBeenCalled();
+  });
+
+  it('takes the setting of an album that carries the asset', async () => {
+    albumLocationPrecision['album-a'] = 'country';
+    getAlbum.mockResolvedValue(album('album-a', [ASSET]));
+    await expect(assetLocationPrecision(ASSET)).resolves.toBe('country');
+  });
+
+  it('ignores an album that restricts but does not carry the asset', async () => {
+    albumLocationPrecision['album-a'] = 'hidden';
+    getAlbum.mockResolvedValue(album('album-a', [OTHER]));
+    await expect(assetLocationPrecision(ASSET)).resolves.toBe('exact');
+  });
+
+  // Same rule as a merged map marker: the cautious setting governs.
+  it('takes the strictest when several albums carry the asset', async () => {
+    albumLocationPrecision['album-a'] = 'city';
+    albumLocationPrecision['album-b'] = 'hidden';
+    getAlbum.mockImplementation(async (id: string) => album(id, [ASSET]));
+    await expect(assetLocationPrecision(ASSET)).resolves.toBe('hidden');
+  });
+
+  it('only asks about albums that actually restrict something', async () => {
+    albumLocationPrecision['album-a'] = 'exact';
+    albumLocationPrecision['album-b'] = 'city';
+    getAlbum.mockImplementation(async (id: string) => album(id, [ASSET]));
+    await assetLocationPrecision(ASSET);
+    expect(getAlbum).toHaveBeenCalledTimes(1);
+    expect(getAlbum).toHaveBeenCalledWith('album-b');
+  });
+
+  // Failing open would publish the position the setting exists to withhold.
+  it('withholds the place when an album cannot be read', async () => {
+    albumLocationPrecision['album-a'] = 'city';
+    getAlbum.mockRejectedValue(new Error('Immich is down'));
+    await expect(assetLocationPrecision(ASSET)).resolves.toBe('hidden');
+  });
+
+  it('withholds it when the album is gone from the allowlist', async () => {
+    albumLocationPrecision['album-a'] = 'city';
+    getAlbum.mockResolvedValue(null);
+    await expect(assetLocationPrecision(ASSET)).resolves.toBe('hidden');
+  });
+});

--- a/lib/assetLocation.ts
+++ b/lib/assetLocation.ts
@@ -1,0 +1,58 @@
+/**
+ * The location precision that applies to a single photograph (#469).
+ *
+ * `location:` was written for the map, and the map was the only surface that
+ * honoured it. The lightbox info panel names the city and country of every
+ * photo from its own EXIF, gated on the global `exifDisplay` group — so an
+ * album set to `location: hidden`, which asks to be absent from the map
+ * entirely, still told anyone who clicked "Info" exactly where it was taken.
+ * Two settings with almost the same name disagreeing about the same fact.
+ *
+ * An asset has no album in its own right: the info request carries only an
+ * asset token. So the question is turned around — of the albums the operator
+ * deliberately restricted, which ones carry this asset?
+ *
+ * That keeps the common case free. Nobody using `location:` means nothing to
+ * check and no album fetched; the cost is bounded by how many albums were
+ * restricted, not by how many exist.
+ */
+
+import { getConfig } from './config';
+import { immich } from './immich';
+import { strictestPrecision, type LocationPrecision } from './mapPrecision';
+
+/**
+ * The strictest `location:` among the albums carrying this asset, or `exact`
+ * when none of them restricts anything.
+ *
+ * An album that cannot be read counts as `hidden`. Membership is then unknown,
+ * and guessing that the asset is not in it would publish the position the
+ * setting exists to withhold — so this fails closed, at the cost of the info
+ * panel dropping its location line site-wide until the album is readable
+ * again. A configured album that Immich no longer has is already a warning in
+ * the config doctor.
+ */
+export async function assetLocationPrecision(assetId: string): Promise<LocationPrecision> {
+  const restricted = Object.entries(getConfig().albumLocationPrecision).filter(
+    ([, level]) => level !== 'exact',
+  );
+  if (restricted.length === 0) return 'exact';
+
+  const levels = await Promise.all(
+    restricted.map(async ([albumId, level]): Promise<LocationPrecision | null> => {
+      try {
+        const album = await immich.getAlbum(albumId);
+        if (!album) return 'hidden';
+        return album.assets.some((asset) => asset.id === assetId) ? level : null;
+      } catch {
+        return 'hidden';
+      }
+    }),
+  );
+
+  const applicable = levels.filter((level): level is LocationPrecision => level !== null);
+  // strictestPrecision() reads an empty list as `hidden` — correct for a map
+  // marker nothing contributed to, wrong here, where it means no restricted
+  // album carries this photograph.
+  return applicable.length === 0 ? 'exact' : strictestPrecision(applicable);
+}


### PR DESCRIPTION
The finding raised in #527. `location:` was written for the map, and the map was the only surface that honoured it.

## The gap

The lightbox info panel names the city and country of every photograph, from the asset's own EXIF:

```ts
...(show.location ? { city: exif.city, country: exif.country } : {}),
```

`show.location` is the **global** `exifDisplay` group. The per-album `location:` never reached here. So an album set to `location: hidden` — which asks to be absent from the map *entirely* — still told anyone who clicked "Info" exactly where it was taken. Two settings with almost the same name, disagreeing about the same fact.

## Turning the question around

An asset has no album of its own at this point: the request carries an asset token and nothing else. Rather than change the client contract to pass album context — which would also let anyone omit it and get the unrestricted answer — the question is inverted:

> Of the albums the operator deliberately restricted, which ones carry this asset?

That keeps the common case free. No `location:` anywhere means nothing to check and **no album fetched at all** (pinned by a test). The cost is bounded by how many albums were restricted, not by how many exist.

## Behaviour

Reduction reuses `placeLabel()`, so the panel and the map agree by construction:

| `location:` | map marker | info panel |
| --- | --- | --- |
| `exact` | exact position | city + country |
| `city` | ~5 km | city + country |
| `country` | ~100 km, city dropped | country only |
| `hidden` | no marker | no place at all |

A photograph in several restricted albums resolves like a merged marker — the most cautious governs.

## Two decisions worth challenging

**An album that cannot be read counts as `hidden`.** Membership is unknown then, and assuming the asset is *not* in it would publish the position the setting exists to withhold. The cost is blast radius: one unreadable restricted album drops the location line for every photo until it is readable again. A configured album Immich no longer has is already a warning in the config doctor, so it should not be silent — but if you would rather it failed open, this is the line to change.

**The place fields are emitted only when non-empty.** An empty string is not `null`, so keeping the keys would have defeated the route's "no EXIF data" check and rendered the blank panel that check exists to prevent.

## Verification

- 7 new unit tests for `assetLocationPrecision` and 3 at route level. The route-level ones were confirmed failing against `dev`'s route — city came through as `Vienna` at both `country` and `hidden`.
- Full suite 806 passed / 61 files; `tsc --noEmit`, `prettier --check`, `next build` clean.
- `content/gallery.yaml.example` now says the setting governs both surfaces, since it previously promised only the map.
