### PR TITLE
refactor(admin): give the panel a form-field layer (#533)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Releases up to and including v0.9.2 are documented in the
 [GitHub releases](https://github.com/ralksta/immich-folio/releases).
 
+## [Unreleased]
+
+### Fixed
+
+- **The admin panel's switches and pickers announce their state.** The toggle
+  cards and the five card pickers — theme preset, photo frame, hero style,
+  layout, aspect ratio — showed which option was active by colour alone, with
+  no `aria-pressed`, so a screen reader read a row of buttons without saying
+  which one was on. `SettingRow` already announced itself; the cards beside it
+  did not. Fixed while giving the panel a form-field layer
+  ([#533](https://github.com/ralksta/immich-folio/issues/533)), which is what
+  made it one change instead of nineteen.
+
 ## [0.13.0] — 2026-08-25
 
 ### Added

--- a/app/admin/components/PageBuilder.tsx
+++ b/app/admin/components/PageBuilder.tsx
@@ -24,6 +24,7 @@ import AssetPicker from './AssetPicker';
 import AssetOrderEditor from './AssetOrderEditor';
 import { EssayBlockEditor } from './EssayBlockEditor';
 import SaveBar from './SaveBar';
+import GridOverrideFields from './fields/GridOverrideFields';
 import { useScrollLock } from './useScrollLock';
 import {
   ALBUM_SORT_MODES,
@@ -1499,72 +1500,27 @@ export default function PageBuilder() {
                                   vanishes while you edit is worse than one that
                                   has no effect yet. */}
                               {sp.grid?.layout !== 'essay' && sp.essayText == null && (
-                                <div className="admin-field" style={{ marginTop: '1rem' }}>
-                                  <label>Album Cover Grid</label>
-                                  <div style={{ display: 'flex', gap: '12px' }}>
-                                    <input
-                                      type="number"
-                                      min={COVER_GRID_COLUMNS_MIN}
-                                      max={COVER_GRID_COLUMNS_MAX}
-                                      value={sp.coverGrid?.columns ?? ''}
-                                      placeholder="Columns (site default)"
-                                      onChange={(e) => {
-                                        const raw = e.target.value;
-                                        const columns = raw === '' ? undefined : Number(raw);
-                                        updateSubpage(spIndex, {
-                                          coverGrid: normalizeSubpageGrid({
-                                            ...(sp.coverGrid || {}),
-                                            columns:
-                                              columns != null &&
-                                              columns >= COVER_GRID_COLUMNS_MIN &&
-                                              columns <= COVER_GRID_COLUMNS_MAX
-                                                ? columns
-                                                : undefined,
-                                          }),
-                                        });
-                                      }}
-                                      style={{
-                                        padding: '8px 12px',
-                                        borderRadius: '6px',
-                                        flex: 1,
-                                        fontSize: '0.9rem',
-                                      }}
-                                    />
-                                    <input
-                                      type="number"
-                                      min={0}
-                                      max={COVER_GRID_GAP_MAX}
-                                      value={sp.coverGrid?.gap ?? ''}
-                                      placeholder="Gap in px (theme default)"
-                                      onChange={(e) => {
-                                        const raw = e.target.value;
-                                        const gap = raw === '' ? undefined : Number(raw);
-                                        updateSubpage(spIndex, {
-                                          coverGrid: normalizeSubpageGrid({
-                                            ...(sp.coverGrid || {}),
-                                            gap:
-                                              gap != null && gap >= 0 && gap <= COVER_GRID_GAP_MAX
-                                                ? gap
-                                                : undefined,
-                                          }),
-                                        });
-                                      }}
-                                      style={{
-                                        padding: '8px 12px',
-                                        borderRadius: '6px',
-                                        flex: 1,
-                                        fontSize: '0.9rem',
-                                      }}
-                                    />
-                                  </div>
-                                  <p className="admin-field-hint">
-                                    Overrides how the album covers are tiled on this page — the
-                                    photos inside the albums are not affected. Leave the column
-                                    count empty to follow the site-wide grid setting, and the gap
-                                    empty to keep the theme&apos;s own spacing. Tablet widths show
-                                    at most two covers per row.
-                                  </p>
-                                </div>
+                                <GridOverrideFields
+                                  label="Album Cover Grid"
+                                  hint={
+                                    <>
+                                      Overrides how the album covers are tiled on this page — the
+                                      photos inside the albums are not affected. Leave the column
+                                      count empty to follow the site-wide grid setting, and the gap
+                                      empty to keep the theme&apos;s own spacing. Tablet widths show
+                                      at most two covers per row.
+                                    </>
+                                  }
+                                  columnsMin={COVER_GRID_COLUMNS_MIN}
+                                  columnsMax={COVER_GRID_COLUMNS_MAX}
+                                  gapMax={COVER_GRID_GAP_MAX}
+                                  value={sp.coverGrid}
+                                  onChange={(next) =>
+                                    updateSubpage(spIndex, {
+                                      coverGrid: normalizeSubpageGrid(next),
+                                    })
+                                  }
+                                />
                               )}
 
                               {/* Photo grid — the albums opened from this page.
@@ -1572,70 +1528,23 @@ export default function PageBuilder() {
                                   used to drive both, so a cover gap retuned
                                   every photo grid on the page (#523). */}
                               {sp.essayText == null && (
-                                <div className="admin-field" style={{ marginTop: '1rem' }}>
-                                  <label>Photo Grid (Albums On This Page)</label>
-                                  <div style={{ display: 'flex', gap: '12px' }}>
-                                    <input
-                                      type="number"
-                                      min={PHOTO_GRID_COLUMNS_MIN}
-                                      max={PHOTO_GRID_COLUMNS_MAX}
-                                      value={sp.grid?.columns ?? ''}
-                                      placeholder="Columns (site default)"
-                                      onChange={(e) => {
-                                        const raw = e.target.value;
-                                        const columns = raw === '' ? undefined : Number(raw);
-                                        updateSubpage(spIndex, {
-                                          grid: normalizeSubpageGrid({
-                                            ...(sp.grid || {}),
-                                            columns:
-                                              columns != null &&
-                                              columns >= PHOTO_GRID_COLUMNS_MIN &&
-                                              columns <= PHOTO_GRID_COLUMNS_MAX
-                                                ? columns
-                                                : undefined,
-                                          }),
-                                        });
-                                      }}
-                                      style={{
-                                        padding: '8px 12px',
-                                        borderRadius: '6px',
-                                        flex: 1,
-                                        fontSize: '0.9rem',
-                                      }}
-                                    />
-                                    <input
-                                      type="number"
-                                      min={0}
-                                      max={PHOTO_GRID_GAP_MAX}
-                                      value={sp.grid?.gap ?? ''}
-                                      placeholder="Gap in px (theme default)"
-                                      onChange={(e) => {
-                                        const raw = e.target.value;
-                                        const gap = raw === '' ? undefined : Number(raw);
-                                        updateSubpage(spIndex, {
-                                          grid: normalizeSubpageGrid({
-                                            ...(sp.grid || {}),
-                                            gap:
-                                              gap != null && gap >= 0 && gap <= PHOTO_GRID_GAP_MAX
-                                                ? gap
-                                                : undefined,
-                                          }),
-                                        });
-                                      }}
-                                      style={{
-                                        padding: '8px 12px',
-                                        borderRadius: '6px',
-                                        flex: 1,
-                                        fontSize: '0.9rem',
-                                      }}
-                                    />
-                                  </div>
-                                  <p className="admin-field-hint">
-                                    How the photos inside every album on this page are laid out.
-                                    Leave both empty to follow Settings &rsaquo; Grid; a single
-                                    album can still override this in gallery.yaml.
-                                  </p>
-                                </div>
+                                <GridOverrideFields
+                                  label="Photo Grid (Albums On This Page)"
+                                  hint={
+                                    <>
+                                      How the photos inside every album on this page are laid out.
+                                      Leave both empty to follow Settings &rsaquo; Grid; a single
+                                      album can still override this in gallery.yaml.
+                                    </>
+                                  }
+                                  columnsMin={PHOTO_GRID_COLUMNS_MIN}
+                                  columnsMax={PHOTO_GRID_COLUMNS_MAX}
+                                  gapMax={PHOTO_GRID_GAP_MAX}
+                                  value={sp.grid}
+                                  onChange={(next) =>
+                                    updateSubpage(spIndex, { grid: normalizeSubpageGrid(next) })
+                                  }
+                                />
                               )}
                             </div>
 

--- a/app/admin/components/SettingsEditor.tsx
+++ b/app/admin/components/SettingsEditor.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import * as Icons from './Icons';
 import SaveBar from './SaveBar';
 import ToggleCard from './fields/ToggleCard';
+import OptionGrid, { toOptions } from './fields/OptionGrid';
 // Direct import from the theme module, not from '@/lib/config': the config
 // index pulls in `fs` and cannot be bundled into a client component.
 import { DEFAULT_PRESET } from '@/lib/config/theme';
@@ -100,6 +101,266 @@ const LAYOUTS = ['masonry', 'uniform', 'showcase', 'filmstrip', 'editorial-flow'
 const PHOTO_FRAMES = ['none', 'passepartout', 'shadow'];
 const HERO_STYLES = ['split', 'fullbleed', 'minimal', 'stacked', 'typographic', 'mosaic', 'cover'];
 const ASPECT_RATIOS = ['1', '3/2', '2/3', '16/9', 'auto'];
+
+/** The theme picker's own metadata, with the fallback the card grid needs. */
+function themeInfo(value: string) {
+  return (
+    THEME_INFO[value] || {
+      label: value,
+      desc: '',
+      bg: '#fff',
+      tile: '#eee',
+      accent: '#333',
+      font: 'System',
+      type: 'sans' as const,
+      radius: 0,
+      frame: 'none' as const,
+      gap: 4,
+    }
+  );
+}
+
+const PRESET_OPTIONS = PRESETS.map((value) => ({
+  value,
+  label: themeInfo(value).label,
+  desc: themeInfo(value).desc,
+}));
+
+function PresetPreview({ value }: { value: string }) {
+  const i = themeInfo(value);
+  return (
+    <div className="preset-card-preview" data-frame={i.frame}>
+      <div className="mini-header">
+        <span className={`mini-specimen type-${i.type}`}>Aa</span>
+        <span className="mini-line" />
+      </div>
+      <div className="mini-grid">
+        <div className="mini-tile" />
+        <div className="mini-tile" />
+        <div className="mini-tile" />
+      </div>
+    </div>
+  );
+}
+
+function PresetSpecs({ value }: { value: string }) {
+  const i = themeInfo(value);
+  return (
+    <span className="preset-card-specs">
+      {i.font} &middot; radius {i.radius} &middot; {i.frame}
+    </span>
+  );
+}
+
+const PHOTO_FRAME_INFO: Record<string, { label: string; desc: string }> = {
+  none: { label: 'None', desc: 'Flush image with crisp edges' },
+  passepartout: {
+    label: 'Passepartout',
+    desc: 'Classic gallery matting border',
+  },
+  shadow: { label: 'Shadow', desc: 'Soft floating drop shadow' },
+};
+const PHOTO_FRAME_OPTIONS = toOptions(PHOTO_FRAMES, PHOTO_FRAME_INFO);
+
+function PhotoFramePreview({ value }: { value: string }) {
+  return (
+    <div className="frame-card-preview">
+      <div className={`mini-frame-demo frame-${value}`}>
+        <div className="mini-frame-photo" />
+      </div>
+    </div>
+  );
+}
+
+const HERO_STYLE_INFO: Record<string, { label: string; desc: string }> = {
+  split: { label: 'Split', desc: 'Side-by-side title & photo' },
+  fullbleed: { label: 'Fullbleed', desc: 'Edge-to-edge full width banner' },
+  minimal: { label: 'Minimal', desc: 'Centered title with subtle photo' },
+  stacked: { label: 'Stacked', desc: 'Title stacked directly over photo' },
+  typographic: { label: 'Typographic', desc: 'Oversized magazine masthead' },
+  mosaic: { label: 'Mosaic', desc: 'Dynamic photo collage layout' },
+  cover: {
+    label: 'Cover (Experimental)',
+    desc: 'Fullscreen splash with a single Enter link',
+  },
+};
+const HERO_STYLE_OPTIONS = toOptions(HERO_STYLES, HERO_STYLE_INFO);
+
+function HeroStylePreview({ value }: { value: string }) {
+  return (
+    <div className="hero-card-preview">
+      <div className={`mini-hero-demo hero-demo-${value}`}>
+        {value === 'split' && (
+          <>
+            <div className="hero-demo-text">
+              <div className="demo-line title" />
+              <div className="demo-line sub" />
+            </div>
+            <div className="hero-demo-photo" />
+          </>
+        )}
+        {value === 'fullbleed' && (
+          <div className="hero-demo-full">
+            <div className="demo-line title light" />
+          </div>
+        )}
+        {value === 'minimal' && (
+          <>
+            <div className="hero-demo-center-text">
+              <div className="demo-line title short" />
+            </div>
+            <div className="hero-demo-photo small" />
+          </>
+        )}
+        {value === 'stacked' && (
+          <>
+            <div className="hero-demo-text">
+              <div className="demo-line title" />
+            </div>
+            <div className="hero-demo-photo banner" />
+          </>
+        )}
+        {value === 'typographic' && (
+          <>
+            <div className="demo-line title giant" />
+            <div className="hero-demo-grid2">
+              <div className="hero-demo-photo" />
+              <div className="hero-demo-photo" />
+            </div>
+          </>
+        )}
+        {value === 'mosaic' && (
+          <div className="hero-demo-mosaic">
+            <div className="hero-demo-photo big" />
+            <div className="hero-demo-photo-col">
+              <div className="hero-demo-photo" />
+              <div className="hero-demo-photo" />
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const LAYOUT_INFO: Record<string, { label: string; desc: string }> = {
+  masonry: {
+    label: 'Masonry',
+    desc: 'Dynamic pinterest-style staggered columns',
+  },
+  uniform: { label: 'Uniform Grid', desc: 'Clean equal aspect ratio grid' },
+  showcase: {
+    label: 'Showcase',
+    desc: 'Featured hero photos mixed with smaller tiles',
+  },
+  filmstrip: {
+    label: 'Filmstrip',
+    desc: 'Horizontal scrollable film strip timeline',
+  },
+  'editorial-flow': {
+    label: 'Editorial Flow',
+    desc: 'Magazine story layout with varying photo sizes',
+  },
+  justified: {
+    label: 'Justified (Experimental)',
+    desc: 'Equal-height rows that fill the full width',
+  },
+};
+const LAYOUT_OPTIONS = toOptions(LAYOUTS, LAYOUT_INFO);
+
+function LayoutPreview({ value }: { value: string }) {
+  return (
+    <div className="grid-card-preview">
+      <div className={`mini-layout-demo layout-demo-${value}`}>
+        {value === 'masonry' && (
+          <div className="demo-masonry-col-group">
+            <div className="demo-col">
+              <div className="demo-tile h-high" />
+              <div className="demo-tile h-low" />
+            </div>
+            <div className="demo-col">
+              <div className="demo-tile h-low" />
+              <div className="demo-tile h-high" />
+            </div>
+            <div className="demo-col">
+              <div className="demo-tile h-med" />
+              <div className="demo-tile h-med" />
+            </div>
+          </div>
+        )}
+        {value === 'uniform' && (
+          <div className="demo-uniform-grid">
+            <div className="demo-tile" />
+            <div className="demo-tile" />
+            <div className="demo-tile" />
+            <div className="demo-tile" />
+            <div className="demo-tile" />
+            <div className="demo-tile" />
+          </div>
+        )}
+        {value === 'showcase' && (
+          <div className="demo-showcase-grid">
+            <div className="demo-tile demo-hero" />
+            <div className="demo-col">
+              <div className="demo-tile" />
+              <div className="demo-tile" />
+            </div>
+          </div>
+        )}
+        {value === 'filmstrip' && (
+          <div className="demo-filmstrip-row">
+            <div className="demo-tile strip" />
+            <div className="demo-tile strip" />
+            <div className="demo-tile strip" />
+          </div>
+        )}
+        {value === 'editorial-flow' && (
+          <div className="demo-editorial-flow">
+            <div className="demo-tile wide" />
+            <div className="demo-row">
+              <div className="demo-tile" />
+              <div className="demo-tile" />
+            </div>
+          </div>
+        )}
+        {value === 'justified' && (
+          <div className="demo-editorial-flow">
+            <div className="demo-row">
+              <div className="demo-tile wide" />
+              <div className="demo-tile" />
+            </div>
+            <div className="demo-row">
+              <div className="demo-tile" />
+              <div className="demo-tile wide" />
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const ASPECT_RATIO_INFO: Record<string, { label: string; desc: string }> = {
+  '1': { label: 'Square (1:1)', desc: '1:1 ratio square crops' },
+  '3/2': { label: 'Landscape (3:2)', desc: 'Standard 35mm DSLR landscape' },
+  '2/3': { label: 'Portrait (2:3)', desc: 'Vertical portrait orientation' },
+  '16/9': { label: 'Cinema (16:9)', desc: 'Widescreen 16:9 cinematic ratio' },
+  auto: {
+    label: 'Original Auto',
+    desc: 'Uncropped original image proportions',
+  },
+};
+const ASPECT_RATIO_OPTIONS = toOptions(ASPECT_RATIOS, ASPECT_RATIO_INFO);
+
+function AspectRatioPreview({ value }: { value: string }) {
+  return (
+    <div className="ratio-card-preview">
+      <div className={`mini-aspect-box ratio-${value.replace('/', '-')}`}>
+        <div className="mini-aspect-inner" />
+      </div>
+    </div>
+  );
+}
 
 /**
  * Card metadata for the theme picker. `font`, `radius` and `frame` mirror the
@@ -965,62 +1226,25 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
                 </p>
               </div>
 
-              <div className="admin-field">
-                <label>Preset</label>
-                <div className="preset-card-grid">
-                  {PRESETS.map((p) => {
-                    const info = THEME_INFO[p] || {
-                      label: p,
-                      desc: '',
-                      bg: '#fff',
-                      tile: '#eee',
-                      accent: '#333',
-                      font: 'System',
-                      type: 'sans' as const,
-                      radius: 0,
-                      frame: 'none' as const,
-                      gap: 4,
-                    };
-                    const isActive = (settings.theme?.preset || DEFAULT_PRESET) === p;
-                    return (
-                      <button
-                        key={p}
-                        type="button"
-                        className={`preset-card theme-preset-card ${isActive ? 'active' : ''}`}
-                        onClick={() => update('theme.preset', p)}
-                        style={
-                          {
-                            '--preset-accent': info.accent,
-                            '--preset-bg': info.bg,
-                            '--preset-tile': info.tile,
-                            '--preset-radius': `${info.radius}px`,
-                            '--preset-gap': `${info.gap}px`,
-                          } as React.CSSProperties
-                        }
-                      >
-                        <div className="preset-card-preview" data-frame={info.frame}>
-                          <div className="mini-header">
-                            <span className={`mini-specimen type-${info.type}`}>Aa</span>
-                            <span className="mini-line" />
-                          </div>
-                          <div className="mini-grid">
-                            <div className="mini-tile" />
-                            <div className="mini-tile" />
-                            <div className="mini-tile" />
-                          </div>
-                        </div>
-                        <div className="preset-card-info">
-                          <span className="preset-card-name">{info.label}</span>
-                          <span className="preset-card-desc">{info.desc}</span>
-                          <span className="preset-card-specs">
-                            {info.font} &middot; radius {info.radius} &middot; {info.frame}
-                          </span>
-                        </div>
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
+              <OptionGrid
+                label="Preset"
+                options={PRESET_OPTIONS}
+                value={settings.theme?.preset || DEFAULT_PRESET}
+                onSelect={(v) => update('theme.preset', v)}
+                cardClassName="theme-preset-card"
+                renderPreview={(o) => <PresetPreview value={o.value} />}
+                renderSpecs={(o) => <PresetSpecs value={o.value} />}
+                cardStyle={(o) => {
+                  const i = themeInfo(o.value);
+                  return {
+                    '--preset-accent': i.accent,
+                    '--preset-bg': i.bg,
+                    '--preset-tile': i.tile,
+                    '--preset-radius': `${i.radius}px`,
+                    '--preset-gap': `${i.gap}px`,
+                  } as React.CSSProperties;
+                }}
+              />
 
               <div className="admin-field">
                 <label>Color Mode</label>
@@ -1119,128 +1343,23 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
                 </p>
               </div>
 
-              <div className="admin-field">
-                <label>Photo Frame</label>
-                <div className="preset-card-grid">
-                  {PHOTO_FRAMES.map((f) => {
-                    const info = {
-                      none: { label: 'None', desc: 'Flush image with crisp edges' },
-                      passepartout: {
-                        label: 'Passepartout',
-                        desc: 'Classic gallery matting border',
-                      },
-                      shadow: { label: 'Shadow', desc: 'Soft floating drop shadow' },
-                    }[f] || { label: f, desc: '' };
-                    const isActive = (settings.theme?.photoFrame || 'none') === f;
+              <OptionGrid
+                label="Photo Frame"
+                options={PHOTO_FRAME_OPTIONS}
+                value={settings.theme?.photoFrame || 'none'}
+                onSelect={(v) => update('theme.photoFrame', v)}
+                cardClassName="frame-card"
+                renderPreview={(o) => <PhotoFramePreview value={o.value} />}
+              />
 
-                    return (
-                      <button
-                        key={f}
-                        type="button"
-                        className={`preset-card frame-card ${isActive ? 'active' : ''}`}
-                        onClick={() => update('theme.photoFrame', f)}
-                      >
-                        <div className="frame-card-preview">
-                          <div className={`mini-frame-demo frame-${f}`}>
-                            <div className="mini-frame-photo" />
-                          </div>
-                        </div>
-                        <div className="preset-card-info">
-                          <span className="preset-card-name">{info.label}</span>
-                          <span className="preset-card-desc">{info.desc}</span>
-                        </div>
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-
-              <div className="admin-field">
-                <label>Hero Style</label>
-                <div className="preset-card-grid">
-                  {HERO_STYLES.map((s) => {
-                    const info = {
-                      split: { label: 'Split', desc: 'Side-by-side title & photo' },
-                      fullbleed: { label: 'Fullbleed', desc: 'Edge-to-edge full width banner' },
-                      minimal: { label: 'Minimal', desc: 'Centered title with subtle photo' },
-                      stacked: { label: 'Stacked', desc: 'Title stacked directly over photo' },
-                      typographic: { label: 'Typographic', desc: 'Oversized magazine masthead' },
-                      mosaic: { label: 'Mosaic', desc: 'Dynamic photo collage layout' },
-                      cover: {
-                        label: 'Cover (Experimental)',
-                        desc: 'Fullscreen splash with a single Enter link',
-                      },
-                    }[s] || { label: s, desc: '' };
-                    const isActive = (settings.theme?.heroStyle || 'split') === s;
-
-                    return (
-                      <button
-                        key={s}
-                        type="button"
-                        className={`preset-card hero-card ${isActive ? 'active' : ''}`}
-                        onClick={() => update('theme.heroStyle', s)}
-                      >
-                        <div className="hero-card-preview">
-                          <div className={`mini-hero-demo hero-demo-${s}`}>
-                            {s === 'split' && (
-                              <>
-                                <div className="hero-demo-text">
-                                  <div className="demo-line title" />
-                                  <div className="demo-line sub" />
-                                </div>
-                                <div className="hero-demo-photo" />
-                              </>
-                            )}
-                            {s === 'fullbleed' && (
-                              <div className="hero-demo-full">
-                                <div className="demo-line title light" />
-                              </div>
-                            )}
-                            {s === 'minimal' && (
-                              <>
-                                <div className="hero-demo-center-text">
-                                  <div className="demo-line title short" />
-                                </div>
-                                <div className="hero-demo-photo small" />
-                              </>
-                            )}
-                            {s === 'stacked' && (
-                              <>
-                                <div className="hero-demo-text">
-                                  <div className="demo-line title" />
-                                </div>
-                                <div className="hero-demo-photo banner" />
-                              </>
-                            )}
-                            {s === 'typographic' && (
-                              <>
-                                <div className="demo-line title giant" />
-                                <div className="hero-demo-grid2">
-                                  <div className="hero-demo-photo" />
-                                  <div className="hero-demo-photo" />
-                                </div>
-                              </>
-                            )}
-                            {s === 'mosaic' && (
-                              <div className="hero-demo-mosaic">
-                                <div className="hero-demo-photo big" />
-                                <div className="hero-demo-photo-col">
-                                  <div className="hero-demo-photo" />
-                                  <div className="hero-demo-photo" />
-                                </div>
-                              </div>
-                            )}
-                          </div>
-                        </div>
-                        <div className="preset-card-info">
-                          <span className="preset-card-name">{info.label}</span>
-                          <span className="preset-card-desc">{info.desc}</span>
-                        </div>
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
+              <OptionGrid
+                label="Hero Style"
+                options={HERO_STYLE_OPTIONS}
+                value={settings.theme?.heroStyle || 'split'}
+                onSelect={(v) => update('theme.heroStyle', v)}
+                cardClassName="hero-card"
+                renderPreview={(o) => <HeroStylePreview value={o.value} />}
+              />
 
               <div className="settings-section-divider" />
 
@@ -1284,156 +1403,23 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
                 </p>
               </div>
 
-              <div className="admin-field">
-                <label>Layout Algorithm</label>
-                <div className="preset-card-grid">
-                  {LAYOUTS.map((l) => {
-                    const info = {
-                      masonry: {
-                        label: 'Masonry',
-                        desc: 'Dynamic pinterest-style staggered columns',
-                      },
-                      uniform: { label: 'Uniform Grid', desc: 'Clean equal aspect ratio grid' },
-                      showcase: {
-                        label: 'Showcase',
-                        desc: 'Featured hero photos mixed with smaller tiles',
-                      },
-                      filmstrip: {
-                        label: 'Filmstrip',
-                        desc: 'Horizontal scrollable film strip timeline',
-                      },
-                      'editorial-flow': {
-                        label: 'Editorial Flow',
-                        desc: 'Magazine story layout with varying photo sizes',
-                      },
-                      justified: {
-                        label: 'Justified (Experimental)',
-                        desc: 'Equal-height rows that fill the full width',
-                      },
-                    }[l] || { label: l, desc: '' };
-                    const isActive = (settings.grid?.layout || 'masonry') === l;
+              <OptionGrid
+                label="Layout Algorithm"
+                options={LAYOUT_OPTIONS}
+                value={settings.grid?.layout || 'masonry'}
+                onSelect={(v) => update('grid.layout', v)}
+                cardClassName="grid-layout-card"
+                renderPreview={(o) => <LayoutPreview value={o.value} />}
+              />
 
-                    return (
-                      <button
-                        key={l}
-                        type="button"
-                        className={`preset-card grid-layout-card ${isActive ? 'active' : ''}`}
-                        onClick={() => update('grid.layout', l)}
-                      >
-                        <div className="grid-card-preview">
-                          <div className={`mini-layout-demo layout-demo-${l}`}>
-                            {l === 'masonry' && (
-                              <div className="demo-masonry-col-group">
-                                <div className="demo-col">
-                                  <div className="demo-tile h-high" />
-                                  <div className="demo-tile h-low" />
-                                </div>
-                                <div className="demo-col">
-                                  <div className="demo-tile h-low" />
-                                  <div className="demo-tile h-high" />
-                                </div>
-                                <div className="demo-col">
-                                  <div className="demo-tile h-med" />
-                                  <div className="demo-tile h-med" />
-                                </div>
-                              </div>
-                            )}
-                            {l === 'uniform' && (
-                              <div className="demo-uniform-grid">
-                                <div className="demo-tile" />
-                                <div className="demo-tile" />
-                                <div className="demo-tile" />
-                                <div className="demo-tile" />
-                                <div className="demo-tile" />
-                                <div className="demo-tile" />
-                              </div>
-                            )}
-                            {l === 'showcase' && (
-                              <div className="demo-showcase-grid">
-                                <div className="demo-tile demo-hero" />
-                                <div className="demo-col">
-                                  <div className="demo-tile" />
-                                  <div className="demo-tile" />
-                                </div>
-                              </div>
-                            )}
-                            {l === 'filmstrip' && (
-                              <div className="demo-filmstrip-row">
-                                <div className="demo-tile strip" />
-                                <div className="demo-tile strip" />
-                                <div className="demo-tile strip" />
-                              </div>
-                            )}
-                            {l === 'editorial-flow' && (
-                              <div className="demo-editorial-flow">
-                                <div className="demo-tile wide" />
-                                <div className="demo-row">
-                                  <div className="demo-tile" />
-                                  <div className="demo-tile" />
-                                </div>
-                              </div>
-                            )}
-                            {l === 'justified' && (
-                              <div className="demo-editorial-flow">
-                                <div className="demo-row">
-                                  <div className="demo-tile wide" />
-                                  <div className="demo-tile" />
-                                </div>
-                                <div className="demo-row">
-                                  <div className="demo-tile" />
-                                  <div className="demo-tile wide" />
-                                </div>
-                              </div>
-                            )}
-                          </div>
-                        </div>
-                        <div className="preset-card-info">
-                          <span className="preset-card-name">{info.label}</span>
-                          <span className="preset-card-desc">{info.desc}</span>
-                        </div>
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-
-              <div className="admin-field">
-                <label>Aspect Ratio</label>
-                <div className="preset-card-grid">
-                  {ASPECT_RATIOS.map((r) => {
-                    const info = {
-                      '1': { label: 'Square (1:1)', desc: '1:1 ratio square crops' },
-                      '3/2': { label: 'Landscape (3:2)', desc: 'Standard 35mm DSLR landscape' },
-                      '2/3': { label: 'Portrait (2:3)', desc: 'Vertical portrait orientation' },
-                      '16/9': { label: 'Cinema (16:9)', desc: 'Widescreen 16:9 cinematic ratio' },
-                      auto: {
-                        label: 'Original Auto',
-                        desc: 'Uncropped original image proportions',
-                      },
-                    }[r] || { label: r, desc: '' };
-                    const isActive = (settings.grid?.aspectRatio || '1') === r;
-
-                    return (
-                      <button
-                        key={r}
-                        type="button"
-                        className={`preset-card ratio-card ${isActive ? 'active' : ''}`}
-                        onClick={() => update('grid.aspectRatio', r)}
-                      >
-                        <div className="ratio-card-preview">
-                          <div className={`mini-aspect-box ratio-${r.replace('/', '-')}`}>
-                            <div className="mini-aspect-inner" />
-                          </div>
-                        </div>
-                        <div className="preset-card-info">
-                          <span className="preset-card-name">{info.label}</span>
-                          <span className="preset-card-desc">{info.desc}</span>
-                        </div>
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
+              <OptionGrid
+                label="Aspect Ratio"
+                options={ASPECT_RATIO_OPTIONS}
+                value={settings.grid?.aspectRatio || '1'}
+                onSelect={(v) => update('grid.aspectRatio', v)}
+                cardClassName="ratio-card"
+                renderPreview={(o) => <AspectRatioPreview value={o.value} />}
+              />
 
               <div className="settings-section-divider" />
 

--- a/app/admin/components/SettingsEditor.tsx
+++ b/app/admin/components/SettingsEditor.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import * as Icons from './Icons';
 import SaveBar from './SaveBar';
+import ToggleCard from './fields/ToggleCard';
 // Direct import from the theme module, not from '@/lib/config': the config
 // index pulls in `fs` and cannot be bundled into a client component.
 import { DEFAULT_PRESET } from '@/lib/config/theme';
@@ -720,61 +721,29 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
                 description="Chrome the visitor sees on every page."
               >
                 <div className="admin-toggle-cards-grid">
-                  <button
-                    type="button"
-                    className={`admin-toggle-card ${settings.about?.enabled !== false ? 'active' : ''}`}
-                    onClick={() => update('about.enabled', settings.about?.enabled === false)}
-                  >
-                    <div className="toggle-card-info">
-                      <span className="toggle-card-title">
-                        <Icons.IconCamera size={16} /> About Page
-                      </span>
-                      <span className="toggle-card-desc">
-                        Show a portrait, bio, and gear section on your portfolio
-                      </span>
-                    </div>
-                    <div
-                      className={`switch-toggle ${settings.about?.enabled !== false ? 'on' : ''}`}
-                    >
-                      <span className="switch-slider" />
-                    </div>
-                  </button>
+                  <ToggleCard
+                    icon={<Icons.IconCamera size={16} />}
+                    title="About Page"
+                    description="Show a portrait, bio, and gear section on your portfolio"
+                    checked={settings.about?.enabled !== false}
+                    onToggle={() => update('about.enabled', settings.about?.enabled === false)}
+                  />
 
-                  <button
-                    type="button"
-                    className={`admin-toggle-card ${settings.transitions !== false ? 'active' : ''}`}
-                    onClick={() => update('transitions', settings.transitions === false)}
-                  >
-                    <div className="toggle-card-info">
-                      <span className="toggle-card-title">
-                        <Icons.IconSparkles size={16} /> Smooth Page Transitions
-                      </span>
-                      <span className="toggle-card-desc">
-                        Enable subtle fade-in animations between page navigation
-                      </span>
-                    </div>
-                    <div className={`switch-toggle ${settings.transitions !== false ? 'on' : ''}`}>
-                      <span className="switch-slider" />
-                    </div>
-                  </button>
+                  <ToggleCard
+                    icon={<Icons.IconSparkles size={16} />}
+                    title="Smooth Page Transitions"
+                    description="Enable subtle fade-in animations between page navigation"
+                    checked={settings.transitions !== false}
+                    onToggle={() => update('transitions', settings.transitions === false)}
+                  />
 
-                  <button
-                    type="button"
-                    className={`admin-toggle-card ${settings.scrollToTop !== false ? 'active' : ''}`}
-                    onClick={() => update('scrollToTop', settings.scrollToTop === false)}
-                  >
-                    <div className="toggle-card-info">
-                      <span className="toggle-card-title">
-                        <Icons.IconArrowUp size={16} /> Scroll-to-Top Button
-                      </span>
-                      <span className="toggle-card-desc">
-                        Show a floating arrow that returns visitors to the top of long pages
-                      </span>
-                    </div>
-                    <div className={`switch-toggle ${settings.scrollToTop !== false ? 'on' : ''}`}>
-                      <span className="switch-slider" />
-                    </div>
-                  </button>
+                  <ToggleCard
+                    icon={<Icons.IconArrowUp size={16} />}
+                    title="Scroll-to-Top Button"
+                    description="Show a floating arrow that returns visitors to the top of long pages"
+                    checked={settings.scrollToTop !== false}
+                    onToggle={() => update('scrollToTop', settings.scrollToTop === false)}
+                  />
                 </div>
               </FeatureGroup>
 
@@ -866,44 +835,23 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
                 description="Optional pages and interactions."
               >
                 <div className="admin-toggle-cards-grid">
-                  <button
-                    type="button"
-                    className={`admin-toggle-card ${settings.map === true ? 'active' : ''}`}
-                    onClick={() => update('map', !settings.map)}
-                  >
-                    <div className="toggle-card-info">
-                      <span className="toggle-card-title">
-                        <Icons.IconMap size={16} /> Interactive GPS Map
-                      </span>
-                      <span className="toggle-card-desc">
-                        Enable /map view showing photo locations on a world map
-                      </span>
-                    </div>
-                    <div className={`switch-toggle ${settings.map === true ? 'on' : ''}`}>
-                      <span className="switch-slider" />
-                    </div>
-                  </button>
+                  <ToggleCard
+                    icon={<Icons.IconMap size={16} />}
+                    title="Interactive GPS Map"
+                    description="Enable /map view showing photo locations on a world map"
+                    checked={settings.map === true}
+                    onToggle={() => update('map', !settings.map)}
+                  />
 
-                  <button
-                    type="button"
-                    className={`admin-toggle-card ${settings.proofing?.enabled !== false ? 'active' : ''}`}
-                    onClick={() => update('proofing.enabled', settings.proofing?.enabled === false)}
-                  >
-                    <div className="toggle-card-info">
-                      <span className="toggle-card-title">
-                        <Icons.IconHeart size={16} /> Client Proofing &amp; Favorites
-                      </span>
-                      <span className="toggle-card-desc">
-                        Allow visitors &amp; clients to heart, filter, and export favorite photo
-                        selections
-                      </span>
-                    </div>
-                    <div
-                      className={`switch-toggle ${settings.proofing?.enabled !== false ? 'on' : ''}`}
-                    >
-                      <span className="switch-slider" />
-                    </div>
-                  </button>
+                  <ToggleCard
+                    icon={<Icons.IconHeart size={16} />}
+                    title="Client Proofing & Favorites"
+                    description="Allow visitors & clients to heart, filter, and export favorite photo selections"
+                    checked={settings.proofing?.enabled !== false}
+                    onToggle={() =>
+                      update('proofing.enabled', settings.proofing?.enabled === false)
+                    }
+                  />
                 </div>
               </FeatureGroup>
 
@@ -913,23 +861,13 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
                 description="Cookieless and self-hosted — nothing leaves your server."
               >
                 <div className="admin-toggle-cards-grid">
-                  <button
-                    type="button"
-                    className={`admin-toggle-card ${settings.analytics !== false ? 'active' : ''}`}
-                    onClick={() => update('analytics', settings.analytics === false)}
-                  >
-                    <div className="toggle-card-info">
-                      <span className="toggle-card-title">
-                        <Icons.IconBarChart size={16} /> Analytics Tracking
-                      </span>
-                      <span className="toggle-card-desc">
-                        Collect anonymous privacy-friendly visit statistics
-                      </span>
-                    </div>
-                    <div className={`switch-toggle ${settings.analytics !== false ? 'on' : ''}`}>
-                      <span className="switch-slider" />
-                    </div>
-                  </button>
+                  <ToggleCard
+                    icon={<Icons.IconBarChart size={16} />}
+                    title="Analytics Tracking"
+                    description="Collect anonymous privacy-friendly visit statistics"
+                    checked={settings.analytics !== false}
+                    onToggle={() => update('analytics', settings.analytics === false)}
+                  />
                 </div>
               </FeatureGroup>
 
@@ -1316,43 +1254,21 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
               </div>
 
               <div className="admin-toggle-cards-grid">
-                <button
-                  type="button"
-                  className={`admin-toggle-card ${settings.theme?.grain === true ? 'active' : ''}`}
-                  onClick={() => update('theme.grain', !settings.theme?.grain)}
-                >
-                  <div className="toggle-card-info">
-                    <span className="toggle-card-title">
-                      <Icons.IconFilm size={16} /> Film Grain Texture
-                    </span>
-                    <span className="toggle-card-desc">
-                      Adds analog noise overlay across portfolio background
-                    </span>
-                  </div>
-                  <div className={`switch-toggle ${settings.theme?.grain === true ? 'on' : ''}`}>
-                    <span className="switch-slider" />
-                  </div>
-                </button>
+                <ToggleCard
+                  icon={<Icons.IconFilm size={16} />}
+                  title="Film Grain Texture"
+                  description="Adds analog noise overlay across portfolio background"
+                  checked={settings.theme?.grain === true}
+                  onToggle={() => update('theme.grain', !settings.theme?.grain)}
+                />
 
-                <button
-                  type="button"
-                  className={`admin-toggle-card ${settings.theme?.headerDot !== false ? 'active' : ''}`}
-                  onClick={() => update('theme.headerDot', settings.theme?.headerDot === false)}
-                >
-                  <div className="toggle-card-info">
-                    <span className="toggle-card-title">
-                      <Icons.IconTarget size={16} /> Header Accent Dot
-                    </span>
-                    <span className="toggle-card-desc">
-                      Displays accent dot next to active section header
-                    </span>
-                  </div>
-                  <div
-                    className={`switch-toggle ${settings.theme?.headerDot !== false ? 'on' : ''}`}
-                  >
-                    <span className="switch-slider" />
-                  </div>
-                </button>
+                <ToggleCard
+                  icon={<Icons.IconTarget size={16} />}
+                  title="Header Accent Dot"
+                  description="Displays accent dot next to active section header"
+                  checked={settings.theme?.headerDot !== false}
+                  onToggle={() => update('theme.headerDot', settings.theme?.headerDot === false)}
+                />
               </div>
             </div>
           )}
@@ -1680,23 +1596,13 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
               </div>
 
               <div className="admin-toggle-cards-grid" style={{ marginBottom: '1.25rem' }}>
-                <button
-                  type="button"
-                  className={`admin-toggle-card ${settings.legal?.enabled === true ? 'active' : ''}`}
-                  onClick={() => update('legal.enabled', !settings.legal?.enabled)}
-                >
-                  <div className="toggle-card-info">
-                    <span className="toggle-card-title">
-                      <Icons.IconFileText size={16} /> Enable Impressum Page (/impressum)
-                    </span>
-                    <span className="toggle-card-desc">
-                      Automatically generates and links /impressum in footer
-                    </span>
-                  </div>
-                  <div className={`switch-toggle ${settings.legal?.enabled === true ? 'on' : ''}`}>
-                    <span className="switch-slider" />
-                  </div>
-                </button>
+                <ToggleCard
+                  icon={<Icons.IconFileText size={16} />}
+                  title="Enable Impressum Page (/impressum)"
+                  description="Automatically generates and links /impressum in footer"
+                  checked={settings.legal?.enabled === true}
+                  onToggle={() => update('legal.enabled', !settings.legal?.enabled)}
+                />
               </div>
 
               {settings.legal?.enabled && (
@@ -1874,41 +1780,21 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
               </div>
 
               <div className="admin-toggle-cards-grid">
-                <button
-                  type="button"
-                  className={`admin-toggle-card ${settings.seo?.noIndex === true ? 'active' : ''}`}
-                  onClick={() => update('seo.noIndex', !settings.seo?.noIndex)}
-                >
-                  <div className="toggle-card-info">
-                    <span className="toggle-card-title">
-                      <Icons.IconBan size={16} /> noindex (Hide from Google)
-                    </span>
-                    <span className="toggle-card-desc">
-                      Instructs search engines NOT to index this site in search results
-                    </span>
-                  </div>
-                  <div className={`switch-toggle ${settings.seo?.noIndex === true ? 'on' : ''}`}>
-                    <span className="switch-slider" />
-                  </div>
-                </button>
+                <ToggleCard
+                  icon={<Icons.IconBan size={16} />}
+                  title="noindex (Hide from Google)"
+                  description="Instructs search engines NOT to index this site in search results"
+                  checked={settings.seo?.noIndex === true}
+                  onToggle={() => update('seo.noIndex', !settings.seo?.noIndex)}
+                />
 
-                <button
-                  type="button"
-                  className={`admin-toggle-card ${settings.seo?.noFollow === true ? 'active' : ''}`}
-                  onClick={() => update('seo.noFollow', !settings.seo?.noFollow)}
-                >
-                  <div className="toggle-card-info">
-                    <span className="toggle-card-title">
-                      <Icons.IconLink size={16} /> nofollow (Block Link Following)
-                    </span>
-                    <span className="toggle-card-desc">
-                      Instructs search engine crawlers not to follow outgoing links
-                    </span>
-                  </div>
-                  <div className={`switch-toggle ${settings.seo?.noFollow === true ? 'on' : ''}`}>
-                    <span className="switch-slider" />
-                  </div>
-                </button>
+                <ToggleCard
+                  icon={<Icons.IconLink size={16} />}
+                  title="nofollow (Block Link Following)"
+                  description="Instructs search engine crawlers not to follow outgoing links"
+                  checked={settings.seo?.noFollow === true}
+                  onToggle={() => update('seo.noFollow', !settings.seo?.noFollow)}
+                />
               </div>
             </div>
           )}
@@ -1954,49 +1840,25 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
               </div>
 
               <div className="admin-toggle-cards-grid">
-                <button
-                  type="button"
-                  className={`admin-toggle-card ${settings.protection?.disableRightClick === true ? 'active' : ''}`}
-                  onClick={() =>
+                <ToggleCard
+                  icon={<Icons.IconLock size={16} />}
+                  title="Disable Right-Click Menu"
+                  description="Prevents context menu on portfolio images to hinder unauthorized downloads"
+                  checked={settings.protection?.disableRightClick === true}
+                  onToggle={() =>
                     update('protection.disableRightClick', !settings.protection?.disableRightClick)
                   }
-                >
-                  <div className="toggle-card-info">
-                    <span className="toggle-card-title">
-                      <Icons.IconLock size={16} /> Disable Right-Click Menu
-                    </span>
-                    <span className="toggle-card-desc">
-                      Prevents context menu on portfolio images to hinder unauthorized downloads
-                    </span>
-                  </div>
-                  <div
-                    className={`switch-toggle ${settings.protection?.disableRightClick === true ? 'on' : ''}`}
-                  >
-                    <span className="switch-slider" />
-                  </div>
-                </button>
+                />
 
-                <button
-                  type="button"
-                  className={`admin-toggle-card ${settings.protection?.disableImageDrag === true ? 'active' : ''}`}
-                  onClick={() =>
+                <ToggleCard
+                  icon={<Icons.IconBan size={16} />}
+                  title="Disable Image Dragging"
+                  description="Prevents visitors from dragging images off the portfolio page"
+                  checked={settings.protection?.disableImageDrag === true}
+                  onToggle={() =>
                     update('protection.disableImageDrag', !settings.protection?.disableImageDrag)
                   }
-                >
-                  <div className="toggle-card-info">
-                    <span className="toggle-card-title">
-                      <Icons.IconBan size={16} /> Disable Image Dragging
-                    </span>
-                    <span className="toggle-card-desc">
-                      Prevents visitors from dragging images off the portfolio page
-                    </span>
-                  </div>
-                  <div
-                    className={`switch-toggle ${settings.protection?.disableImageDrag === true ? 'on' : ''}`}
-                  >
-                    <span className="switch-slider" />
-                  </div>
-                </button>
+                />
               </div>
 
               <div className="settings-section-divider" />
@@ -2011,25 +1873,13 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
               </div>
 
               <div className="admin-toggle-cards-grid" style={{ marginBottom: '1.25rem' }}>
-                <button
-                  type="button"
-                  className={`admin-toggle-card ${settings.watermark?.enabled === true ? 'active' : ''}`}
-                  onClick={() => update('watermark.enabled', !settings.watermark?.enabled)}
-                >
-                  <div className="toggle-card-info">
-                    <span className="toggle-card-title">
-                      <Icons.IconFrame size={16} /> Enable Watermark
-                    </span>
-                    <span className="toggle-card-desc">
-                      Overlay copyright text on portfolio image views
-                    </span>
-                  </div>
-                  <div
-                    className={`switch-toggle ${settings.watermark?.enabled === true ? 'on' : ''}`}
-                  >
-                    <span className="switch-slider" />
-                  </div>
-                </button>
+                <ToggleCard
+                  icon={<Icons.IconFrame size={16} />}
+                  title="Enable Watermark"
+                  description="Overlay copyright text on portfolio image views"
+                  checked={settings.watermark?.enabled === true}
+                  onToggle={() => update('watermark.enabled', !settings.watermark?.enabled)}
+                />
               </div>
 
               {settings.watermark?.enabled && (

--- a/app/admin/components/fields/GridOverrideFields.tsx
+++ b/app/admin/components/fields/GridOverrideFields.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+type GridOverride = { columns?: number; gap?: number };
+
+const NUMBER_INPUT_STYLE = {
+  padding: '8px 12px',
+  borderRadius: '6px',
+  flex: 1,
+  fontSize: '0.9rem',
+} as const;
+
+/**
+ * The override editor for one grid: a column count and a gap, both optional,
+ * both falling back to a wider setting when left empty.
+ *
+ * Giving the album covers their own grid (#523) was implemented by copying this
+ * block — fifty-eight lines whose entire diff was the bounds it clamps to and
+ * the key it writes (#533). Two editors that have to behave identically had two
+ * implementations, which is how they drift apart.
+ *
+ * A value outside the bounds is discarded rather than clamped, which is what
+ * the copies did: the field then reads as empty and the setting falls back,
+ * instead of silently saving a number nobody typed.
+ */
+export default function GridOverrideFields({
+  label,
+  hint,
+  columnsMin,
+  columnsMax,
+  gapMax,
+  value,
+  onChange,
+}: {
+  label: string;
+  hint: ReactNode;
+  columnsMin: number;
+  columnsMax: number;
+  gapMax: number;
+  value: GridOverride | undefined;
+  /** Receives the whole next override; the caller normalises and stores it. */
+  onChange: (next: GridOverride) => void;
+}) {
+  const patch = (key: 'columns' | 'gap', raw: string, min: number, max: number) => {
+    const n = raw === '' ? undefined : Number(raw);
+    onChange({
+      ...(value || {}),
+      [key]: n != null && n >= min && n <= max ? n : undefined,
+    });
+  };
+
+  return (
+    <div className="admin-field" style={{ marginTop: '1rem' }}>
+      <label>{label}</label>
+      <div style={{ display: 'flex', gap: '12px' }}>
+        <input
+          type="number"
+          min={columnsMin}
+          max={columnsMax}
+          value={value?.columns ?? ''}
+          placeholder="Columns (site default)"
+          onChange={(e) => patch('columns', e.target.value, columnsMin, columnsMax)}
+          style={NUMBER_INPUT_STYLE}
+        />
+        <input
+          type="number"
+          min={0}
+          max={gapMax}
+          value={value?.gap ?? ''}
+          placeholder="Gap in px (theme default)"
+          onChange={(e) => patch('gap', e.target.value, 0, gapMax)}
+          style={NUMBER_INPUT_STYLE}
+        />
+      </div>
+      <p className="admin-field-hint">{hint}</p>
+    </div>
+  );
+}

--- a/app/admin/components/fields/OptionGrid.tsx
+++ b/app/admin/components/fields/OptionGrid.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import type { CSSProperties, ReactNode } from 'react';
+
+export type CardOption = { value: string; label: string; desc: string };
+
+/**
+ * Builds the option list for a picker from its value list and a label map, so
+ * the values a setting accepts and the words shown for them stay one thing.
+ */
+export function toOptions(
+  values: readonly string[],
+  info: Record<string, { label: string; desc: string }>,
+): CardOption[] {
+  return values.map((value) => ({
+    value,
+    label: info[value]?.label ?? value,
+    desc: info[value]?.desc ?? '',
+  }));
+}
+
+/**
+ * A labelled grid of picker cards — theme preset, layout, frame, hero style,
+ * aspect ratio.
+ *
+ * All five were written out separately: each had its own `.map()`, its own
+ * `preset-card` button, its own `active` handling, and its label text buried in
+ * an object literal a thousand lines from the value list it described (#533).
+ * The differences between them are the preview drawn on the card and, for the
+ * theme preset, a few custom properties — so those are the props, and the rest
+ * is stated once.
+ *
+ * The class names are unchanged, so `admin.css` styles these exactly as it
+ * styled the copies.
+ */
+export default function OptionGrid({
+  label,
+  options,
+  value,
+  onSelect,
+  cardClassName,
+  renderPreview,
+  renderSpecs,
+  cardStyle,
+}: {
+  label: string;
+  options: CardOption[];
+  /** The resolved value — the caller applies its own default before passing it. */
+  value: string;
+  onSelect: (value: string) => void;
+  /** Second class on the card, e.g. `frame-card`; `preset-card` is always set. */
+  cardClassName: string;
+  renderPreview?: (option: CardOption) => ReactNode;
+  /** Extra line under the description, used by the theme preset for its specs. */
+  renderSpecs?: (option: CardOption) => ReactNode;
+  cardStyle?: (option: CardOption) => CSSProperties | undefined;
+}) {
+  return (
+    <div className="admin-field">
+      <label>{label}</label>
+      <div className="preset-card-grid">
+        {options.map((option) => {
+          const isActive = value === option.value;
+          return (
+            <button
+              key={option.value}
+              type="button"
+              className={`preset-card ${cardClassName} ${isActive ? 'active' : ''}`}
+              onClick={() => onSelect(option.value)}
+              style={cardStyle?.(option)}
+              aria-pressed={isActive}
+            >
+              {renderPreview?.(option)}
+              <div className="preset-card-info">
+                <span className="preset-card-name">{option.label}</span>
+                <span className="preset-card-desc">{option.desc}</span>
+                {renderSpecs?.(option)}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/app/admin/components/fields/ToggleCard.tsx
+++ b/app/admin/components/fields/ToggleCard.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+/**
+ * A switch rendered as a card — the panel's top-level on/off control.
+ *
+ * The markup used to be written out at every call site: fourteen copies of the
+ * same eighteen lines, differing only in the label and which setting they read
+ * (#533). Changing how a switch looked meant editing it fourteen times, and the
+ * copies had already drifted apart in their line wrapping. The class names are
+ * unchanged, so `admin.css` styles this exactly as it styled the copies.
+ *
+ * `SettingRow` is the lighter sibling for switches *inside* a group panel; this
+ * is the card that sits at the top level of a section.
+ */
+export default function ToggleCard({
+  icon,
+  title,
+  description,
+  checked,
+  onToggle,
+}: {
+  icon: ReactNode;
+  title: ReactNode;
+  description: ReactNode;
+  checked: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={`admin-toggle-card ${checked ? 'active' : ''}`}
+      onClick={onToggle}
+      aria-pressed={checked}
+    >
+      <div className="toggle-card-info">
+        <span className="toggle-card-title">
+          {icon} {title}
+        </span>
+        <span className="toggle-card-desc">{description}</span>
+      </div>
+      <div className={`switch-toggle ${checked ? 'on' : ''}`}>
+        <span className="switch-slider" />
+      </div>
+    </button>
+  );
+}


### PR DESCRIPTION
Steps 1 and 2 of #533. No behaviour changes and no visual changes — the CSS class names are untouched, so `admin.css` styles everything exactly as before.

## What changed

**`ToggleCard`** replaces the 14 copies in `SettingsEditor`. Each was the same eighteen lines of `admin-toggle-card` / `toggle-card-info` / `switch-toggle`, differing only in the label and the setting it read.

**`GridOverrideFields`** replaces the two grid editors in `PageBuilder` — the 58 lines #532 introduced by copying, whose entire diff was the bounds it clamps to and the key it writes.

**`OptionGrid`** replaces all five card pickers. Their label maps move to module scope beside the value lists they describe: `LAYOUTS` was a bare array of six strings on line 99, and what those strings mean was written on line 1290. The previews become five flat components instead of JSX nested inside a callback.

| | before | after |
|---|---|---|
| `SettingsEditor.tsx` | 2,156 | 1,992 |
| `PageBuilder.tsx` | 2,290 | 2,199 |
| deepest indentation in `SettingsEditor` | 34 | 26 |

**One deliberate behaviour change:** the cards now carry `aria-pressed`. They showed their state by colour alone, while `SettingRow` beside them already announced itself. That is the one thing worth a CHANGELOG entry here.

## Verification

Mechanical checks cannot see a visual regression, so the content was compared directly:

- Every CSS class in the old `SettingsEditor` is still present across the new file plus `fields/` — the inventories diff clean, so no styling hook was lost or invented.
- Every `label:` / `desc:` string is unchanged, minus four `desc: ` fallbacks now stated once in `toOptions()`.
- Preview markup moved verbatim; only the loop variable is renamed.
- `tsc --noEmit` clean · `test:unit` 811 passed · `build` passes · `lint` one error, the same pre-existing `react/no-unescaped-entities` that is on `dev`.

**Not verified: how it looks.** The panel renders client-side against a live Immich instance, so it cannot be driven headlessly from a bare checkout — and `e2e/` covers the public site only, with no admin spec at all. Worth its own issue; step 3 (extracting the drawers, which moves logic rather than markup) should not land without it.

## Deferred, with reasons

**No `TextField` yet.** 26 of the 34 `admin-field` blocks are label-plus-one-control, but their handlers vary enough that a shared component means rewriting each. The version actually worth building is different: none of the 34 labels uses `htmlFor`, so clicking a label does not focus its input. A `Field` wrapper generating an id would fix that 34 times over — it needs a decision on how the id reaches the control first.

**`Listbox` unresolved.** 345 LOC for one call site is still the worst ratio in the tree, but adopting it replaces five native `<select>` with a custom keyboard model and deleting it takes away the nicer control. A product decision, not a mechanical one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DmsHVRL9yQvckUB1ZpVWre