### PR TITLE
fix(themes): let grid.gap move rows as well as columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ Releases up to and including v0.9.2 are documented in the
 
 ## [Unreleased]
 
+### Fixed
+
+- **`grid.gap` moves both axes, and two presets get their spacing back**
+  ([#513](https://github.com/ralksta/immich-folio/issues/513)). The earlier fix
+  changed the hardcoded `column-gap` in `editorial`, `minimal` and `monograph`
+  into a `--grid-gap` default, but left the hardcoded `margin-bottom` sitting a
+  few lines below it in the same three files. In the masonry layout that margin
+  _is_ the row spacing — a `column-count` layout has no `row-gap` — so the
+  setting moved the columns and left the rows pinned. It now derives from
+  `--grid-gap` like everything else. `monograph` keeps its rows deliberately
+  looser than its columns, so it derives the ratio instead of the value.
+
+  The same change also declared `--grid-gap: 12px` on the base grid, which
+  meant `classic` and `studio-modern` — which asked for `var(--grid-gap, 20px)`
+  — never reached their fallback and silently rendered at 12px from v0.12.0 on.
+  Both declare their 20px outright now, as the other presets do.
+
+  Verified in a browser rather than by reading the cascade: for all seven
+  presets, an explicit gap of 50px produces 50px on both axes (60px rows for
+  `monograph`), and with no gap set each preset renders its own intended
+  default.
+
 ### Added
 
 - **CI loads the admin panel in a real browser.** A Playwright spec walks all
@@ -401,6 +423,11 @@ Releases up to and including v0.9.2 are documented in the
   That is what those three presets already rendered horizontally, so the visible
   change is that their rows finally match their columns. Sites that set `gap`
   are unaffected, and `classic` and `studio-modern` keep the 12px they had.
+
+  > **Correction.** Two claims above were wrong: the row spacing did _not_
+  > follow the setting in those three presets, and `classic` and
+  > `studio-modern` did not keep what they had — they dropped from 20px to
+  > 12px. Both were fixed later; see the entry under Unreleased.
 
 - **The Immich description can be switched off**
   ([#506](https://github.com/ralksta/immich-folio/issues/506)). It was served

--- a/app/themes/classic.css
+++ b/app/themes/classic.css
@@ -72,11 +72,11 @@
 
 /* Photo grid: warm passepartout, elegant hover */
 [data-preset='classic'] .photo-grid {
-  column-gap: var(--grid-gap, 20px);
-}
-
-[data-preset='classic'] .photo-grid__item {
-  margin-bottom: var(--grid-gap, 20px);
+  /* Declared, not a var() fallback. The base .photo-grid sets --grid-gap: 12px,
+     so `var(--grid-gap, 20px)` never reached its fallback and this preset
+     silently rendered at 12px from v0.12.0 on (#513). The base rules read
+     --grid-gap for both axes, so declaring it here is all this needs. */
+  --grid-gap: 20px;
 }
 
 [data-preset='classic'] .photo-grid__item:hover img {

--- a/app/themes/editorial.css
+++ b/app/themes/editorial.css
@@ -58,9 +58,10 @@
   --grid-gap: 32px;
 }
 
-[data-preset='editorial'] .photo-grid__item {
-  margin-bottom: 32px;
-}
+/* No row spacing here on purpose. The base .photo-grid__item rule reads
+   var(--grid-gap), which inherits the 32px declared above — so the default look
+   is unchanged and an explicit grid.gap now moves rows as well as columns.
+   A hardcoded margin-bottom here was the other half of #513. */
 
 [data-preset='editorial'] .photo-grid__item img {
   transition:

--- a/app/themes/minimal.css
+++ b/app/themes/minimal.css
@@ -98,7 +98,8 @@
 }
 
 [data-preset='minimal'] .photo-grid__item {
-  margin-bottom: 2px;
+  /* Row spacing deliberately omitted — the base rule reads var(--grid-gap) and
+     inherits the 2px above, so grid.gap moves both axes (#513). */
   border-radius: 0;
   cursor: pointer;
 }

--- a/app/themes/monograph.css
+++ b/app/themes/monograph.css
@@ -36,7 +36,10 @@
 
 [data-preset='monograph'] .photo-grid__item {
   counter-increment: photo-index;
-  margin-bottom: 48px;
+  /* Rows sit looser than columns by design — 48px against 40px. Derived from
+     --grid-gap rather than hardcoded so an explicit grid.gap keeps that ratio
+     instead of leaving the rows behind (#513). */
+  margin-bottom: calc(var(--grid-gap, 40px) * 1.2);
 }
 
 [data-preset='monograph'] .photo-grid__item::before {

--- a/app/themes/studio-modern.css
+++ b/app/themes/studio-modern.css
@@ -783,11 +783,14 @@
 
 /* ── Fotoraster ─────────────────────────────────────────────── */
 [data-preset='studio-modern'] .photo-grid {
-  column-gap: var(--grid-gap, 20px);
+  /* Declared, not a var() fallback. The base .photo-grid sets --grid-gap: 12px,
+     so `var(--grid-gap, 20px)` never reached its fallback and this preset
+     silently rendered at 12px from v0.12.0 on (#513). The base rules read
+     --grid-gap for both axes, so declaring it here is all this needs. */
+  --grid-gap: 20px;
 }
 
 [data-preset='studio-modern'] .photo-grid__item {
-  margin-bottom: var(--grid-gap, 20px);
   border-radius: 0;
 }
 


### PR DESCRIPTION
Reopened #513 — the v0.12.0 fix only moved one axis. Reported by @ylbeethoven with a screenshot of the Editorial theme.

## What was wrong

The earlier fix turned the hardcoded `column-gap` in `editorial`, `minimal` and `monograph` into a `--grid-gap` default, and left the hardcoded `margin-bottom` a few lines below it in the same three files:

```css
[data-preset='editorial'] .photo-grid       { --grid-gap: 32px; }    /* followed the setting */
[data-preset='editorial'] .photo-grid__item { margin-bottom: 32px; } /* did not */
```

The masonry layout is `column-count`-based and therefore has no `row-gap` — that margin *is* the row spacing.

**A second regression from the same change:** it declared `--grid-gap: 12px` on the base `.photo-grid`, so `classic` and `studio-modern`, which asked for `var(--grid-gap, 20px)`, could never reach their fallback. Both had been rendering at 12px since v0.12.0.

## Verification

Measured in a browser rather than reasoned about from the cascade — computed `column-gap` on the grid and `margin-bottom` on the item, per preset:

| preset | default (col/row) | `gap=50px` (col/row) |
|---|---|---|
| editorial | 32px / 32px | 50px / 50px |
| minimal | 2px / 2px | 50px / 50px |
| monograph | 40px / 48px | 50px / **60px** |
| classic | 20px / 20px | 50px / 50px |
| studio-modern | 20px / 20px | 50px / 50px |
| noir | 12px / 12px | 50px / 50px |
| studio | 12px / 12px | 50px / 50px |

`monograph` runs its rows deliberately looser than its columns, so it derives the ratio rather than the value.

The non-masonry layouts (uniform, showcase, filmstrip, editorial-flow, justified) still zero the item margin and space themselves with the two-axis `gap` shorthand — checked for all five presets, unchanged.

The v0.12.0 changelog entry claimed the rows already followed the setting and that `classic` and `studio-modern` kept their spacing. Neither was true; the entry now carries a correction.

Closes #513
