### PR TITLE
feat(grid): give a subpage's album covers their own grid (#523)

### DIFF
--- a/app/[...path]/page.tsx
+++ b/app/[...path]/page.tsx
@@ -251,10 +251,10 @@ export default async function PathPage({ params, searchParams }: PathPageProps) 
   const resolveLayout = (overrides?: Partial<GridConfig>) =>
     overrides?.layout ?? config.grid.layout;
 
-  // The album-cover grid on a subpage takes its column count from the same
-  // config as the photo grids, so "3 columns" in the admin means three columns
-  // everywhere. `gap` deliberately does not follow the global setting — see
-  // buildCoverGridVars() for why.
+  // The album-cover grid on a subpage is sized by its own `coverGrid`, which
+  // touches nothing but the cover tiles (#523). An unset column count still
+  // falls back to the global one; `gap` deliberately does not follow the global
+  // setting — see buildCoverGridVars() for why.
   const buildCoverGridStyle = (overrides?: Partial<GridConfig>): React.CSSProperties =>
     buildCoverGridVars(overrides, config.grid.columns) as React.CSSProperties;
 
@@ -516,7 +516,7 @@ export default async function PathPage({ params, searchParams }: PathPageProps) 
         albums={albumsWithHero}
         coverPlaceholders={coverPlaceholders}
         sections={result.subpage.sections}
-        gridStyle={buildCoverGridStyle(result.subpage.grid)}
+        gridStyle={buildCoverGridStyle(result.subpage.coverGrid)}
         {...(subpageIndex >= 0 ? { index: subpageIndex + 1 } : {})}
       />
     );

--- a/app/admin/components/PageBuilder.tsx
+++ b/app/admin/components/PageBuilder.tsx
@@ -35,6 +35,9 @@ import {
   COVER_GRID_COLUMNS_MAX,
   COVER_GRID_COLUMNS_MIN,
   COVER_GRID_GAP_MAX,
+  PHOTO_GRID_COLUMNS_MAX,
+  PHOTO_GRID_COLUMNS_MIN,
+  PHOTO_GRID_GAP_MAX,
   slugify,
   type AlbumEntryObject,
 } from '@/lib/config/schema';
