### PR TITLE
fix(doctor): give the unverifiable findings their own NOTES group (#521)

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -137,7 +137,10 @@ The exit code is the worst thing it found, so it can gate a deployment script:
 One check cannot run here: `TRUSTED_PROXY_HOPS` is judged against the
 `X-Forwarded-For` chain of a live request, and a CLI has none. It reports the
 configured value and says so rather than guessing — use the Diagnostics panel,
-reached over your public URL, to have that one measured.
+reached over your public URL, to have that one measured. It is printed under
+**NOTES** rather than among the passed checks, since nothing was verified, and
+counted separately in the summary line for the same reason. Notes never affect
+the exit code.
 
 Run from a checkout, it reads `.env.local` and `.env` the way `npm run dev`
 does; real environment variables and `content/install.json` are resolved in the

--- a/scripts/__tests__/doctor-cli.test.ts
+++ b/scripts/__tests__/doctor-cli.test.ts
@@ -283,6 +283,45 @@ describe('formatReport', () => {
     expect(ansi.test(formatReport(findings))).toBe(false);
     expect(ansi.test(formatReport(findings, { color: true }))).toBe(true);
   });
+
+  // The proxy-hop finding carries level `ok` so it cannot skew the exit code,
+  // but the CLI never checked it — listing it under PASSED would claim a check
+  // that did not run.
+  describe('notes', () => {
+    const proxy: DoctorFinding = {
+      id: 'proxy-hops',
+      level: 'ok',
+      title: 'TRUSTED_PROXY_HOPS is 0 (unset) — not verifiable from the terminal',
+      detail: 'Open the Diagnostics panel to have it measured.',
+    };
+
+    it('lists a note in its own group rather than under PASSED', () => {
+      const report = formatReport([...findings, proxy]);
+      expect(report).toContain('NOTES (1)');
+      expect(report).toContain('PASSED (1)');
+      expect(report).toContain(proxy.title);
+      expect(report.indexOf(proxy.title)).toBeGreaterThan(report.indexOf('NOTES (1)'));
+      expect(report.indexOf(proxy.title)).toBeLessThan(report.indexOf('PASSED (1)'));
+    });
+
+    it('sits between the warnings and the passes', () => {
+      const report = formatReport([...findings, proxy]);
+      expect(report.indexOf('WARNINGS (1)')).toBeLessThan(report.indexOf('NOTES (1)'));
+      expect(report.indexOf('NOTES (1)')).toBeLessThan(report.indexOf('PASSED (1)'));
+    });
+
+    it('is counted separately, not as a passed check', () => {
+      expect(formatReport([...findings, proxy])).toContain(
+        '1 error, 1 warning, 1 check passed, 1 note.',
+      );
+    });
+
+    it('says nothing about notes when there are none', () => {
+      const report = formatReport(findings);
+      expect(report).not.toContain('NOTES');
+      expect(report).toContain('1 error, 1 warning, 1 check passed.');
+    });
+  });
 });
 
 describe('shouldUseColor', () => {

--- a/scripts/doctor.mts
+++ b/scripts/doctor.mts
@@ -293,6 +293,22 @@ const LEVEL_LABEL: Record<DoctorLevel, string> = {
   ok: 'PASSED',
 };
 
+/**
+ * Findings the CLI reports without having checked anything.
+ *
+ * They carry level `ok` so they cannot skew `worstLevel()` or the exit code,
+ * but listing them under PASSED would claim a check that never ran. They get
+ * their own group instead. Membership is by `id` rather than by a field on
+ * `DoctorFinding`, because the type is shared with the panel — where these
+ * findings are real checks — and this is a fact about the terminal, not about
+ * the finding.
+ */
+const NOTE_IDS = new Set(['proxy-hops']);
+
+const NOTE_LABEL = 'NOTES';
+const NOTE_MARK = 'i';
+const NOTE_COLOR = '\x1b[36m';
+
 const LEVEL_MARK: Record<DoctorLevel, string> = { error: 'x', warn: '!', ok: 'v' };
 
 /** Hand-written, so the CLI needs no colour dependency. */
@@ -334,28 +350,43 @@ export function formatReport(findings: DoctorFinding[], options: FormatOptions =
 
   const out: string[] = ['', paint(BOLD, 'Immich Folio — config doctor'), ''];
 
-  for (const level of LEVEL_ORDER) {
-    const group = findings.filter((f) => f.level === level);
-    if (!group.length) continue;
+  const notes = findings.filter((f) => NOTE_IDS.has(f.id));
+  const checks = findings.filter((f) => !NOTE_IDS.has(f.id));
 
-    out.push(paint(LEVEL_COLOR[level] + BOLD, `${LEVEL_LABEL[level]} (${group.length})`));
+  const group = (label: string, color: string, mark: string, group: DoctorFinding[]) => {
+    if (!group.length) return;
+    out.push(paint(color + BOLD, `${label} (${group.length})`));
     for (const finding of group) {
-      out.push(`  ${paint(LEVEL_COLOR[level], LEVEL_MARK[level])} ${finding.title}`);
+      out.push(`  ${paint(color, mark)} ${finding.title}`);
       for (const line of wrap(finding.detail, width - 6, '    ')) {
         out.push(paint(DIM, line));
       }
       out.push('');
     }
+  };
+
+  for (const level of LEVEL_ORDER) {
+    // Notes sit between the warnings and the passes: they are not a problem,
+    // but they are the part of the report a reader still has to act on.
+    if (level === 'ok') group(NOTE_LABEL, NOTE_COLOR, NOTE_MARK, notes);
+    group(
+      LEVEL_LABEL[level],
+      LEVEL_COLOR[level],
+      LEVEL_MARK[level],
+      checks.filter((f) => f.level === level),
+    );
   }
 
-  const counts = LEVEL_ORDER.map((level) => findings.filter((f) => f.level === level).length);
+  const counts = LEVEL_ORDER.map((level) => checks.filter((f) => f.level === level).length);
   const [errors, warns, oks] = counts;
   out.push(
     paint(
       BOLD,
       `${errors} error${errors === 1 ? '' : 's'}, ` +
         `${warns} warning${warns === 1 ? '' : 's'}, ` +
-        `${oks} check${oks === 1 ? '' : 's'} passed.`,
+        `${oks} check${oks === 1 ? '' : 's'} passed` +
+        (notes.length ? `, ${notes.length} note${notes.length === 1 ? '' : 's'}` : '') +
+        `.`,
     ),
   );
   out.push('');


### PR DESCRIPTION
Follow-up to #546, which flagged this in its own description.

`TRUSTED_PROXY_HOPS` is judged against the `X-Forwarded-For` chain of a live request, so the CLI cannot check it and says so in its title. But the finding carries level `ok` — deliberately, so it cannot skew `worstLevel()` or the exit code — which listed it under **PASSED**, beside checks that actually ran. A line reading `PASSED … not verifiable from the terminal` claims the opposite of what it says.

It now gets its own group, between the warnings and the passes, and its own term in the summary line — so the passed-check count means what it says:

```
NOTES (1)
  i TRUSTED_PROXY_HOPS is 1 — not verifiable from the terminal
    Whether this is right can only be judged against a real request: …

PASSED (1)
  v content/gallery.yaml parses

2 errors, 2 warnings, 1 check passed, 1 note.
```

Notes never affect the exit code — the level model is untouched.

Membership is by finding **id**, not a new field on `DoctorFinding`. That type is shared with the admin panel, where the same check is real and does run; being unverifiable is a fact about the terminal, not about the finding. The set is one entry today and the comment says what belongs in it.

## Verification

- `npx tsc --noEmit` — 0 errors
- `npm run test:unit` — 855 passed, incl. 4 new cases (own group, position between warnings and passes, separate count, and silence when there are no notes)
- `npm run build` — passes
- `npm run lint` — unchanged from the baseline on `dev`
- Ran the CLI against a real `content/` and read the output

`docs/deployment.md` gains two sentences next to the exit-code table.