### PR TITLE
fix(doctor): say which user the writability check tested (#551)

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -134,13 +134,26 @@ The exit code is the worst thing it found, so it can gate a deployment script:
 | `2`  | at least one error              |
 | `3`  | the doctor itself could not run |
 
-One check cannot run here: `TRUSTED_PROXY_HOPS` is judged against the
+Two findings are reported rather than judged. `content/` writability is tested
+as the user who typed the command, and on a Docker deployment that is not the
+user the app writes as — so when the paths belong to someone else, the CLI says
+whose they are and leaves it at that. Run it through the container to have it
+checked as the app itself:
+
+```bash
+docker compose exec folio npm run doctor
+```
+
+The other is `TRUSTED_PROXY_HOPS`, judged against the
 `X-Forwarded-For` chain of a live request, and a CLI has none. It reports the
 configured value and says so rather than guessing — use the Diagnostics panel,
-reached over your public URL, to have that one measured. It is printed under
-**NOTES** rather than among the passed checks, since nothing was verified, and
-counted separately in the summary line for the same reason. Notes never affect
-the exit code.
+reached over your public URL, to have that one measured.
+
+Both are printed under **NOTES** rather than among the passed checks, since
+nothing was established, and counted separately in the summary line for the
+same reason. Notes never affect the exit code. An unwritable path _does_ stay a
+plain error when the CLI runs as the owner, which is the case that is really
+about the app.
 
 Run from a checkout, it reads `.env.local` and `.env` the way `npm run dev`
 does; real environment variables and `content/install.json` are resolved in the

--- a/scripts/__tests__/doctor-cli.test.ts
+++ b/scripts/__tests__/doctor-cli.test.ts
@@ -3,15 +3,18 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import yaml from 'js-yaml';
+import type { CliFinding } from '../doctor.mts';
 import {
   EXIT_CODES,
   EXIT_INTERNAL,
   collectAlbumIds,
   collectPasswords,
   exitCodeFor,
+  currentUid,
   findUnwritable,
   formatReport,
   frontmatterPassword,
+  reportWritable,
   loadDotEnv,
   resolveCredentials,
   shouldUseColor,
@@ -242,6 +245,81 @@ describe('findUnwritable', () => {
   it('does not report a directory that has not been created yet', () => {
     expect(findUnwritable(tmpdir())).toEqual([]);
   });
+
+  it('reports the owner alongside a path it cannot write', () => {
+    const dir = tmpdir();
+    const backups = path.join(dir, '.backups');
+    fs.mkdirSync(backups);
+    fs.chmodSync(backups, 0o555);
+    try {
+      const found = findUnwritable(dir);
+      // Running as root, 0555 is still writable — the case cannot be staged.
+      if (currentUid() === 0) return;
+      expect(found).toHaveLength(1);
+      expect(found[0].label).toBe('content/.backups');
+      expect(found[0].ownerUid).toBe(fs.statSync(backups).uid);
+    } finally {
+      fs.chmodSync(backups, 0o755);
+    }
+  });
+});
+
+/**
+ * The CLI tests whoever typed the command; the panel tests the app's own user.
+ * On a Docker deployment those differ, and calling that an error accused a
+ * healthy install (#551).
+ */
+describe('reportWritable', () => {
+  const mine = { label: 'content/.backups', ownerUid: 1000 };
+  const theirs = { label: 'content/.backups', ownerUid: 1001 };
+
+  it('passes when everything is writable', () => {
+    const finding = reportWritable([], 1000);
+    expect(finding.level).toBe('ok');
+    expect(finding.note).toBeUndefined();
+    expect(finding.title).toBe('content/ is writable');
+  });
+
+  it('is a real error when the CLI runs as the owner', () => {
+    const finding = reportWritable([mine], 1000);
+    expect(finding.level).toBe('error');
+    expect(finding.note).toBeUndefined();
+    expect(finding.detail).toContain('Saving from the admin panel will fail');
+  });
+
+  it('is a note, not an error, when the owner is someone else', () => {
+    const finding = reportWritable([theirs], 1000);
+    expect(finding.level).toBe('ok');
+    expect(finding.note).toBe(true);
+    expect(finding.title).toContain('uid 1000');
+    expect(finding.title).toContain('uid 1001');
+    expect(finding.detail).toContain('docker compose exec');
+  });
+
+  it('does not downgrade a mixed result to a note', () => {
+    const finding = reportWritable([mine, theirs], 1000);
+    expect(finding.level).toBe('ok');
+    expect(finding.note).toBe(true);
+  });
+
+  it('claims nothing on a platform without uids', () => {
+    const finding = reportWritable([theirs], null);
+    expect(finding.level).toBe('ok');
+    expect(finding.note).toBe(true);
+    expect(finding.title).not.toContain('undefined');
+    expect(finding.detail).toContain('may not be the account the app');
+  });
+
+  it('keeps the id the panel uses, whatever the outcome', () => {
+    for (const finding of [
+      reportWritable([], 1000),
+      reportWritable([mine], 1000),
+      reportWritable([theirs], 1000),
+      reportWritable([theirs], null),
+    ]) {
+      expect(finding.id).toBe('content-writable');
+    }
+  });
 });
 
 describe('wrap', () => {
@@ -288,12 +366,20 @@ describe('formatReport', () => {
   // but the CLI never checked it — listing it under PASSED would claim a check
   // that did not run.
   describe('notes', () => {
-    const proxy: DoctorFinding = {
+    const proxy: CliFinding = {
       id: 'proxy-hops',
       level: 'ok',
+      note: true,
       title: 'TRUSTED_PROXY_HOPS is 0 (unset) — not verifiable from the terminal',
       detail: 'Open the Diagnostics panel to have it measured.',
     };
+
+    it('needs the flag, not the id: the same check can be a real finding', () => {
+      const notANote = { ...proxy, note: undefined };
+      const report = formatReport([notANote]);
+      expect(report).not.toContain('NOTES');
+      expect(report).toContain('PASSED (1)');
+    });
 
     it('lists a note in its own group rather than under PASSED', () => {
       const report = formatReport([...findings, proxy]);

--- a/scripts/doctor.mts
+++ b/scripts/doctor.mts
@@ -55,7 +55,6 @@ import {
   checkAuthSecret,
   checkImmichCalls,
   checkPasswords,
-  checkWritable,
   worstLevel,
   type AlbumRef,
   type DoctorFinding,
@@ -264,23 +263,113 @@ export function frontmatterPassword(markdown: string): string | null {
   return null;
 }
 
-/** Content paths that exist but refuse writes. Absent is fine — see the route. */
-export function findUnwritable(contentDir: string): string[] {
-  const unwritable: string[] = [];
+export interface UnwritablePath {
+  /** As the report names it, e.g. `content/.backups`. */
+  label: string;
+  /** Owner of the path, so the report can say whose permission problem it is. */
+  ownerUid: number;
+}
+
+/**
+ * Content paths that exist but refuse writes. Absent is fine — see the route.
+ *
+ * The owner comes back with each path because "not writable" from a terminal
+ * is only half a finding: the panel asks as the app's own user, a CLI asks as
+ * whoever typed the command, and on a Docker deployment those differ (#551).
+ */
+export function findUnwritable(contentDir: string): UnwritablePath[] {
+  const unwritable: UnwritablePath[] = [];
   for (const dir of ['', '.backups', 'journal']) {
     const target = path.join(contentDir, dir);
     try {
       fs.accessSync(target, fs.constants.W_OK);
     } catch {
       try {
-        fs.statSync(target);
-        unwritable.push(`content/${dir}`.replace(/\/$/, ''));
+        const stat = fs.statSync(target);
+        unwritable.push({ label: `content/${dir}`.replace(/\/$/, ''), ownerUid: stat.uid });
       } catch {
         // Not created yet: the app makes it on first write.
       }
     }
   }
   return unwritable;
+}
+
+/** The uid this process runs as, or null where the platform has none. */
+export function currentUid(): number | null {
+  return typeof process.getuid === 'function' ? process.getuid() : null;
+}
+
+/**
+ * The writability finding, in the CLI's own words.
+ *
+ * `checkWritable()` in lib/admin/doctor.ts says "saving from the admin panel
+ * will fail", which is true where it runs — inside the app, as the app's user.
+ * A CLI tests whoever typed the command. Run from the host against a container
+ * that writes as uid 1001, that produced an error on a deployment with nothing
+ * wrong with it, and the obvious reaction (chown the volume from the host) is
+ * the one change that would actually break the container's access (#551).
+ *
+ * So the level follows what the answer is worth:
+ *
+ * - running as the owner — the app's own user, or a bare-metal install — the
+ *   result is about the app, and stays an error.
+ * - anyone else: reported, attributed, and left in NOTES, because the CLI
+ *   cannot tell whether the user it tested is the one that matters.
+ *
+ * The id stays `content-writable`, so the panel and the CLI still name the
+ * same check.
+ */
+export function reportWritable(unwritable: UnwritablePath[], uid: number | null): CliFinding {
+  if (!unwritable.length) {
+    return {
+      id: 'content-writable',
+      level: 'ok',
+      title: 'content/ is writable',
+      detail: 'Config, journal and backups can be saved.',
+    };
+  }
+
+  const labels = unwritable.map((u) => u.label).join(', ');
+  const count = unwritable.length;
+  const noun = `${count} content ${count === 1 ? 'path is' : 'paths are'} not writable`;
+
+  // No getuid(): Windows. Nothing can be attributed, so nothing is claimed.
+  if (uid === null) {
+    return {
+      id: 'content-writable',
+      level: 'ok',
+      note: true,
+      title: `${noun} for this user`,
+      detail:
+        'Checked as the account running this command, which may not be the account the app ' +
+        `runs as. If it is, saving from the admin panel will fail, and so will backups: ${labels}`,
+    };
+  }
+
+  if (unwritable.every((u) => u.ownerUid === uid)) {
+    return {
+      id: 'content-writable',
+      level: 'error',
+      title: noun,
+      detail:
+        'Saving from the admin panel will fail, and so will backups. Check the ownership of the ' +
+        `mounted volume: ${labels}`,
+    };
+  }
+
+  const owners = [...new Set(unwritable.map((u) => u.ownerUid))].join(', ');
+  return {
+    id: 'content-writable',
+    level: 'ok',
+    note: true,
+    title: `${noun} by uid ${uid} — but ${count === 1 ? 'it is' : 'they are'} owned by uid ${owners}`,
+    detail:
+      'Checked as the user running this command, not as the user the app runs as. The paths ' +
+      `belong to uid ${owners}, which can write them; the Docker image runs the app as uid 1001. ` +
+      `This only matters if the app itself runs as uid ${uid}. To check as the app: ` +
+      `docker compose exec folio npm run doctor. Paths: ${labels}`,
+  };
 }
 
 // ── Report formatting ─────────────────────────────────────────────────────
@@ -294,16 +383,19 @@ const LEVEL_LABEL: Record<DoctorLevel, string> = {
 };
 
 /**
- * Findings the CLI reports without having checked anything.
+ * A finding, plus whether the CLI actually established it.
  *
- * They carry level `ok` so they cannot skew `worstLevel()` or the exit code,
+ * Notes carry level `ok` so they cannot skew `worstLevel()` or the exit code,
  * but listing them under PASSED would claim a check that never ran. They get
- * their own group instead. Membership is by `id` rather than by a field on
- * `DoctorFinding`, because the type is shared with the panel — where these
- * findings are real checks — and this is a fact about the terminal, not about
- * the finding.
+ * their own group instead. The flag lives here rather than on `DoctorFinding`
+ * because the type is shared with the panel, where the same checks are real —
+ * being unverifiable is a fact about the terminal, not about the finding.
+ *
+ * It is per finding rather than per id: `content-writable` is a note when the
+ * CLI ran as someone other than the owner, and a genuine error when it did not
+ * (#551).
  */
-const NOTE_IDS = new Set(['proxy-hops']);
+export type CliFinding = DoctorFinding & { note?: boolean };
 
 const NOTE_LABEL = 'NOTES';
 const NOTE_MARK = 'i';
@@ -343,17 +435,17 @@ export interface FormatOptions {
 }
 
 /** The whole report as one string, so it can be asserted on in a test. */
-export function formatReport(findings: DoctorFinding[], options: FormatOptions = {}): string {
+export function formatReport(findings: CliFinding[], options: FormatOptions = {}): string {
   const color = options.color ?? false;
   const width = Math.max(40, Math.min(options.width ?? 80, 120));
   const paint = (code: string, text: string) => (color ? `${code}${text}${RESET}` : text);
 
   const out: string[] = ['', paint(BOLD, 'Immich Folio — config doctor'), ''];
 
-  const notes = findings.filter((f) => NOTE_IDS.has(f.id));
-  const checks = findings.filter((f) => !NOTE_IDS.has(f.id));
+  const notes = findings.filter((f) => f.note === true);
+  const checks = findings.filter((f) => f.note !== true);
 
-  const group = (label: string, color: string, mark: string, group: DoctorFinding[]) => {
+  const group = (label: string, color: string, mark: string, group: CliFinding[]) => {
     if (!group.length) return;
     out.push(paint(color + BOLD, `${label} (${group.length})`));
     for (const finding of group) {
@@ -415,12 +507,13 @@ export function shouldUseColor(
  * that is not there — the CLI reports the configured value and says where the
  * real check lives.
  */
-function reportProxyHops(env: EnvLike): DoctorFinding {
+function reportProxyHops(env: EnvLike): CliFinding {
   const raw = env.TRUSTED_PROXY_HOPS;
   const hops = raw && !isNaN(parseInt(raw, 10)) ? Math.max(0, parseInt(raw, 10)) : 0;
   return {
     id: 'proxy-hops',
     level: 'ok',
+    note: true,
     title: `TRUSTED_PROXY_HOPS is ${hops}${raw ? '' : ' (unset)'} — not verifiable from the terminal`,
     detail:
       'Whether this is right can only be judged against a real request: the value says how far ' +
@@ -430,9 +523,9 @@ function reportProxyHops(env: EnvLike): DoctorFinding {
   };
 }
 
-async function gatherFindings(cwd: string, env: EnvLike): Promise<DoctorFinding[]> {
+async function gatherFindings(cwd: string, env: EnvLike): Promise<CliFinding[]> {
   const contentDir = env.INSTALL_CONTENT_DIR || path.join(cwd, 'content');
-  const findings: DoctorFinding[] = [];
+  const findings: CliFinding[] = [];
   const credentials = resolveCredentials(contentDir, env);
 
   findings.push(checkAuthSecret(credentials.authSecret || undefined));
@@ -612,7 +705,7 @@ async function gatherFindings(cwd: string, env: EnvLike): Promise<DoctorFinding[
         'run the doctor from the project root, or check that the volume is mounted.',
     });
   } else {
-    findings.push(checkWritable(findUnwritable(contentDir)));
+    findings.push(reportWritable(findUnwritable(contentDir), currentUid()));
   }
 
   return findings;
@@ -624,7 +717,7 @@ export async function main(
 ): Promise<number> {
   loadDotEnv(cwd, env);
 
-  let findings: DoctorFinding[];
+  let findings: CliFinding[];
   try {
     findings = await gatherFindings(cwd, env);
   } catch (error) {


### PR DESCRIPTION
Closes #551.

## The bug

`findUnwritable()` asks whether *this process* can write; `checkWritable()` phrased the answer as "Saving from the admin panel will fail, and so will backups." In the panel that is exactly right — it runs inside the app, as the app's user. In a CLI it is a different question, and run from the host against a container that writes as uid 1001, it produced this on a deployment with nothing wrong with it:

```
ERRORS (1)
  x 1 content path is not writable
    Saving from the admin panel will fail, and so will backups. Check the
    ownership of the mounted volume: content/.backups
```

The worst part is the advice: chowning the mounted volume from the host is the one change that would actually break the container's access.

## After

```
NOTES (1)
  i 1 content path is not writable by uid 1000 — but it is owned by uid 1001
    Checked as the user running this command, not as the user the app runs as.
    The paths belong to uid 1001, which can write them; the Docker image runs
    the app as uid 1001. This only matters if the app itself runs as uid 1000.
    To check as the app: docker compose exec folio npm run doctor. Paths:
    content/.backups

0 errors, 0 warnings, 0 checks passed, 1 note.
```

`findUnwritable()` returns each path's owner, and the level follows what the answer is worth:

| Situation | Level |
| --- | --- |
| everything writable | `ok`, a normal passed check |
| unwritable, CLI runs as the owner | `error`, wording unchanged — this one really is about the app |
| unwritable, owned by someone else | note: both uids named, `docker compose exec` suggested |
| no `getuid()` (Windows) | note: claims nothing, and never prints `undefined` |

The `id` stays `content-writable`, so the panel and the CLI still name the same check.

## One design change from #550

Notes move from an id set to a `note` flag on the finding. `content-writable` is a note in one case and a real error in the other, and an id cannot express that — the id set would also have swallowed a healthy `content/ is writable` into NOTES. The flag sits on a CLI-local `CliFinding = DoctorFinding & { note?: boolean }` rather than on `DoctorFinding`, which is shared with the panel where all of these checks are real. A test pins that the flag, not the id, is what decides.

## Verification

- `npx tsc --noEmit` — 0 errors
- `npm run test:unit` — 863 passed, incl. 9 new (owner recorded by `findUnwritable`, each of the four `reportWritable` outcomes, mixed ownership, the stable id, and the flag-not-id rule)
- `npm run build` — passes
- `npm run lint` — unchanged from the baseline on `dev`
- Ran end to end: the error branch against a staged read-only directory I own (`EXIT=2`, wording unchanged), the note branch rendered through `formatReport`, and the healthy path against a real `content/`

`docs/deployment.md` now describes both reported-not-judged findings together.