@@ -125,7 +128,24 @@ interface Subpage {
   essayFile?: string;
   sections?: Section[];
   albums: AlbumEntry[];
+  /** Photo grid for the albums on this page (and the page layout style). */
   grid?: { columns?: number; gap?: number; aspectRatio?: string; layout?: string };
+  /** The album-cover tiles on this page only (#523). */
+  coverGrid?: { columns?: number; gap?: number; aspectRatio?: string; layout?: string };
+}
+
+/**
+ * The cover grid a subpage renders with when its gallery.yaml predates #523.
+ *
+ * Back then one `grid` key sized both the covers and the photos, so the values
+ * a user typed into "Album Cover Grid" live there. Seeding the new field from
+ * them means the drawer shows what the page actually renders, and the first
+ * save writes the split out explicitly. Only the two keys the cover grid reads
+ * are carried over — `layout` and `aspectRatio` never reached the covers.
+ */
+function seedCoverGrid(grid: Subpage['grid']): Subpage['coverGrid'] {
+  if (!grid) return undefined;
+  return normalizeSubpageGrid({ columns: grid.columns, gap: grid.gap });
 }
 
 /**
@@ -554,6 +574,8 @@ export default function PageBuilder() {
             }))
           : undefined,
         grid: sp.grid as Subpage['grid'],
+        coverGrid:
+          (sp.coverGrid as Subpage['coverGrid']) ?? seedCoverGrid(sp.grid as Subpage['grid']),
       }));
     } else if (raw.subpages && typeof raw.subpages === 'object') {
       subpages = Object.entries(raw.subpages as Record<string, unknown>).map(([name, value]) => {
@@ -575,6 +597,8 @@ export default function PageBuilder() {
           ),
           sections: undefined,
           grid: sp.grid as Subpage['grid'],
+          coverGrid:
+            (sp.coverGrid as Subpage['coverGrid']) ?? seedCoverGrid(sp.grid as Subpage['grid']),
         };
       });
     }
@@ -611,6 +635,7 @@ export default function PageBuilder() {
         if (sp.essayText) entry.essayText = sp.essayText;
         if (sp.essayFile) entry.essayFile = sp.essayFile;
         if (sp.grid) entry.grid = sp.grid;
+        if (sp.coverGrid) entry.coverGrid = sp.coverGrid;
 
         if (sp.sections && sp.sections.length > 0) {
           entry.sections = sp.sections.map((sec) => {
@@ -1481,14 +1506,14 @@ export default function PageBuilder() {
                                       type="number"
                                       min={COVER_GRID_COLUMNS_MIN}
                                       max={COVER_GRID_COLUMNS_MAX}
-                                      value={sp.grid?.columns ?? ''}
+                                      value={sp.coverGrid?.columns ?? ''}
                                       placeholder="Columns (site default)"
                                       onChange={(e) => {
                                         const raw = e.target.value;
                                         const columns = raw === '' ? undefined : Number(raw);
                                         updateSubpage(spIndex, {
-                                          grid: normalizeSubpageGrid({
-                                            ...(sp.grid || {}),
+                                          coverGrid: normalizeSubpageGrid({
+                                            ...(sp.coverGrid || {}),
                                             columns:
                                               columns != null &&
                                               columns >= COVER_GRID_COLUMNS_MIN &&
@@ -1509,14 +1534,14 @@ export default function PageBuilder() {
                                       type="number"
                                       min={0}
                                       max={COVER_GRID_GAP_MAX}
-                                      value={sp.grid?.gap ?? ''}
+                                      value={sp.coverGrid?.gap ?? ''}
                                       placeholder="Gap in px (theme default)"
                                       onChange={(e) => {
                                         const raw = e.target.value;
                                         const gap = raw === '' ? undefined : Number(raw);
                                         updateSubpage(spIndex, {
-                                          grid: normalizeSubpageGrid({
-                                            ...(sp.grid || {}),
+                                          coverGrid: normalizeSubpageGrid({
+                                            ...(sp.coverGrid || {}),
                                             gap:
                                               gap != null && gap >= 0 && gap <= COVER_GRID_GAP_MAX
                                                 ? gap
@@ -1533,10 +1558,82 @@ export default function PageBuilder() {
                                     />
                                   </div>
                                   <p className="admin-field-hint">
-                                    Overrides how the album covers are tiled on this page. Leave the
-                                    column count empty to follow the site-wide grid setting, and the
-                                    gap empty to keep the theme&apos;s own spacing. Tablet widths
-                                    show at most two covers per row.
+                                    Overrides how the album covers are tiled on this page — the
+                                    photos inside the albums are not affected. Leave the column
+                                    count empty to follow the site-wide grid setting, and the gap
+                                    empty to keep the theme&apos;s own spacing. Tablet widths show
+                                    at most two covers per row.
+                                  </p>
+                                </div>
+                              )}
+
+                              {/* Photo grid — the albums opened from this page.
+                                  Separate from the cover grid above: one field
+                                  used to drive both, so a cover gap retuned
+                                  every photo grid on the page (#523). */}
+                              {sp.essayText == null && (
+                                <div className="admin-field" style={{ marginTop: '1rem' }}>
+                                  <label>Photo Grid (Albums On This Page)</label>
+                                  <div style={{ display: 'flex', gap: '12px' }}>
+                                    <input
+                                      type="number"
+                                      min={PHOTO_GRID_COLUMNS_MIN}
+                                      max={PHOTO_GRID_COLUMNS_MAX}
+                                      value={sp.grid?.columns ?? ''}
+                                      placeholder="Columns (site default)"
+                                      onChange={(e) => {
+                                        const raw = e.target.value;
+                                        const columns = raw === '' ? undefined : Number(raw);
+                                        updateSubpage(spIndex, {
+                                          grid: normalizeSubpageGrid({
+                                            ...(sp.grid || {}),
+                                            columns:
+                                              columns != null &&
+                                              columns >= PHOTO_GRID_COLUMNS_MIN &&
+                                              columns <= PHOTO_GRID_COLUMNS_MAX
+                                                ? columns
+                                                : undefined,
+                                          }),
+                                        });
+                                      }}
+                                      style={{
+                                        padding: '8px 12px',
+                                        borderRadius: '6px',
+                                        flex: 1,
+                                        fontSize: '0.9rem',
+                                      }}
+                                    />
+                                    <input
+                                      type="number"
+                                      min={0}
+                                      max={PHOTO_GRID_GAP_MAX}
+                                      value={sp.grid?.gap ?? ''}
+                                      placeholder="Gap in px (theme default)"
+                                      onChange={(e) => {
+                                        const raw = e.target.value;
+                                        const gap = raw === '' ? undefined : Number(raw);
+                                        updateSubpage(spIndex, {
+                                          grid: normalizeSubpageGrid({
+                                            ...(sp.grid || {}),
+                                            gap:
+                                              gap != null && gap >= 0 && gap <= PHOTO_GRID_GAP_MAX
+                                                ? gap
+                                                : undefined,
+                                          }),
+                                        });
+                                      }}
+                                      style={{
+                                        padding: '8px 12px',
+                                        borderRadius: '6px',
+                                        flex: 1,
+                                        fontSize: '0.9rem',
+                                      }}
+                                    />
+                                  </div>
+                                  <p className="admin-field-hint">
+                                    How the photos inside every album on this page are laid out.
+                                    Leave both empty to follow Settings &rsaquo; Grid; a single
+                                    album can still override this in gallery.yaml.
                                   </p>
                                 </div>
                               )}

