### PR TITLE
fix(admin): declare THEME_INFO before the options that read it (#542)

### DIFF
--- a/app/admin/components/SettingsEditor.tsx
+++ b/app/admin/components/SettingsEditor.tsx
@@ -103,56 +103,6 @@ const PHOTO_FRAMES = ['none', 'passepartout', 'shadow'];
 const HERO_STYLES = ['split', 'fullbleed', 'minimal', 'stacked', 'typographic', 'mosaic', 'cover'];
 const ASPECT_RATIOS = ['1', '3/2', '2/3', '16/9', 'auto'];
 
-/** The theme picker's own metadata, with the fallback the card grid needs. */
-function themeInfo(value: string) {
-  return (
-    THEME_INFO[value] || {
-      label: value,
-      desc: '',
-      bg: '#fff',
-      tile: '#eee',
-      accent: '#333',
-      font: 'System',
-      type: 'sans' as const,
-      radius: 0,
-      frame: 'none' as const,
-      gap: 4,
-    }
-  );
-}
-
-const PRESET_OPTIONS = PRESETS.map((value) => ({
-  value,
-  label: themeInfo(value).label,
-  desc: themeInfo(value).desc,
-}));
-
-function PresetPreview({ value }: { value: string }) {
-  const i = themeInfo(value);
-  return (
-    <div className="preset-card-preview" data-frame={i.frame}>
-      <div className="mini-header">
-        <span className={`mini-specimen type-${i.type}`}>Aa</span>
-        <span className="mini-line" />
-      </div>
-      <div className="mini-grid">
-        <div className="mini-tile" />
-        <div className="mini-tile" />
-        <div className="mini-tile" />
-      </div>
-    </div>
-  );
-}
-
-function PresetSpecs({ value }: { value: string }) {
-  const i = themeInfo(value);
-  return (
-    <span className="preset-card-specs">
-      {i.font} &middot; radius {i.radius} &middot; {i.frame}
-    </span>
-  );
-}
-
 const PHOTO_FRAME_INFO: Record<string, { label: string; desc: string }> = {
   none: { label: 'None', desc: 'Flush image with crisp edges' },
   passepartout: {
@@ -468,6 +418,62 @@ const THEME_INFO: Record<
     gap: 5,
   },
 };
+
+/* The preset group sits below THEME_INFO on purpose. PRESET_OPTIONS is built
+   at module evaluation and reads it through themeInfo(); declared above, it
+   hit the temporal dead zone and the whole Settings page failed to load with
+   "Cannot access 'THEME_INFO' before initialization". tsc does not catch it
+   because the read goes through a hoisted function, and a production build
+   succeeds because the module is only evaluated in the browser (#542). */
+/** The theme picker's own metadata, with the fallback the card grid needs. */
+function themeInfo(value: string) {
+  return (
+    THEME_INFO[value] || {
+      label: value,
+      desc: '',
+      bg: '#fff',
+      tile: '#eee',
+      accent: '#333',
+      font: 'System',
+      type: 'sans' as const,
+      radius: 0,
+      frame: 'none' as const,
+      gap: 4,
+    }
+  );
+}
+
+const PRESET_OPTIONS = PRESETS.map((value) => ({
+  value,
+  label: themeInfo(value).label,
+  desc: themeInfo(value).desc,
+}));
+
+function PresetPreview({ value }: { value: string }) {
+  const i = themeInfo(value);
+  return (
+    <div className="preset-card-preview" data-frame={i.frame}>
+      <div className="mini-header">
+        <span className={`mini-specimen type-${i.type}`}>Aa</span>
+        <span className="mini-line" />
+      </div>
+      <div className="mini-grid">
+        <div className="mini-tile" />
+        <div className="mini-tile" />
+        <div className="mini-tile" />
+      </div>
+    </div>
+  );
+}
+
+function PresetSpecs({ value }: { value: string }) {
+  const i = themeInfo(value);
+  return (
+    <span className="preset-card-specs">
+      {i.font} &middot; radius {i.radius} &middot; {i.frame}
+    </span>
+  );
+}
 
 const SETTINGS_SECTIONS = [
   { id: 'general', label: 'General' },


### PR DESCRIPTION
Closes #542. Regression from `a3c6611`, unreleased — `main` is on v0.13.0 and unaffected.

## The bug

The whole admin panel failed to render after login, every route, with `Cannot access 'THEME_INFO' before initialization`.

`PRESET_OPTIONS` was built at module evaluation and read `THEME_INFO` through `themeInfo()` 250 lines before that `const` was initialised. The module threw, and it is in the admin client chunk, so the whole panel went with it.

## The fix

The preset group moves below `THEME_INFO`, with a comment recording that the order is load-bearing.

## Why every gate was green

`tsc` cannot see it — the read goes through a hoisted function. `next build` cannot see it — the module is only evaluated in a browser. `test:unit` cannot see it — nothing imports it. The HTTP smoke test passed — the server renders the shell and the throw happens after hydration.

## Verification

Driving a real browser against a real build:

| | settings routes rendering |
|---|---|
| running container (`099163f`) | **0 of 8** — all show the error boundary |
| this branch | **8 of 8**, theme reporting 25 controls |

Plus `tsc --noEmit` clean, `test:unit` 820 passed, `build` passes.

No CHANGELOG entry: the refactor that introduced it is unreleased, so no operator ever had the bug.

## Follow-up

#542 records the two things that would have caught this — an admin smoke test in `e2e/` (already noted in #533) and `no-use-before-define` for variables. I would like to add the smoke test next; this is the second time in one day that the admin panel's lack of any browser-level test has cost something.
