### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix memory exhaustion DoS in Buffer.from allocations

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** The decodeAssetId function in lib/tokens.ts accepted arbitrary length tokens and passed them directly to Buffer.from(..., 'base64url'), creating a risk of massive memory allocation (memory exhaustion/CPU DoS).
 **Learning:** Functions that decode tokens from URLs (like GET /api/image/:token) must limit the input string length before passing it to Buffer.from. Otherwise, a maliciously crafted huge token can cause the Node.js process to throw RangeError (Invalid string length) or exhaust memory, despite being wrapped in a try/catch.
 **Prevention:** Always enforce a strict maximum length check on opaque URL tokens before decoding them.
+## 2024-05-31 - Fix missing string length bounds before Buffer.from
+**Vulnerability:** Multiple places accepted unbounded string inputs (like webhook signatures and authentication cookies) and passed them directly to Buffer.from(), enabling memory exhaustion/CPU DoS if large buffers were allocated.
+**Learning:** Even when inputs are verified with timingSafeEqual later, simply creating a buffer from an unconstrained string allocates memory proportional to its size and causes memory exhaustion.
+**Prevention:** Always enforce a max length check on unconstrained variable-length string inputs before passing them into Buffer.from(), especially for authentication or token inputs originating from headers or cookies.

--- a/app/api/webhook/route.ts
+++ b/app/api/webhook/route.ts
@@ -61,6 +61,13 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Missing signature' }, { status: 401 });
   }
 
+  // 🛡️ SECURITY: Enforce maximum signature length to prevent memory exhaustion DoS
+  // Expected length is 64 hex characters (32 bytes).
+  if (signature.length > 128) {
+    console.warn(`[Webhook] ⚠️ Overlong signature from ${ip}`);
+    return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
+  }
+
   const expected = createHmac('sha256', env.WEBHOOK_SECRET).update(rawBody).digest('hex');
 
   let signatureValid = false;

--- a/app/journal/[slug]/page.tsx
+++ b/app/journal/[slug]/page.tsx
@@ -63,6 +63,10 @@ function isJournalAuthenticated(
   if (!storedPassword) return true;
   if (!cookieVal) return false;
 
+  // 🛡️ SECURITY: Enforce maximum cookie length to prevent memory exhaustion DoS
+  // Expected token length is ~100 characters.
+  if (cookieVal.length > 512) return false;
+
   const sep = cookieVal.indexOf('.');
   if (sep === -1) return false;
 

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -241,6 +241,10 @@ export function isAuthenticated(
   const cookie = getCookie(cookieName(key, type));
   if (!cookie) return false;
 
+  // 🛡️ SECURITY: Enforce maximum cookie length to prevent memory exhaustion DoS
+  // Expected token length is ~100 characters.
+  if (cookie.length > 512) return false;
+
   // Legacy tokens (bare HMAC, no expiry) do not parse here and are rejected;
   // the visitor simply re-enters the password.
   const sep = cookie.indexOf('.');

--- a/lib/install.ts
+++ b/lib/install.ts
@@ -93,6 +93,11 @@ export function getSetupToken(): string {
 
 export function validateSetupToken(token: string | null): boolean {
   if (!token) return false;
+
+  // 🛡️ SECURITY: Enforce maximum token length to prevent memory exhaustion DoS
+  // Expected length is 32 chars (24 bytes in base64url).
+  if (token.length > 128) return false;
+
   const expected = generateSetupToken();
   try {
     const a = Buffer.from(token, 'utf8');


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Unbounded strings from headers and cookies were passed directly into `Buffer.from()`, allowing attackers to cause memory exhaustion DoS.
🎯 Impact: An attacker could crash the server by sending massive request headers or cookies.
🔧 Fix: Enforced maximum length constraints on webhook signatures, install tokens, and auth cookies before buffer allocation.
✅ Verification: Ran `pnpm test` and `pnpm lint` to ensure no regressions.

---
*PR created automatically by Jules for task [8174942953531149518](https://jules.google.com/task/8174942953531149518) started by @ralksta*