--- a/app/admin/components/SettingsEditor.tsx
+++ b/app/admin/components/SettingsEditor.tsx
@@ -8,7 +8,13 @@ import SaveBar from './SaveBar';
 // Direct import from the theme module, not from '@/lib/config': the config
 // index pulls in `fs` and cannot be bundled into a client component.
 import { DEFAULT_PRESET } from '@/lib/config/theme';
-import { resolveExifDisplay, resolveWatermarkOpacity } from '@/lib/config/schema';
+import {
+  PHOTO_GRID_COLUMNS_MAX,
+  PHOTO_GRID_COLUMNS_MIN,
+  PHOTO_GRID_GAP_MAX,
+  resolveExifDisplay,
+  resolveWatermarkOpacity,
+} from '@/lib/config/schema';
 import { SUPPORTED_LOCALES } from '@/lib/i18n';
 
 interface Settings {
@@ -1528,11 +1534,13 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
 
               <div className="admin-field-row">
                 <div className="admin-field">
-                  <label>Columns (1 - 6)</label>
+                  <label>
+                    Columns ({PHOTO_GRID_COLUMNS_MIN} - {PHOTO_GRID_COLUMNS_MAX})
+                  </label>
                   <input
                     type="number"
-                    min={1}
-                    max={6}
+                    min={PHOTO_GRID_COLUMNS_MIN}
+                    max={PHOTO_GRID_COLUMNS_MAX}
                     value={settings.grid?.columns ?? 3}
                     onChange={(e) => update('grid.columns', parseInt(e.target.value) || 3)}
                   />
@@ -1542,7 +1550,7 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
                   <input
                     type="number"
                     min={0}
-                    max={48}
+                    max={PHOTO_GRID_GAP_MAX}
                     value={settings.grid?.gap ?? 12}
                     onChange={(e) => update('grid.gap', parseInt(e.target.value) || 0)}
                   />

--- a/content/gallery.yaml.example
+++ b/content/gallery.yaml.example
@@ -56,9 +56,13 @@ subpages:
     subtitle: "A collection of 2026 highlights in 35mm film." # Optional: Sub-text for headers
     password: "your-password" # Optional protection
     # hidden: true # EXPERIMENTAL: reachable by direct link, but not shown in navigation
-    # grid: # Optional per-page grid override (wins over settings.yaml)
+    # coverGrid: # Optional: the album covers on this page (nothing else)
     #   columns: 3 # how many album covers per row on this page
     #   gap: 8 # spacing between the covers, in px — omit to keep the theme's own
+    # grid: # Optional: the photos inside the albums (wins over settings.yaml)
+    #   columns: 4
+    #   gap: 6 # omit to keep the theme's own photo spacing
+    #   layout: "masonry"
     albums:
       - "album-uuid-5"
       - "album-uuid-6":

--- a/docs/admin-panel.md
+++ b/docs/admin-panel.md
@@ -72,8 +72,9 @@ Group albums under custom URL paths (e.g. `/japan`, `/wedding-smith`).
 - **Name** — navigation label; the URL slug is derived from it
 - **Title / Subtitle** — page heading and subline
 - **Password** — protect the whole subpage
-- **Grid override** — layout settings for the photos on this page
+- **Page Layout Style** — the layout the photos on this page are shown in (masonry, uniform, showcase, …), or essay mode
 - **Album Cover Grid** — how the album covers are tiled: columns (empty = the site-wide grid setting) and gap in px (empty = the theme's own cover spacing). Hidden in essay mode
+- **Photo Grid (Albums On This Page)** — columns and gap for the photos inside those albums; empty follows _Settings › Grid_. Separate from the cover grid: one field used to size both until [#523](https://github.com/ralksta/immich-folio/issues/523)
 - **Enabled** — take the page offline without deleting it
 - **Hidden** _(experimental)_ — unlisted: reachable by direct link, absent from the navigation
 - **Essay** — turn the page into a photo essay, with a block editor for the text

--- a/docs/gallery-config.md
+++ b/docs/gallery-config.md
@@ -110,20 +110,21 @@ subpages:
 
 ### Subpage Options
 
-| Key         | Type    | Description                                                                            |
-| ----------- | ------- | -------------------------------------------------------------------------------------- |
-| `name`      | string  | Navigation label; the URL slug is derived from it                                      |
-| `title`     | string  | Page heading, defaults to `name`                                                       |
-| `subtitle`  | string  | Subline under the heading                                                              |
-| `password`  | string  | Gates the whole subpage — see [Password Protection](#password-protection)              |
-| `albums`    | list    | Album UUIDs, optionally with [per-album options](#per-album-options)                   |
-| `sections`  | list    | Named groups of albums — see [Sections](#sections)                                     |
-| `grid`      | object  | Grid override for this page, photos and album covers — see [Grid Layout](#grid-layout) |
-| `proofing`  | boolean | Enables [client proofing](#client-proofing) on this page                               |
-| `essayFile` | string  | Render a Markdown essay instead of a grid — see [Journal & Photo Essays](journal.md)   |
-| `essayText` | string  | Essay Markdown inline; written by the admin block editor                               |
-| `enabled`   | boolean | `false` takes the page offline without deleting it                                     |
-| `hidden`    | boolean | **Experimental.** Reachable by direct link, but hidden from the navigation             |
+| Key         | Type    | Description                                                                                      |
+| ----------- | ------- | ------------------------------------------------------------------------------------------------ |
+| `name`      | string  | Navigation label; the URL slug is derived from it                                                |
+| `title`     | string  | Page heading, defaults to `name`                                                                 |
+| `subtitle`  | string  | Subline under the heading                                                                        |
+| `password`  | string  | Gates the whole subpage — see [Password Protection](#password-protection)                        |
+| `albums`    | list    | Album UUIDs, optionally with [per-album options](#per-album-options)                             |
+| `sections`  | list    | Named groups of albums — see [Sections](#sections)                                               |
+| `grid`      | object  | Grid override for the photos on this page — see [Grid Layout](#grid-layout)                      |
+| `coverGrid` | object  | Grid override for the album covers on this page — see [Album covers](#album-covers-on-a-subpage) |
+| `proofing`  | boolean | Enables [client proofing](#client-proofing) on this page                                         |
+| `essayFile` | string  | Render a Markdown essay instead of a grid — see [Journal & Photo Essays](journal.md)             |
+| `essayText` | string  | Essay Markdown inline; written by the admin block editor                                         |
+| `enabled`   | boolean | `false` takes the page offline without deleting it                                               |
+| `hidden`    | boolean | **Experimental.** Reachable by direct link, but hidden from the navigation                       |
 
 ```yaml
 subpages:
@@ -383,33 +384,47 @@ Available layouts: `masonry`, `uniform`, `showcase`, `filmstrip`,
 ### Album covers on a subpage
 
 A subpage with more than one album shows a grid of album covers rather than
-photos. That grid follows the same `columns` value — set it globally in
-`settings.yaml` or per page in `gallery.yaml`, and the covers are tiled the same
-way the photos are. Valid range is 1–6; below 1024px viewport width at most two
-covers share a row, and below 640px they stack.
+photos. That grid has its own key, `coverGrid`, which sizes the cover tiles and
+nothing else. `grid` next to it stays what it always was: the photos inside
+those albums.
+
+An unset `columns` falls back to the site-wide `grid.columns`, so a page that
+states nothing tiles its covers the way it tiles its photos. Valid range is 1–6;
+below 1024px viewport width at most two covers share a row, and below 640px they
+stack.
 
 `gap` is the deliberate exception: it does **not** cascade from the global
 setting to the covers. Every theme preset picks its own cover spacing as part of
 its look — 1px in `monograph`, 2px in `minimal` and `editorial`, 20px in
 `studio-modern` — and letting the site-wide photo gap through would flatten all
-of them into one look. Only an explicit `gap` on the subpage overrides the
-preset:
+of them into one look. Only an explicit `coverGrid.gap` overrides the preset:
 
 ```yaml
-# gallery.yaml — album covers on this page only
+# gallery.yaml — the two grids of one page, set independently
 subpages:
   - name: Editorial
-    grid:
+    coverGrid:
       columns: 3 # three covers per row (site-wide default otherwise)
       gap: 24 # overrides the theme's own cover spacing
+    grid:
+      columns: 4 # the photos inside each album
+      gap: 6
     albums:
       - '33333333-3333-3333-3333-333333333333'
       - '44444444-4444-4444-4444-444444444444'
 ```
 
-Both fields are editable per page in the admin panel under
-**Pages › _subpage_ › Album Cover Grid**; left empty they follow the site-wide
+Both are editable per page in the admin panel, under **Pages › _subpage_ ›
+Album Cover Grid** and **Photo Grid**; left empty they follow the site-wide
 setting and the theme respectively.
+
+> [!NOTE]
+> The covers and the photos shared a single `grid` key until
+> [#523](https://github.com/ralksta/immich-folio/issues/523), where a gap typed
+> into the admin's cover field turned out to retune every photo grid on the page
+> as well. A `gallery.yaml` that predates the split has no `coverGrid`, so the
+> covers fall back to `grid` and the page renders exactly as before; the first
+> save from the admin panel writes the two out separately.
 
 ## Site Behaviour
 

--- a/lib/__tests__/subpage-cover-grid.test.ts
+++ b/lib/__tests__/subpage-cover-grid.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/lib/env', () => ({
+  env: {
+    IMMICH_API_URL: 'http://localhost:2283',
+    IMMICH_API_KEY: 'test-key',
+    SITE_TITLE: 'Test Gallery',
+    SITE_SUBTITLE: '',
+    CACHE_TTL: 300,
+    IMMICH_TIMEOUT_MS: 15000,
+    RATE_LIMIT_RPM: 120,
+    TRUSTED_PROXY_HOPS: 0,
+  },
+}));
+
+vi.mock('@/lib/config/parser', () => ({
+  loadYaml: vi.fn(),
+  clearYamlCache: vi.fn(),
+  validateUuid: (id: string) => id,
+}));
+
+import { deriveGallery } from '@/lib/config';
+import type { GalleryYaml } from '@/lib/config/schema';
+
+const A = '11111111-1111-1111-1111-111111111111';
+
+function subpage(entry: Record<string, unknown>) {
+  const gallery = deriveGallery({
+    subpages: [{ name: 'Travel', albums: [A], ...entry }],
+  } as unknown as GalleryYaml);
+  return gallery.subpages[0];
+}
+
+/**
+ * The album covers and the photos inside those albums used to share a single
+ * `grid` key, so a gap typed into the admin's "Album Cover Grid" retuned every
+ * photo grid on the page (#523).
+ */
+describe('subpage grid vs. coverGrid', () => {
+  it('keeps the two independent once both are set', () => {
+    const sp = subpage({ grid: { columns: 4, gap: 6 }, coverGrid: { columns: 2, gap: 24 } });
+    expect(sp.grid).toEqual({ columns: 4, gap: 6 });
+    expect(sp.coverGrid).toEqual({ columns: 2, gap: 24 });
+  });
+
+  it('leaves the photo grid alone when only the covers are configured', () => {
+    const sp = subpage({ coverGrid: { columns: 2, gap: 24 } });
+    expect(sp.grid).toBeUndefined();
+    expect(sp.coverGrid).toEqual({ columns: 2, gap: 24 });
+  });
+
+  // A gallery.yaml written before the split has no `coverGrid` at all, and its
+  // covers were sized by `grid`. Falling back to it keeps that page rendering
+  // exactly as it did.
+  it('falls back to the photo grid when no coverGrid was written', () => {
+    const sp = subpage({ grid: { columns: 4, gap: 6, layout: 'uniform' } });
+    expect(sp.coverGrid).toEqual({ columns: 4, gap: 6, layout: 'uniform' });
+  });
+
+  it('reports no cover override when the page states neither', () => {
+    expect(subpage({}).coverGrid).toBeUndefined();
+  });
+
+  it('reads coverGrid from the map form of subpages too', () => {
+    const gallery = deriveGallery({
+      subpages: {
+        Travel: { albums: [A], grid: { gap: 6 }, coverGrid: { columns: 2 } },
+      },
+    } as unknown as GalleryYaml);
+    expect(gallery.subpages[0].grid).toEqual({ gap: 6 });
+    expect(gallery.subpages[0].coverGrid).toEqual({ columns: 2 });
+  });
+});

--- a/lib/config/index.ts
+++ b/lib/config/index.ts
@@ -58,27 +58,54 @@ export function getConfigOrNull(): AppConfig | null {
   }
 }
 
-/** Converts raw YAML grid overrides into a typed partial GridConfig. */
-export function buildSubpageGrid(raw?: {
+interface RawGridOverrides {
   columns?: number;
   gap?: number;
   aspectRatio?: string;
   layout?: string;
-}): { grid: Partial<GridConfig> } | Record<string, never> {
-  if (!raw) return {};
+}
+
+/** Converts raw YAML grid overrides into a typed partial GridConfig. */
+function parseGridOverrides(raw: RawGridOverrides): Partial<GridConfig> {
   return {
-    grid: {
-      ...(raw.columns != null ? { columns: raw.columns } : {}),
-      ...(raw.gap != null ? { gap: raw.gap } : {}),
-      ...(raw.aspectRatio != null ? { aspectRatio: raw.aspectRatio } : {}),
-      ...(raw.layout != null
-        ? {
-            layout: (VALID_LAYOUTS.includes(raw.layout)
-              ? raw.layout
-              : 'masonry') as GridConfig['layout'],
-          }
-        : {}),
-    },
+    ...(raw.columns != null ? { columns: raw.columns } : {}),
+    ...(raw.gap != null ? { gap: raw.gap } : {}),
+    ...(raw.aspectRatio != null ? { aspectRatio: raw.aspectRatio } : {}),
+    ...(raw.layout != null
+      ? {
+          layout: (VALID_LAYOUTS.includes(raw.layout)
+            ? raw.layout
+            : 'masonry') as GridConfig['layout'],
+        }
+      : {}),
+  };
+}
+
+/** Converts raw YAML grid overrides into a typed partial GridConfig. */
+export function buildSubpageGrid(
+  raw?: RawGridOverrides,
+): { grid: Partial<GridConfig> } | Record<string, never> {
+  if (!raw) return {};
+  return { grid: parseGridOverrides(raw) };
+}
+
+/**
+ * The two grids a subpage can override, as one spread-able object.
+ *
+ * `grid` sizes the photos inside its albums, `coverGrid` the album-cover tiles
+ * on the page itself. They were a single key until #523, where the admin field
+ * labelled "Album Cover Grid" turned out to retune every photo grid on the page
+ * as well. A gallery.yaml written before the split has no `coverGrid`, so the
+ * covers fall back to `grid` and such a page renders exactly as it did.
+ */
+function buildSubpageGrids(
+  grid?: RawGridOverrides,
+  coverGrid?: RawGridOverrides,
+): { grid?: Partial<GridConfig>; coverGrid?: Partial<GridConfig> } {
+  const resolved = coverGrid ?? grid;
+  return {
+    ...buildSubpageGrid(grid),
+    ...(resolved ? { coverGrid: parseGridOverrides(resolved) } : {}),
   };
 }
 
@@ -353,7 +380,7 @@ export function deriveGallery(gallery: GalleryYaml): GalleryDerivation {
         essayText: sp.essayText,
         enabled: sp.enabled !== false,
         hidden: sp.hidden === true,
-        ...buildSubpageGrid(sp.grid),
+        ...buildSubpageGrids(sp.grid, sp.coverGrid),
       };
     });
   } else if (gallery.subpages) {
@@ -384,7 +411,7 @@ export function deriveGallery(gallery: GalleryYaml): GalleryDerivation {
         essayText: sp.essayText,
         enabled: sp.enabled !== false,
         hidden: sp.hidden === true,
-        ...buildSubpageGrid(sp.grid),
+        ...buildSubpageGrids(sp.grid, sp.coverGrid),
       };
     });
   }

--- a/lib/config/schema.ts
+++ b/lib/config/schema.ts
@@ -16,7 +16,13 @@ export interface SubpageConfig {
   albumIds: string[]; // flat list (all albums, incl. from sections)
   sections?: SubpageSectionConfig[];
   password?: string;
+  /** Photo grid for the albums on this page: global < subpage < album. */
   grid?: Partial<GridConfig>;
+  /**
+   * The album-cover tiles on this page. Falls back to `grid` when unset, which
+   * is what a pre-#523 gallery.yaml renders with (#523).
+   */
+  coverGrid?: Partial<GridConfig>;
   proofing?: boolean;
   essayFile?: string;
   essayText?: string;
@@ -30,6 +36,8 @@ export interface SubpageObjectValue {
   subtitle?: string;
   password?: string;
   grid?: Partial<GridConfig>;
+  /** Album-cover tiles only; falls back to `grid` when unset (#523). */
+  coverGrid?: Partial<GridConfig>;
   proofing?: boolean;
   essayFile?: string;
   essayText?: string;
@@ -95,6 +103,14 @@ export interface GridConfig {
 }
 
 /**
+ * Bounds for the photo grid, shared by the site-wide and per-subpage inputs so
+ * the two forms cannot offer different ranges for the same setting.
+ */
+export const PHOTO_GRID_COLUMNS_MIN = 1;
+export const PHOTO_GRID_COLUMNS_MAX = 6;
+export const PHOTO_GRID_GAP_MAX = 48;
+
+/**
  * Bounds for the album-cover grid on a subpage. Shared with the admin inputs so
  * the form and the renderer cannot drift apart.
  */
@@ -108,12 +124,16 @@ export const COVER_GRID_TABLET_COLUMNS_MAX = 2;
 /**
  * The CSS custom properties that size the album-cover grid on a subpage.
  *
- * `columns` follows the same config as the photo grids (global `settings.yaml`
- * < per-subpage override), so "3 columns" in the admin means three columns
- * everywhere. `gap` deliberately does not: each theme preset picks the cover
- * spacing as part of its look (1px monograph, 20px studio-modern), so the
- * variable is only emitted when a subpage sets `gap` explicitly — otherwise the
- * preset's own `--subpage-gap` stands.
+ * The overrides come from the subpage's own `coverGrid`, which sizes the cover
+ * tiles and nothing else — it used to be the same `grid` key the photos read,
+ * so a cover gap silently retuned every photo grid on the page (#523).
+ *
+ * `columns` still falls back to the global `settings.yaml` count, so a page
+ * that states nothing tiles its covers like its photos. `gap` deliberately does
+ * not: each theme preset picks the cover spacing as part of its look (1px
+ * monograph, 20px studio-modern), so the variable is only emitted when a
+ * subpage sets `gap` explicitly — otherwise the preset's own `--subpage-gap`
+ * stands.
  *
  * `--subpage-columns-tablet` is computed here rather than in CSS because
  * `repeat()` does not reliably accept a `min()` expression.
@@ -308,6 +328,13 @@ export interface GalleryYaml {
         /** Map precision inherited by every album here (#469). */
         location?: string;
         grid?: {
+          columns?: number;
+          gap?: number;
+          aspectRatio?: string;
+          layout?: string;
+        };
+        /** Album covers only; falls back to `grid` when unset (#523). */
+        coverGrid?: {
           columns?: number;
           gap?: number;
           aspectRatio?: string;


### PR DESCRIPTION
Closes #523.

## The bug

A subpage had a single `grid` key, and two different consumers read it:

- the album-cover tiles, via `buildCoverGridVars()` → `SubpageGridView`
- the photos inside every album on that page, via `mergeAlbumGrid()` → `buildGridStyle()` → `PhotoGrid`

The admin field is labelled **Album Cover Grid**, but it writes into that shared key — so a gap typed for the covers silently retuned every photo grid on the page, overriding `Settings › Grid`.

## The fix

Split the field in two, as discussed in the issue:

- `coverGrid` — sizes the album-cover tiles and nothing else. `columns` still falls back to the site-wide count; `gap` still does not, so each theme preset keeps its own cover spacing.
- `grid` — unchanged: the photos, with `global < subpage < album` precedence.

A `gallery.yaml` written before the split has no `coverGrid`, so the covers fall back to `grid` and such a page renders exactly as it did. The page builder shows both groups and seeds the cover fields from the old `grid` when it opens a pre-split page, so the drawer reflects what the page really renders and the first save writes the two out separately.

```yaml
subpages:
  - name: Editorial
    coverGrid:
      columns: 3
      gap: 24
    grid:
      columns: 4
      gap: 6
```

Photo-grid bounds (`PHOTO_GRID_COLUMNS_MIN/MAX`, `PHOTO_GRID_GAP_MAX`) moved into `lib/config/schema.ts` next to the cover ones, and `SettingsEditor` now reads them too, so the site-wide and per-subpage inputs cannot offer different ranges for the same setting.

## Verification

- `npx tsc --noEmit` — 0 errors
- `npm run test:unit` — 811 passed, incl. new `lib/__tests__/subpage-cover-grid.test.ts` (split stays independent, legacy fallback, map form)
- `npm run build` — passes
- `npm run lint` — one pre-existing error in `SettingsEditor.tsx` (unescaped `'`), untouched by this branch

Docs updated: `docs/gallery-config.md`, `docs/admin-panel.md`, `content/gallery.yaml.example`.