### PR TITLE
test(admin): load every admin route in a real browser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,3 +88,59 @@ jobs:
           done <<< "$unformatted"
           echo '' >> "$GITHUB_STEP_SUMMARY"
           echo 'Advisory only — this does not block the merge.' >> "$GITHUB_STEP_SUMMARY"
+
+  # Separate job because it needs a browser and a built server, and because a
+  # slow browser run should not hold up the fast type-check/test feedback.
+  #
+  # Only the admin smoke spec runs here. The other e2e specs render the public
+  # gallery, which needs a real Immich behind it — CI has none, so they would
+  # fail for reasons that have nothing to do with the change under test. The
+  # admin panel reads its state from the repo's config files and degrades
+  # gracefully when Immich is unreachable, so it is the part of the suite that
+  # can honestly run without a backend.
+  e2e-admin:
+    name: Admin panel smoke test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Build
+        run: npm run build
+        env:
+          IMMICH_API_URL: http://localhost:2283
+          IMMICH_API_KEY: placeholder-key-for-ci
+          AUTH_SECRET: placeholder-secret-for-ci-builds-must-be-32-chars-long
+
+      # E2E_START runs the spec against `npm run start` rather than the dev
+      # server. #542 was a module-evaluation error in shipped output, so the
+      # build that ships is the one worth loading in a browser.
+      - name: Admin smoke test
+        run: npm run test:e2e:admin
+        env:
+          E2E_START: '1'
+          IMMICH_API_URL: http://localhost:2283
+          IMMICH_API_KEY: placeholder-key-for-ci
+          AUTH_SECRET: placeholder-secret-for-ci-builds-must-be-32-chars-long
+          ADMIN_PASSWORD: e2e-admin-password
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ Releases up to and including v0.9.2 are documented in the
 
 ## [Unreleased]
 
