### PR TITLE
fix(admin): unsaved-changes guard for the journal editor, and a status badge that agrees with itself (#538, #539)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ Releases up to and including v0.9.2 are documented in the
 
 ### Fixed
 
+- **The dashboard status badge's colour and words agree**
+  ([#539](https://github.com/ralksta/immich-folio/issues/539)). The badge decided
+  its colour and its label through two separately-ordered nested ternaries over
+  the same four inputs, and they disagreed in two states: with Immich
+  unreachable _and_ the config doctor warning, the colour matched the warning
+  first and stayed neutral while the words read "System Degraded"; and a refresh
+  that followed an earlier error left the badge red under "Checking...". Both
+  are now decided together, most serious first, so a condition cannot be added
+  to one and forgotten in the other.
+
 - **The journal editor warns before you close it with unsaved work**
   ([#538](https://github.com/ralksta/immich-folio/issues/538)). It tracked
   unsaved changes and used them to drive its save button, but registered no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Releases up to and including v0.9.2 are documented in the
 
 ### Fixed
 
+- **The journal editor warns before you close it with unsaved work**
+  ([#538](https://github.com/ralksta/immich-folio/issues/538)). It tracked
+  unsaved changes and used them to drive its save button, but registered no
+  `beforeunload` handler — so closing the tab mid-entry discarded the work
+  silently, while the same action in the page builder or the settings editor
+  asked first. Those two carried the guard as a copy each; all three now share
+  one, so a fourth editor cannot quietly be the next to forget it.
+
 - **Editing an essay paragraph no longer strips its italics and links**
   ([#537](https://github.com/ralksta/immich-folio/issues/537)). The essay block
   editor rendered its textarea from a stripped copy of the paragraph — it turned

--- a/app/admin/__tests__/systemHealth.test.ts
+++ b/app/admin/__tests__/systemHealth.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { systemHealth, type SystemHealthInput } from '../components/systemHealth';
+
+const base: SystemHealthInput = {
+  statusLoading: false,
+  setupIncomplete: false,
+  immich: 'ok',
+  doctorLevel: null,
+};
+const health = (over: Partial<SystemHealthInput> = {}) => systemHealth({ ...base, ...over });
+
+describe('systemHealth', () => {
+  it('reports a healthy system', () => {
+    expect(health()).toEqual({ tone: 'connected', label: 'System OK' });
+  });
+
+  it('stays neutral while loading', () => {
+    expect(health({ statusLoading: true })).toEqual({ tone: 'unknown', label: 'Checking...' });
+  });
+
+  it('keeps the badge neutral while a stale error is being rechecked', () => {
+    // The class used to have no loading case, so a doctor error left over from
+    // the previous run painted the badge red under "Checking..." (#539).
+    expect(health({ statusLoading: true, immich: 'unknown', doctorLevel: 'error' })).toEqual({
+      tone: 'unknown',
+      label: 'Checking...',
+    });
+  });
+
+  it('treats an unfinished install as neutral, not as a fault', () => {
+    expect(health({ setupIncomplete: true, immich: 'error' })).toEqual({
+      tone: 'unknown',
+      label: 'Setup Incomplete',
+    });
+  });
+
+  it('lets an unreachable Immich outrank a doctor warning', () => {
+    // The class matched `warn` first and went neutral while the text said
+    // "System Degraded" — the less serious condition decided the colour (#539).
+    expect(health({ immich: 'error', doctorLevel: 'warn' })).toEqual({
+      tone: 'disconnected',
+      label: 'System Degraded',
+    });
+  });
+
+  it('reports a doctor error when Immich itself is fine', () => {
+    expect(health({ doctorLevel: 'error' })).toEqual({
+      tone: 'disconnected',
+      label: 'Needs Attention',
+    });
+  });
+
+  it('reports a doctor warning as neutral', () => {
+    expect(health({ doctorLevel: 'warn' })).toEqual({
+      tone: 'unknown',
+      label: 'Check Diagnostics',
+    });
+  });
+
+  it('falls back to unknown when Immich is neither ok nor in error', () => {
+    expect(health({ immich: 'unknown' })).toEqual({ tone: 'unknown', label: 'Status Unknown' });
+  });
+
+  it('never pairs a label with a tone that contradicts it', () => {
+    const expected: Record<string, string> = {
+      'Checking...': 'unknown',
+      'Setup Incomplete': 'unknown',
+      'System Degraded': 'disconnected',
+      'Needs Attention': 'disconnected',
+      'Check Diagnostics': 'unknown',
+      'System OK': 'connected',
+      'Status Unknown': 'unknown',
+    };
+    for (const statusLoading of [false, true]) {
+      for (const setupIncomplete of [false, true]) {
+        for (const immich of ['ok', 'error', 'unknown']) {
+          for (const doctorLevel of [null, 'ok', 'warn', 'error'] as const) {
+            const { tone, label } = health({ statusLoading, setupIncomplete, immich, doctorLevel });
+            expect(expected[label], `${label} with tone ${tone}`).toBe(tone);
+          }
+        }
+      }
+    }
+  });
+});

--- a/app/admin/components/AdminDashboard.tsx
+++ b/app/admin/components/AdminDashboard.tsx
@@ -6,6 +6,7 @@ import { usePathname } from 'next/navigation';
 import BackupManagerModal from './BackupManagerModal';
 import DoctorModal from './DoctorModal';
 import type { DoctorLevel } from '@/lib/admin/doctor';
+import { systemHealth } from './systemHealth';
 import * as Icons from './Icons';
 
 interface Props {
@@ -117,6 +118,15 @@ export default function AdminDashboard({ onLogout, children }: Props) {
   // as "System Degraded" with no further hint, which sent operators looking for
   // a network problem that did not exist (#507).
   const setupIncomplete = !statusLoading && !statusError && status?.setup?.complete === false;
+
+  // Colour and words decided together — they used to be two separately-ordered
+  // nested ternaries over the same inputs, and disagreed in two states (#539).
+  const health = systemHealth({
+    statusLoading,
+    setupIncomplete,
+    immich: immichIndicator.className,
+    doctorLevel,
+  });
   const missingCredentials = status?.setup?.credentials === 'missing';
 
   return (
@@ -140,15 +150,7 @@ export default function AdminDashboard({ onLogout, children }: Props) {
           {/* Diagnostics Badge */}
           <div className="status-indicator-container">
             <button
-              className={`status-badge-btn ${
-                setupIncomplete || doctorLevel === 'warn'
-                  ? 'unknown'
-                  : immichIndicator.className === 'error' || doctorLevel === 'error'
-                    ? 'disconnected'
-                    : immichIndicator.className === 'ok'
-                      ? 'connected'
-                      : 'unknown'
-              }`}
+              className={`status-badge-btn ${health.tone}`}
               onClick={() => {
                 setShowStatus(!showStatus);
                 if (!showStatus) fetchStatus();
@@ -156,21 +158,7 @@ export default function AdminDashboard({ onLogout, children }: Props) {
               title="Show system status"
             >
               <span className="status-dot"></span>
-              <span className="status-text">
-                {statusLoading
-                  ? 'Checking...'
-                  : setupIncomplete
-                    ? 'Setup Incomplete'
-                    : immichIndicator.className === 'error'
-                      ? 'System Degraded'
-                      : doctorLevel === 'error'
-                        ? 'Needs Attention'
-                        : doctorLevel === 'warn'
-                          ? 'Check Diagnostics'
-                          : immichIndicator.className === 'ok'
-                            ? 'System OK'
-                            : 'Status Unknown'}
-              </span>
+              <span className="status-text">{health.label}</span>
             </button>
 
             {showStatus && (

--- a/app/admin/components/JournalStudio.tsx
+++ b/app/admin/components/JournalStudio.tsx
@@ -25,6 +25,7 @@ import {
 } from './Icons';
 import AssetPicker from './AssetPicker';
 import { BlockBadge } from './BlockBadge';
+import { useUnsavedGuard } from './useUnsavedGuard';
 import { EssayView } from '@/app/[...path]/EssayView';
 import type { PhotoItem } from '@/app/[...path]/PhotoGrid';
 import './journal-studio.css';
@@ -520,6 +521,8 @@ function JournalEditor({ slug, onBack }: JournalEditorProps) {
       setSaving(false);
     }
   };
+
+  useUnsavedGuard(dirty);
 
   // Keyboard shortcut: Cmd+S / Ctrl+S
   useEffect(() => {

--- a/app/admin/components/PageBuilder.tsx
+++ b/app/admin/components/PageBuilder.tsx
@@ -26,6 +26,7 @@ import { EssayBlockEditor } from './EssayBlockEditor';
 import SaveBar from './SaveBar';
 import GridOverrideFields from './fields/GridOverrideFields';
 import { useScrollLock } from './useScrollLock';
+import { useUnsavedGuard } from './useUnsavedGuard';
 import {
   ALBUM_SORT_MODES,
   DEFAULT_ALBUM_SORT,
@@ -513,17 +514,7 @@ export default function PageBuilder() {
     return () => window.removeEventListener('keydown', handleEscape);
   }, [expandedSubpage, editingAlbumAddress, pickerTarget, heroPickerTarget, orderEditorTarget]);
 
-  // ── Unsaved changes guard ────────────────────────────────────
-  useEffect(() => {
-    function handleBeforeUnload(e: BeforeUnloadEvent) {
-      if (dirty) {
-        e.preventDefault();
-        e.returnValue = '';
-      }
-    }
-    window.addEventListener('beforeunload', handleBeforeUnload);
-    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
-  }, [dirty]);
+  useUnsavedGuard(dirty);
 
   async function loadData() {
     setLoading(true);

--- a/app/admin/components/SettingsEditor.tsx
+++ b/app/admin/components/SettingsEditor.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import * as Icons from './Icons';
 import SaveBar from './SaveBar';
+import { useUnsavedGuard } from './useUnsavedGuard';
 import ToggleCard from './fields/ToggleCard';
 import OptionGrid, { toOptions } from './fields/OptionGrid';
 // Direct import from the theme module, not from '@/lib/config': the config
@@ -676,17 +677,7 @@ export default function SettingsEditor({ section }: SettingsEditorProps) {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [handleSaveRef]);
 
-  // ── Unsaved changes guard ────────────────────────────────────
-  useEffect(() => {
-    function handleBeforeUnload(e: BeforeUnloadEvent) {
-      if (dirty) {
-        e.preventDefault();
-        e.returnValue = '';
-      }
-    }
-    window.addEventListener('beforeunload', handleBeforeUnload);
-    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
-  }, [dirty]);
+  useUnsavedGuard(dirty);
 
   async function loadSettings() {
     setLoading(true);

--- a/app/admin/components/systemHealth.ts
+++ b/app/admin/components/systemHealth.ts
@@ -1,0 +1,48 @@
+import type { DoctorLevel } from '@/lib/admin/doctor';
+
+/** The three tones `status-badge-btn` is styled for. */
+export type BadgeTone = 'connected' | 'disconnected' | 'unknown';
+
+export interface SystemHealthInput {
+  statusLoading: boolean;
+  setupIncomplete: boolean;
+  /** `immichIndicator.className` — 'ok', 'error' or 'unknown'. */
+  immich: string;
+  doctorLevel: DoctorLevel | null;
+}
+
+/**
+ * What the dashboard's status badge should say, and in which colour.
+ *
+ * The two used to be decided separately: a four-level nested ternary for the
+ * class and a six-level one for the text, over the same four inputs but in a
+ * different order. They disagreed in exactly two states (#539):
+ *
+ * - Immich unreachable while the doctor also warns — the class matched `warn`
+ *   first and painted the badge neutral, while the text reported "System
+ *   Degraded". The more serious of the two conditions decided the words and the
+ *   less serious one decided the colour.
+ * - A refetch while a previous run had reported an error — the class had no
+ *   loading case at all, so the badge stayed red under "Checking...".
+ *
+ * The text's ordering wins here, because it is the one that reads most-severe
+ * first and the only one that accounted for loading. Deciding both together is
+ * the point: a third condition can no longer be added to one and forgotten in
+ * the other.
+ */
+export function systemHealth({
+  statusLoading,
+  setupIncomplete,
+  immich,
+  doctorLevel,
+}: SystemHealthInput): { tone: BadgeTone; label: string } {
+  if (statusLoading) return { tone: 'unknown', label: 'Checking...' };
+  // An installation that was never finished is not a fault, so it stays neutral
+  // rather than red — the same reasoning that gave it its own label (#507).
+  if (setupIncomplete) return { tone: 'unknown', label: 'Setup Incomplete' };
+  if (immich === 'error') return { tone: 'disconnected', label: 'System Degraded' };
+  if (doctorLevel === 'error') return { tone: 'disconnected', label: 'Needs Attention' };
+  if (doctorLevel === 'warn') return { tone: 'unknown', label: 'Check Diagnostics' };
+  if (immich === 'ok') return { tone: 'connected', label: 'System OK' };
+  return { tone: 'unknown', label: 'Status Unknown' };
+}

--- a/app/admin/components/useUnsavedGuard.ts
+++ b/app/admin/components/useUnsavedGuard.ts
@@ -1,0 +1,29 @@
+'use client';
+
+import { useEffect } from 'react';
+
+/**
+ * Asks the browser to confirm before leaving while `dirty` is true.
+ *
+ * The page builder and the settings editor each carried their own copy of this
+ * effect, byte for byte. The journal studio tracked `dirty` and had none, so
+ * closing the tab mid-entry lost the work without a word while the same action
+ * in the other two editors asked first (#538). A third copy would have been the
+ * third chance to forget it.
+ *
+ * `returnValue` is set as well as `preventDefault()`: the property is what older
+ * browsers read, and Safari still needs it. No custom string is passed because
+ * no browser has shown one for years — the text is the browser's own.
+ */
+export function useUnsavedGuard(dirty: boolean) {
+  useEffect(() => {
+    function handleBeforeUnload(e: BeforeUnloadEvent) {
+      if (dirty) {
+        e.preventDefault();
+        e.returnValue = '';
+      }
+    }
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [dirty]);
+}


### PR DESCRIPTION
Closes #538. Closes #539.

Two admin bugs found while surveying the panel for [#533](https://github.com/ralksta/immich-folio/issues/533). Kept out of that refactor because both are defects, not tidying.

## #538 — the journal editor lost work silently

It tracked `dirty` and drove its save button from it, but registered no `beforeunload` handler. Closing the tab mid-entry discarded the work without a word, while the identical action in the page builder or the settings editor asked first.

Those two each carried the guard as their own byte-identical copy, which is why the third never got one. Rather than add a third, the effect moves to `useUnsavedGuard(dirty)` beside the existing `useScrollLock` — same kind of hook, same directory. All three editors now share it.

## #539 — the status badge could contradict itself

The badge picked its class through a four-level nested ternary and its text through a six-level one, over the same four inputs in a different order. Enumerating every reachable combination finds two where they disagree:

| loading | setupIncomplete | immich | doctor | colour | words |
|---|---|---|---|---|---|
| no | no | `error` | `warn` | `unknown` | System Degraded |
| yes | no | `unknown` | `error` | `disconnected` | Checking... |

In the first, Immich is unreachable *and* the doctor warns; because the class matched `warn` before `error`, the less serious condition decided the colour. In the second, the class branch had no loading case, so a `doctorLevel` left from a previous run kept the badge red under "Checking...".

`systemHealth()` now returns `{tone, label}` from one early-return chain, most-serious-first. That ordering is the text’s — six levels, and the only one that handled loading. `AdminDashboard.tsx` 332 → 320 lines.

*Note: the example originally given in #539 was wrong — `setupIncomplete` with a doctor error is not a contradiction. [Corrected on the issue](https://github.com/ralksta/immich-folio/issues/539#issuecomment-5408306485).*

## Tests — `app/admin/__tests__/` is new

The admin panel had no test of any kind. `systemHealth()` lives in its own module rather than inside the component precisely so it can have one: it is a pure function of four values, and the bug was that those four values were read twice.

The last case in the suite is the enumeration itself — every combination of the four inputs, asserting no label is ever paired with a tone that contradicts it. Both bugs above fail it.

## Verification

`tsc --noEmit` clean · `test:unit` **820 passed in 63 files** (was 811 in 62) · `build` passes · `prettier --check` clean · `lint` one error, the same pre-existing `react/no-unescaped-entities` on `dev`.

`useUnsavedGuard` has no test: `beforeunload` needs a window and vitest runs in a `node` environment. It rests on three call sites now sharing one implementation that was already in production in two of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DmsHVRL9yQvckUB1ZpVWre