### PR TITLE
fix(essay): stop the paragraph editor stripping its own markup (#537)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ Releases up to and including v0.9.2 are documented in the
 
 ### Fixed
 
+- **Editing an essay paragraph no longer strips its italics and links**
+  ([#537](https://github.com/ralksta/immich-folio/issues/537)). The essay block
+  editor rendered its textarea from a stripped copy of the paragraph — it turned
+  `<strong>` into `**` and replaced every other tag, `<em>` and `<a>` included,
+  with nothing — and then wrote that stripped text straight back on the next
+  keystroke. Touching a paragraph destroyed its markup. The transform was a
+  partial re-implementation of the serializer, which converts the HTML back to
+  markdown on save and handles `<em>` correctly, so there was nothing to convert
+  in the editor at all. It now shows the value raw, as the journal editor
+  already did for the same data.
+
 - **The admin panel's switches and pickers announce their state.** The toggle
   cards and the five card pickers — theme preset, photo frame, hero style,
   layout, aspect ratio — showed which option was active by colour alone, with

--- a/app/admin/components/EssayBlockEditor.tsx
+++ b/app/admin/components/EssayBlockEditor.tsx
@@ -241,13 +241,20 @@ export function EssayBlockEditor({ markdown, onChange, onSelectPhoto }: EssayBlo
             </div>
           )}
 
-          {/* 2. PARAGRAPH BLOCK */}
+          {/* 2. PARAGRAPH BLOCK
+
+              The textarea shows `html` raw, as the journal editor does. It used
+              to strip the tags for display — `<strong>` to `**`, everything else
+              to nothing — while `onChange` wrote the stripped text straight back
+              into `html`. Italics, links, anything the markdown had produced was
+              destroyed by the act of editing the paragraph, and the two editors
+              disagreed about the same file. serializeJournalMarkdown() turns the
+              HTML back into markdown on save and handles `<em>` too, so there
+              was nothing to convert here in the first place. */}
           {block.type === 'paragraph' && (
             <textarea
               rows={3}
-              value={block.html.replace(/<[^>]+>/g, (t) =>
-                t.startsWith('<strong>') ? '**' : t.startsWith('</strong>') ? '**' : '',
-              )}
+              value={block.html}
               onChange={(e) => handleUpdateBlock(idx, { ...block, html: e.target.value })}
               placeholder="Write text paragraph... (**bold**, *italic* markdown supported)"
             />


### PR DESCRIPTION
Closes #537.

## The bug

Editing a paragraph in the essay block editor destroyed its italics and links. One keystroke was enough.

`EssayBlockEditor.tsx:246` rendered the textarea from a stripped copy of `block.html`:

```tsx
value={block.html.replace(/<[^>]+>/g, (t) =>
  t.startsWith("<strong>") ? "**" : t.startsWith("</strong>") ? "**" : "",
)}
```

`<strong>` became `**`; every other tag matched `<[^>]+>` and was replaced with the empty string — `<em>` and `<a>` among them. The `onChange` on the next line wrote that value straight back into `block.html`, so the lossy display became the stored value and reached the file on the next save.

## The fix

Show the value raw, as `JournalStudio.tsx:834` already does for the same data. The transform was a partial re-implementation of `serializeJournalMarkdown()` (`lib/journal.ts:348-354`), which converts the HTML back to markdown on save and handles `<em>` and `<i>` correctly. There was nothing for the editor to convert.

`lib/essay.ts` is a fifteen-line re-export of `lib/journal.ts`: two editors, one model, and only one of them lossless.

## Verification

`tsc --noEmit` clean · `test:unit` 811 passed · `build` passes · `prettier --check` clean.

The lib layer was already correct and is untouched — `journal-service-paths.test.ts:75` and `journal-escaping.test.ts:38` cover the markdown round-trip including `<em>`, which is how the serializer was ruled out as the cause and the component isolated as the bug.

**Not covered by a test:** the component. vitest runs in a `node` environment with no jsdom, so a textarea value cannot be asserted here. Noted in #533, which proposes the admin coverage this would have needed.

## Filed alongside, not fixed here

- #538 — the journal editor tracks `dirty` but registers no `beforeunload`, so closing the tab loses unsaved entries silently. The other two editors warn.
- #539 — the dashboard status badge computes its colour and its label through two separately-ordered nested ternaries, which can disagree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DmsHVRL9yQvckUB1ZpVWre