+### Added
+
+- **CI loads the admin panel in a real browser.** A Playwright spec walks all
+  fourteen admin routes against a production build and fails on an error
+  boundary, a missing page body, or anything thrown during hydration. It exists
+  because of [#542](https://github.com/ralksta/immich-folio/issues/542): a
+  temporal-dead-zone error at module evaluation took the whole panel down while
+  the type check, the build and the unit tests all stayed green — none of them
+  evaluates a client module in a browser, which is the only place that bug is
+  visible. The spec was checked against the bug: with it reintroduced, the run
+  names every broken route and reports the original
+  `Cannot access 'THEME_INFO' before initialization`.
+
 ### Fixed
 
 - **The dashboard status badge's colour and words agree**

--- a/e2e/admin-smoke.spec.ts
+++ b/e2e/admin-smoke.spec.ts
@@ -1,0 +1,110 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Smoke test for every admin route.
+ *
+ * This exists because of #542: a module-evaluation TDZ error in SettingsEditor
+ * took the entire admin panel down in production while all four gates stayed
+ * green. tsc could not see it (the read went through a hoisted function),
+ * `next build` could not (the module is only evaluated in the browser), the
+ * unit tests could not (nothing imports it), and an HTTP smoke check could not
+ * (the server renders the shell; the throw happens after hydration).
+ *
+ * A real browser is the only thing that catches that class of bug, so this
+ * spec loads each route and asserts three things: no error boundary, the
+ * route's own content actually rendered, and nothing threw during hydration.
+ */
+
+/** Matches the fallback playwright.config.ts hands the dev/start server. */
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'e2e-admin-password';
+
+/**
+ * Each route plus a selector that only exists once that route's own component
+ * has rendered. Asserting the admin chrome would not be enough — a page that
+ * throws is replaced wholesale by app/error.tsx, but a route that renders an
+ * empty shell would still pass.
+ */
+const ROUTES: { path: string; content: string; name: string }[] = [
+  { path: '/admin', content: '.page-builder', name: 'dashboard' },
+  { path: '/admin/pages', content: '.page-builder', name: 'pages' },
+  { path: '/admin/journal', content: '.journal-studio', name: 'journal' },
+  // AnalyticsView falls back to .admin-panel when the analytics API is
+  // unreachable, which is the normal case without a live Immich behind it.
+  { path: '/admin/analytics', content: '.analytics-view, .admin-panel', name: 'analytics' },
+  { path: '/admin/help', content: '.settings-panel', name: 'help' },
+  { path: '/admin/settings', content: '.settings-editor', name: 'settings' },
+  ...['general', 'theme', 'grid', 'footer', 'legal', 'seo', 'security', 'about'].map((id) => ({
+    path: `/admin/settings/${id}`,
+    content: '.settings-panel',
+    name: `settings/${id}`,
+  })),
+];
+
+/**
+ * Console noise that says nothing about the page's own health. Without a live
+ * Immich the status probe and the analytics fetch both fail, and their failures
+ * are reported as console errors. Uncaught exceptions are never filtered —
+ * those are the signal this test was written for.
+ */
+const IGNORED_CONSOLE = [
+  /Failed to load resource/i,
+  /net::ERR_/i,
+  /ECONNREFUSED/i,
+  /the server responded with a status of 5\d\d/i,
+];
+
+function isRealConsoleError(text: string): boolean {
+  return !IGNORED_CONSOLE.some((pattern) => pattern.test(text));
+}
+
+test('every admin route renders without throwing', async ({ page }) => {
+  const pageErrors: string[] = [];
+  const consoleErrors: string[] = [];
+  page.on('pageerror', (error) => pageErrors.push(error.message));
+  page.on('console', (message) => {
+    if (message.type() === 'error' && isRealConsoleError(message.text())) {
+      consoleErrors.push(message.text());
+    }
+  });
+
+  await page.goto('/admin');
+
+  // A reused local dev server may have been started without ADMIN_PASSWORD.
+  // Skipping beats failing on a configuration difference — CI starts its own
+  // server with the password set, so it never takes this branch.
+  const disabled = await page
+    .locator('.admin-disabled')
+    .isVisible()
+    .catch(() => false);
+  test.skip(disabled, 'Admin panel disabled — start the server with ADMIN_PASSWORD set.');
+
+  await page.fill('input[type="password"]', ADMIN_PASSWORD);
+  await page.click('button[type="submit"]');
+  await expect(page.locator('.page-builder')).toBeVisible({ timeout: 15_000 });
+
+  // One test walking every route rather than one test each: the routes share a
+  // login, and expect.soft keeps a broken route from hiding the ones after it.
+  // When the panel goes down it usually goes down everywhere, and the useful
+  // report is the full list — a run that stops at the first failure was what
+  // made #542 look like a Settings problem instead of a panel-wide one.
+  for (const route of ROUTES) {
+    await test.step(route.name, async () => {
+      pageErrors.length = 0;
+      consoleErrors.length = 0;
+
+      await page.goto(route.path);
+
+      // app/error.tsx replaces the whole page when a route throws. Assert it
+      // first: its absence is what "the panel still works" actually means.
+      await expect
+        .soft(page.locator('.empty-state__title'), `error boundary on ${route.path}`)
+        .toHaveCount(0);
+      await expect
+        .soft(page.locator(route.content).first(), `no content on ${route.path}`)
+        .toBeVisible({ timeout: 15_000 });
+
+      expect.soft(pageErrors, `uncaught exception on ${route.path}`).toEqual([]);
+      expect.soft(consoleErrors, `console errors on ${route.path}`).toEqual([]);
+    });
+  }
+});

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "vitest",
     "test:unit": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "test:e2e:admin": "playwright test e2e/admin-smoke.spec.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,9 @@
 import { defineConfig, devices } from '@playwright/test';
 
+// Overridable so a run can sidestep a dev server or container already holding
+// the default port; CI leaves it alone.
+const PORT = process.env.E2E_PORT || '3000';
+
 export default defineConfig({
   testDir: './e2e',
   fullyParallel: true,
@@ -8,7 +12,7 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: 'html',
   use: {
-    baseURL: 'http://localhost:3000',
+    baseURL: `http://localhost:${PORT}`,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
   },
@@ -19,9 +23,19 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: 'npm run dev',
-    url: 'http://localhost:3000',
+    // The admin smoke test (e2e/admin-smoke.spec.ts) exists to catch bugs that
+    // only surface in a real browser against a real build — #542 was invisible
+    // to the dev server's on-demand compilation path. E2E_START=1 points the
+    // suite at `npm run start` so CI exercises the same output that ships.
+    command:
+      process.env.E2E_START === '1' ? `npm run start -- -p ${PORT}` : `npm run dev -- -p ${PORT}`,
+    url: `http://localhost:${PORT}`,
     reuseExistingServer: !process.env.CI,
-    timeout: 30_000,
+    timeout: 60_000,
+    env: {
+      // Without this the admin panel reports itself disabled and the smoke
+      // test skips. A local run that already exports ADMIN_PASSWORD keeps it.
+      ADMIN_PASSWORD: process.env.ADMIN_PASSWORD || 'e2e-admin-password',
+    },
   },
 });


### PR DESCRIPTION
Closes the prevention item from #542 and step 1 of #533's follow-up.

## Why

#542 took the entire admin panel down in production while all four gates stayed green:

| Gate | Why it missed the bug |
|---|---|
| `tsc --noEmit` | the TDZ read went through a hoisted function |
| `next build` | the module is only evaluated in the browser |
| `vitest run` | nothing imports `SettingsEditor` |
| HTTP smoke check | the server renders the shell; the throw happens after hydration |

None of them evaluates a client module in a browser. That is the gap this closes.

## What

- **`e2e/admin-smoke.spec.ts`** — logs in once and walks all 14 admin routes, asserting per route: no error boundary (`app/error.tsx`), the route's own content rendered, no uncaught exception, no console errors. Network failures from an absent Immich are filtered; uncaught exceptions never are.
- **`playwright.config.ts`** — `E2E_START=1` runs the suite against `npm run start` instead of the dev server, `E2E_PORT` makes the port overridable, and the web server now gets an `ADMIN_PASSWORD` so the panel is enabled.
- **`.github/workflows/ci.yml`** — a separate `e2e-admin` job. Only this spec runs; the other e2e specs render the public gallery and need a real Immich, which CI has none of.
- **`npm run test:e2e:admin`**.

## Verification

Against a production build with no Immich reachable: **14/14 green in 3.5 s**.

Then the bug was reintroduced to check the test actually catches it:

- `tsc --noEmit` → exit 0
- `npm run build` → exit 0
- `npm run test:e2e:admin` → **failed, naming all 9 broken settings routes**, reporting `[Folio] Page render failed: ReferenceError: Cannot access 'w' before initialization` — the original outage error.

`expect.soft` is deliberate: a run that stops at the first failure was what made #542 look like a Settings problem rather than a panel-wide one.
