### PR TITLE
fix(image): strip EXIF from originals instead of streaming them untouched

### DIFF
--- a/app/api/image/[id]/route.ts
+++ b/app/api/image/[id]/route.ts
@@ -14,6 +14,22 @@ import { decodeAssetId } from '@/lib/tokens';
 import { getConfig } from '@/lib/config';
 import { checkRateLimit, getClientIp, retryAfterSeconds } from '@/lib/rate-limit';
 import { siteLockResponse } from '@/lib/auth';
+import { blankRanges, findMetadataRanges } from '@/lib/metadataStrip';
+
+/**
+ * Bumping this changes every original's ETag, so a revalidating cache fetches
+ * the stripped bytes instead of replaying a pre-fix copy. Browsers hold these
+ * URLs as `immutable` and will not revalidate at all, so a real rollout also
+ * needs IMAGE_CACHE_VERSION bumped — that changes the URL itself.
+ */
+const STRIP_VERSION = 's1';
+
+/**
+ * Originals are buffered whole so their metadata can be blanked before a single
+ * byte reaches the client. Anything larger is not worth holding in memory; those
+ * fall back to the preview rendition, which Immich generates without EXIF.
+ */
+const MAX_STRIP_BYTES = 64 * 1024 * 1024;
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   // ── Rate limiting ──────────────────────────────────
@@ -65,7 +81,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
   // `immutable`, so this only matters after expiry or a cache eviction, but a
   // matching ETag across two different URLs would be wrong either way.
   const cacheVersion = request.nextUrl.searchParams.get('v') ?? '';
-  const etag = `W/"${token}-${size}${cacheVersion ? `-${cacheVersion}` : ''}"`;
+  const etag = `W/"${token}-${size}-${STRIP_VERSION}${cacheVersion ? `-${cacheVersion}` : ''}"`;
   if (request.headers.get('if-none-match') === etag) {
     return new NextResponse(null, {
       status: 304,
@@ -113,6 +129,57 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     contentType = 'application/octet-stream';
   }
 
+  // ── Metadaten aus Originalen entfernen ─────────────
+  // Das Asset-Token autorisiert das Bild, nicht die Groesse: ein aus dem
+  // oeffentlichen HTML gelesenes Thumbnail-Token plus ?size=original lieferte
+  // bis hierher die unveraenderte Datei — mitsamt GPS. app/api/exif haelt
+  // Koordinaten bewusst zurueck, und /api/map quantisiert sie; dieser Pfad ging
+  // an beidem vorbei. Nur die Metadaten-Bytes werden genullt, die Bilddaten
+  // bleiben bitgenau erhalten — deshalb kostet das keine Qualitaet.
+  let body: BodyInit = result.stream;
+  // Gesetzt, sobald wir gestrippte Bytes ausliefern — der Wert ist dann die
+  // maßgebliche Content-Length.
+  let strippedLength: number | null = null;
+  if (size === 'original') {
+    const declaredLength = result.contentLength ? parseInt(result.contentLength, 10) : NaN;
+    const zuGross = Number.isFinite(declaredLength) && declaredLength > MAX_STRIP_BYTES;
+
+    const raw = zuGross ? null : new Uint8Array(await new Response(result.stream).arrayBuffer());
+    const ranges =
+      raw && raw.length <= MAX_STRIP_BYTES ? findMetadataRanges(raw, contentType) : null;
+
+    if (raw && ranges) {
+      const blanked = blankRanges(raw, ranges);
+      strippedLength = blanked.byteLength;
+      // ArrayBuffer statt Uint8Array: nur der ist ein gueltiger BodyInit. Die
+      // Zusicherung ist sicher — die Bytes stammen aus Response.arrayBuffer(),
+      // also nie aus einem SharedArrayBuffer, den ArrayBufferLike mit einschliesst.
+      body = blanked.buffer.slice(
+        blanked.byteOffset,
+        blanked.byteOffset + blanked.byteLength,
+      ) as ArrayBuffer;
+    } else {
+      // Unbekanntes Format, kaputter Container oder zu gross: lieber die
+      // Vorschau ausliefern als ein Original, dessen Metadaten wir nicht
+      // sicher finden. Stillschweigend durchreichen war genau der Fehler.
+      console.warn(
+        `[Image API] Original von ${assetId} (${contentType}) nicht strippbar — liefere Preview.`,
+      );
+      const preview = await immich.streamAsset(assetId, 'preview');
+      if (!preview) {
+        return NextResponse.json(
+          { error: 'Asset not found' },
+          { status: 404, headers: { 'Cache-Control': 'no-store' } },
+        );
+      }
+      body = preview.stream;
+      contentType = preview.contentType.toLowerCase().startsWith('image/')
+        ? preview.contentType
+        : 'image/jpeg';
+      result = { ...preview, contentLength: preview.contentLength };
+    }
+  }
+
   const headers: Record<string, string> = {
     'Content-Type': contentType,
     // Images are immutable once uploaded to Immich — cache aggressively
@@ -121,9 +188,13 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     'X-RateLimit-Remaining': String(remaining),
   };
 
-  if (result.contentLength) {
+  // Das Nullen ist laengentreu, der Wert bleibt also gueltig; beim
+  // Preview-Fallback stammt er vom Preview-Abruf.
+  if (strippedLength !== null) {
+    headers['Content-Length'] = String(strippedLength);
+  } else if (result.contentLength) {
     headers['Content-Length'] = result.contentLength;
   }
 
-  return new NextResponse(result.stream, { headers });
+  return new NextResponse(body, { headers });
 }

--- a/lib/__tests__/metadataStrip.test.ts
+++ b/lib/__tests__/metadataStrip.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest';
+import {
+  findJpegMetadataRanges,
+  findIsobmffMetadataRanges,
+  findMetadataRanges,
+  stripMetadata,
+  isStrippable,
+} from '../metadataStrip';
+
+// ── kleine Bau-Helfer ───────────────────────────────────────────────────────
+
+const cat = (...parts: Uint8Array[]) => {
+  const out = new Uint8Array(parts.reduce((n, p) => n + p.length, 0));
+  let o = 0;
+  for (const p of parts) {
+    out.set(p, o);
+    o += p.length;
+  }
+  return out;
+};
+const bytes = (...n: number[]) => new Uint8Array(n);
+const ascii = (s: string) => new Uint8Array([...s].map((c) => c.charCodeAt(0)));
+const be16 = (n: number) => bytes((n >> 8) & 0xff, n & 0xff);
+const be32 = (n: number) => bytes((n >>> 24) & 0xff, (n >>> 16) & 0xff, (n >>> 8) & 0xff, n & 0xff);
+
+/** JPEG-Segment: FFxx <len inkl. Längenfeld> <payload> */
+const seg = (marker: number, payload: Uint8Array) =>
+  cat(bytes(0xff, marker), be16(payload.length + 2), payload);
+
+/** ISOBMFF-Box mit korrekt berechneter Größe. */
+const box = (type: string, ...content: Uint8Array[]) => {
+  const body = cat(...content);
+  return cat(be32(body.length + 8), ascii(type), body);
+};
+
+describe('isStrippable', () => {
+  it('kennt JPEG und die ISOBMFF-Familie', () => {
+    expect(isStrippable('image/jpeg')).toBe(true);
+    expect(isStrippable('IMAGE/AVIF')).toBe(true);
+    expect(isStrippable('image/jpeg; charset=binary')).toBe(true);
+    expect(isStrippable('image/png')).toBe(false);
+    expect(isStrippable('application/octet-stream')).toBe(false);
+  });
+});
+
+describe('JPEG', () => {
+  const exifPayload = cat(ascii('Exif\0\0'), ascii('MM\0*GPS 54.156, 15.3717'));
+  const iccPayload = cat(ascii('ICC_PROFILE\0'), bytes(1, 1, 2, 3, 4, 5));
+  const jfifPayload = cat(ascii('JFIF\0'), bytes(1, 2, 0, 0, 1, 0, 1, 0, 0));
+  const bildDaten = bytes(0x12, 0x34, 0x56, 0x78, 0x9a);
+
+  const bauJpeg = () =>
+    cat(
+      bytes(0xff, 0xd8), // SOI
+      seg(0xe0, jfifPayload), // APP0 JFIF   — bleibt
+      seg(0xe1, exifPayload), // APP1 EXIF    — muss weg
+      seg(0xe2, iccPayload), // APP2 ICC     — bleibt (Farbprofil!)
+      seg(0xed, ascii('Photoshop 3.0\0IPTC')), // APP13 — muss weg
+      seg(0xfe, ascii('ein Kommentar')), // COM   — muss weg
+      bytes(0xff, 0xda),
+      be16(8),
+      bytes(1, 0, 0, 63, 0), // SOS
+      bildDaten,
+      bytes(0xff, 0xd9), // EOI
+    );
+
+  it('findet EXIF, IPTC und Kommentar, aber nicht JFIF/ICC', () => {
+    const b = bauJpeg();
+    const ranges = findJpegMetadataRanges(b);
+    expect(ranges).toHaveLength(3);
+    // Das EXIF-Segment muss vollständig erfasst sein
+    const exifStart = b.indexOf(0x45); // 'E' von 'Exif'
+    expect(ranges[0].start).toBe(exifStart);
+    expect(ranges[0].end - ranges[0].start).toBe(exifPayload.length);
+  });
+
+  it('nullt die GPS-Daten und lässt alles andere unangetastet', () => {
+    const original = bauJpeg();
+    const gestrippt = stripMetadata(bauJpeg(), 'image/jpeg')!;
+
+    expect(gestrippt).not.toBeNull();
+    // Länge unverändert -> Content-Length bleibt gültig
+    expect(gestrippt.length).toBe(original.length);
+
+    const alsText = new TextDecoder('latin1').decode(gestrippt);
+    expect(alsText).not.toContain('GPS 54.156');
+    expect(alsText).not.toContain('Exif');
+    expect(alsText).not.toContain('IPTC');
+    expect(alsText).not.toContain('ein Kommentar');
+
+    // Farbprofil und JFIF müssen erhalten bleiben, sonst kippen die Farben
+    expect(alsText).toContain('ICC_PROFILE');
+    expect(alsText).toContain('JFIF');
+
+    // Bilddaten hinter SOS Byte für Byte identisch
+    const sos = original.length - bildDaten.length - 2;
+    expect(Array.from(gestrippt.slice(sos))).toEqual(Array.from(original.slice(sos)));
+  });
+
+  it('weist etwas zurück, das kein JPEG ist', () => {
+    expect(() => findJpegMetadataRanges(bytes(0x00, 0x01, 0x02, 0x03))).toThrow();
+    expect(findMetadataRanges(bytes(0x00, 0x01, 0x02, 0x03), 'image/jpeg')).toBeNull();
+  });
+});
+
+describe('AVIF / ISOBMFF', () => {
+  const exifNutzlast = ascii('MM\0*GEHEIME-GPS-KOORDINATEN');
+  const bildNutzlast = ascii('AV1-BILDDATEN-UNANTASTBAR');
+
+  /** infe v2: version+flags, item_ID(16), protection(16), item_type(4) */
+  const infe = (id: number, typ: string) =>
+    box('infe', bytes(2, 0, 0, 0), be16(id), be16(0), ascii(typ), bytes(0));
+
+  const bauAvif = () => {
+    // Erst ohne mdat bauen, um die Offsets zu kennen.
+    const ftyp = box('ftyp', ascii('avif'), be32(0), ascii('avifmif1'));
+    const iinf = box('iinf', bytes(0, 0, 0, 0), be16(2), infe(1, 'Exif'), infe(2, 'av01'));
+
+    // iloc v0: offset_size=4, length_size=4, base_offset_size=0
+    const ilocEintrag = (id: number, offset: number, len: number) =>
+      cat(be16(id), be16(0), be16(1), be32(offset), be32(len));
+
+    // Platzhalter, um die Gesamtlänge des Headers zu bestimmen
+    const ilocRoh = (o1: number, o2: number) =>
+      box(
+        'iloc',
+        bytes(0, 0, 0, 0),
+        bytes(0x44, 0x00),
+        be16(2),
+        ilocEintrag(1, o1, exifNutzlast.length),
+        ilocEintrag(2, o2, bildNutzlast.length),
+      );
+
+    const kopfLaenge = (iloc: Uint8Array) =>
+      ftyp.length + box('meta', bytes(0, 0, 0, 0), iinf, iloc).length + 8; // +8 mdat-Header
+
+    let iloc = ilocRoh(0, 0);
+    const basis = kopfLaenge(iloc);
+    iloc = ilocRoh(basis, basis + exifNutzlast.length);
+
+    const meta = box('meta', bytes(0, 0, 0, 0), iinf, iloc);
+    const mdat = box('mdat', exifNutzlast, bildNutzlast);
+    return cat(ftyp, meta, mdat);
+  };
+
+  it('findet das Exif-Item über iinf und iloc', () => {
+    const b = bauAvif();
+    const ranges = findIsobmffMetadataRanges(b);
+    expect(ranges).toHaveLength(1);
+    const gefunden = new TextDecoder('latin1').decode(b.slice(ranges[0].start, ranges[0].end));
+    expect(gefunden).toBe('MM\0*GEHEIME-GPS-KOORDINATEN');
+  });
+
+  it('nullt EXIF, lässt die Bilddaten und die Länge unberührt', () => {
+    const original = bauAvif();
+    const gestrippt = stripMetadata(bauAvif(), 'image/avif')!;
+
+    expect(gestrippt.length).toBe(original.length);
+    const alsText = new TextDecoder('latin1').decode(gestrippt);
+    expect(alsText).not.toContain('GEHEIME-GPS-KOORDINATEN');
+    expect(alsText).toContain('AV1-BILDDATEN-UNANTASTBAR');
+    // Die Container-Struktur muss intakt bleiben
+    expect(alsText).toContain('ftyp');
+    expect(alsText).toContain('iloc');
+  });
+
+  it('gibt null zurück, wenn es kein ISOBMFF ist', () => {
+    expect(findMetadataRanges(ascii('nicht mal ansatzweise'), 'image/avif')).toBeNull();
+  });
+});
+
+describe('unbekannte Formate', () => {
+  it('liefern null — lieber nicht ausliefern als leaken', () => {
+    expect(findMetadataRanges(bytes(0x89, 0x50, 0x4e, 0x47), 'image/png')).toBeNull();
+    expect(stripMetadata(bytes(1, 2, 3), 'application/octet-stream')).toBeNull();
+  });
+});

--- a/lib/metadataStrip.ts
+++ b/lib/metadataStrip.ts
@@ -1,0 +1,251 @@
+/**
+ * Removes camera metadata (EXIF, XMP, IPTC) from image bytes on the way out.
+ *
+ * Why this exists: `/api/image/:token?size=original` streams the untouched file
+ * from Immich, and the asset token authorises *the asset, not the size* — so a
+ * thumbnail token lifted from the public HTML plus `?size=original` returns the
+ * full original, GPS coordinates and all. `app/api/exif/[id]/route.ts`
+ * deliberately hands the browser only city and country; the original download
+ * walked straight past that.
+ *
+ * Why zero the bytes instead of cutting them out: the pixel data must stay
+ * bit-identical — re-encoding would cost quality, which is the whole reason we
+ * serve originals. Overwriting in place keeps every other byte and the total
+ * length untouched, so Content-Length stays valid and, crucially for AVIF, the
+ * absolute offsets in the `iloc` box keep pointing where they did. Removing an
+ * item would mean rewriting every offset in the container.
+ *
+ * A zeroed APPn segment is simply an application segment a decoder does not
+ * recognise, and decoders skip those. A zeroed ISOBMFF item payload is still
+ * addressed by `iloc`, but no longer parses as EXIF.
+ *
+ * NOT stripped: JPEG APP0 (JFIF) and APP2 (ICC colour profile). Dropping the
+ * ICC profile would visibly shift colours — that is a rendering change, not a
+ * privacy one.
+ */
+
+/** Half-open byte range [start, end). */
+export type ByteRange = { start: number; end: number };
+
+/** Formats whose metadata layout we can locate with confidence. */
+export const STRIPPABLE_CONTENT_TYPES = [
+  'image/jpeg',
+  'image/avif',
+  'image/heic',
+  'image/heif',
+] as const;
+
+export function isStrippable(contentType: string): boolean {
+  const t = contentType.toLowerCase().split(';')[0].trim();
+  return (STRIPPABLE_CONTENT_TYPES as readonly string[]).includes(t);
+}
+
+const u16 = (b: Uint8Array, i: number) => (b[i] << 8) | b[i + 1];
+const u32 = (b: Uint8Array, i: number) =>
+  ((b[i] << 24) | (b[i + 1] << 16) | (b[i + 2] << 8) | b[i + 3]) >>> 0;
+const fourcc = (b: Uint8Array, i: number) =>
+  String.fromCharCode(b[i], b[i + 1], b[i + 2], b[i + 3]);
+
+/** Read a big-endian unsigned integer of `n` bytes (n <= 8). */
+function uint(b: Uint8Array, i: number, n: number): number {
+  let v = 0;
+  for (let k = 0; k < n; k++) v = v * 256 + b[i + k];
+  return v;
+}
+
+// ── JPEG ────────────────────────────────────────────────────────────────────
+// Segment layout: 0xFF <marker> <2-byte length incl. itself> <payload>.
+// Metadata always precedes SOS (0xDA); everything after it is entropy-coded
+// image data that must not be touched.
+
+const JPEG_STRIP_MARKERS = new Set([
+  0xe1, // APP1 — EXIF and XMP
+  0xed, // APP13 — Photoshop/IPTC
+  0xfe, // COM — free-text comment
+]);
+
+export function findJpegMetadataRanges(b: Uint8Array): ByteRange[] {
+  if (b.length < 4 || b[0] !== 0xff || b[1] !== 0xd8) {
+    throw new Error('not a JPEG (missing SOI)');
+  }
+  const ranges: ByteRange[] = [];
+  let pos = 2;
+
+  while (pos + 3 < b.length) {
+    if (b[pos] !== 0xff) throw new Error(`lost segment alignment at ${pos}`);
+    const marker = b[pos + 1];
+
+    // Standalone markers carry no length field.
+    if (marker === 0x01 || (marker >= 0xd0 && marker <= 0xd7)) {
+      pos += 2;
+      continue;
+    }
+    if (marker === 0xd9) break; // EOI
+    if (marker === 0xda) break; // SOS — image data follows
+
+    const len = u16(b, pos + 2);
+    if (len < 2) throw new Error(`bogus segment length ${len} at ${pos}`);
+    const payloadStart = pos + 4;
+    const segmentEnd = pos + 2 + len;
+    if (segmentEnd > b.length) break; // truncated head — stop where we are
+
+    if (JPEG_STRIP_MARKERS.has(marker) && segmentEnd > payloadStart) {
+      ranges.push({ start: payloadStart, end: segmentEnd });
+    }
+    pos = segmentEnd;
+  }
+  return ranges;
+}
+
+// ── ISOBMFF (AVIF / HEIC / HEIF) ────────────────────────────────────────────
+// Boxes are <4-byte size><4-byte type>[<8-byte largesize>]<payload>. Metadata
+// items live in `meta`: `iinf`/`infe` name them, `iloc` says where their bytes
+// are. We zero exactly those byte ranges.
+
+type Box = { type: string; start: number; contentStart: number; end: number };
+
+function readBoxes(b: Uint8Array, from: number, to: number): Box[] {
+  const boxes: Box[] = [];
+  let pos = from;
+  while (pos + 8 <= to) {
+    let size = u32(b, pos);
+    let contentStart = pos + 8;
+    if (size === 1) {
+      if (pos + 16 > to) break;
+      size = uint(b, pos + 8, 8);
+      contentStart = pos + 16;
+    } else if (size === 0) {
+      size = to - pos; // extends to the end
+    }
+    if (size < 8) break;
+    const end = Math.min(pos + size, to);
+    boxes.push({ type: fourcc(b, pos + 4), start: pos, contentStart, end });
+    if (end <= pos) break;
+    pos = end;
+  }
+  return boxes;
+}
+
+/** item_ID -> item_type, from the `iinf` box. */
+function readItemTypes(b: Uint8Array, iinf: Box): Map<number, string> {
+  const types = new Map<number, string>();
+  const version = b[iinf.contentStart];
+  let pos = iinf.contentStart + 4; // version + flags
+  if (version === 0) pos += 2;
+  else pos += 4; // entry_count
+
+  for (const infe of readBoxes(b, pos, iinf.end)) {
+    if (infe.type !== 'infe') continue;
+    const v = b[infe.contentStart];
+    let p = infe.contentStart + 4;
+    if (v < 2) continue; // versions 0/1 predate item_type
+    const itemId = v === 2 ? u16(b, p) : u32(b, p);
+    p += v === 2 ? 2 : 4;
+    p += 2; // item_protection_index
+    types.set(itemId, fourcc(b, p));
+  }
+  return types;
+}
+
+/** item_ID -> byte ranges, from the `iloc` box. */
+function readItemLocations(b: Uint8Array, iloc: Box): Map<number, ByteRange[]> {
+  const out = new Map<number, ByteRange[]>();
+  const version = b[iloc.contentStart];
+  let p = iloc.contentStart + 4; // version + flags
+
+  const offsetSize = b[p] >> 4;
+  const lengthSize = b[p] & 0x0f;
+  const baseOffsetSize = b[p + 1] >> 4;
+  const indexSize = version === 1 || version === 2 ? b[p + 1] & 0x0f : 0;
+  p += 2;
+
+  const itemCount = version < 2 ? u16(b, p) : u32(b, p);
+  p += version < 2 ? 2 : 4;
+
+  for (let i = 0; i < itemCount && p < iloc.end; i++) {
+    const itemId = version < 2 ? u16(b, p) : u32(b, p);
+    p += version < 2 ? 2 : 4;
+    if (version === 1 || version === 2) p += 2; // construction_method
+    p += 2; // data_reference_index
+    const baseOffset = baseOffsetSize ? uint(b, p, baseOffsetSize) : 0;
+    p += baseOffsetSize;
+    const extentCount = u16(b, p);
+    p += 2;
+
+    const ranges: ByteRange[] = [];
+    for (let e = 0; e < extentCount; e++) {
+      if ((version === 1 || version === 2) && indexSize) p += indexSize;
+      const extentOffset = offsetSize ? uint(b, p, offsetSize) : 0;
+      p += offsetSize;
+      const extentLength = lengthSize ? uint(b, p, lengthSize) : 0;
+      p += lengthSize;
+      if (extentLength > 0) {
+        const start = baseOffset + extentOffset;
+        ranges.push({ start, end: start + extentLength });
+      }
+    }
+    if (ranges.length) out.set(itemId, ranges);
+  }
+  return out;
+}
+
+export function findIsobmffMetadataRanges(b: Uint8Array): ByteRange[] {
+  const top = readBoxes(b, 0, b.length);
+  if (!top.some((x) => x.type === 'ftyp')) throw new Error('not ISOBMFF (no ftyp)');
+  const meta = top.find((x) => x.type === 'meta');
+  if (!meta) return []; // no metadata box at all — nothing to strip
+
+  // `meta` is a FullBox: skip version + flags before its children.
+  const children = readBoxes(b, meta.contentStart + 4, meta.end);
+  const iinf = children.find((x) => x.type === 'iinf');
+  const iloc = children.find((x) => x.type === 'iloc');
+  if (!iinf || !iloc) return [];
+
+  const types = readItemTypes(b, iinf);
+  const locations = readItemLocations(b, iloc);
+
+  const ranges: ByteRange[] = [];
+  for (const [itemId, itemType] of types) {
+    // 'Exif' is EXIF; 'mime' items are XMP in every AVIF/HEIC writer we see.
+    if (itemType !== 'Exif' && itemType !== 'mime') continue;
+    for (const r of locations.get(itemId) ?? []) ranges.push(r);
+  }
+  return ranges;
+}
+
+// ── Entry point ─────────────────────────────────────────────────────────────
+
+/**
+ * Byte ranges to blank out, or null when the format is not one we understand.
+ * Callers must treat null as "do not serve this original" — silently passing it
+ * through is what caused the leak in the first place.
+ */
+export function findMetadataRanges(b: Uint8Array, contentType: string): ByteRange[] | null {
+  const t = contentType.toLowerCase().split(';')[0].trim();
+  try {
+    if (t === 'image/jpeg') return findJpegMetadataRanges(b);
+    if (t === 'image/avif' || t === 'image/heic' || t === 'image/heif') {
+      return findIsobmffMetadataRanges(b);
+    }
+  } catch {
+    return null; // malformed or unexpected layout — refuse rather than leak
+  }
+  return null;
+}
+
+/** Overwrite `ranges` with zeroes. Mutates and returns `b`. */
+export function blankRanges(b: Uint8Array, ranges: ByteRange[]): Uint8Array {
+  for (const { start, end } of ranges) {
+    const from = Math.max(0, Math.min(start, b.length));
+    const to = Math.max(0, Math.min(end, b.length));
+    if (to > from) b.fill(0, from, to);
+  }
+  return b;
+}
+
+/** Convenience for buffered callers and tests. */
+export function stripMetadata(b: Uint8Array, contentType: string): Uint8Array | null {
+  const ranges = findMetadataRanges(b, contentType);
+  if (ranges === null) return null;
+  return blankRanges(b, ranges);
+}


### PR DESCRIPTION
## Was das behebt

`/api/image/:token?size=original` hat die unveränderte Originaldatei aus Immich durchgereicht. Das Asset-Token autorisiert aber **das Bild, nicht die Größe** — ein aus dem öffentlichen HTML gelesenes Thumbnail-Token plus `?size=original` lieferte damit das Original samt GPS-Koordinaten an jeden nicht angemeldeten Besucher.

An der Live-Galerie nachgemessen:

| Fassung | Größe | EXIF |
|---|---|---|
| preview | 176 KB | kein EXIF-Block |
| original | 16 MB | GPSInfo-Tag + Kameramodell |

Das ging an zwei bewussten Schutzmaßnahmen vorbei: `app/api/exif/[id]` gibt dem Browser nur `city`/`country`, und `/api/map` quantisiert Koordinaten serverseitig.

## Warum genullt und nicht herausgeschnitten

Die Bilddaten bleiben bitgenau erhalten — **Neu-Encodieren kostet Qualität und kam deshalb nicht infrage**. Nur die Metadaten-Bytes werden mit Nullen überschrieben. Das hält außerdem die Dateilänge konstant, womit `Content-Length` gültig bleibt und — bei AVIF entscheidend — die absoluten Offsets in der `iloc`-Box weiter stimmen. Ein Item zu entfernen hieße, sämtliche Offsets im Container neu zu berechnen.

Ein genulltes APPn-Segment ist für Decoder schlicht ein unbekanntes Anwendungssegment und wird übersprungen.

## Umfang

**Entfernt:** JPEG APP1 (EXIF/XMP), APP13 (IPTC), COM · `Exif`- und `mime`-Items in ISOBMFF-Containern (AVIF/HEIC/HEIF), gefunden über `iinf`/`iloc`.

**Bewusst behalten:** JPEG APP0 (JFIF) und APP2 (ICC). Das Farbprofil zu verwerfen würde die Farben sichtbar verschieben — das wäre eine Darstellungs-, keine Datenschutzänderung.

**Nicht angefasst:** die Download-Route pro Album. Die ist sauber abgesichert (Allowlist, `download: true`, Passwort-Gates, Asset-Zugehörigkeit) und eine bewusste Opt-in-Funktion.

Ein Format, das wir nicht sicher parsen können, fällt jetzt auf die Vorschau zurück, statt durchgereicht zu werden — genau dieses stillschweigende Durchreichen war die Ursache.

## Tests

8 neue Unit-Tests in `lib/__tests__/metadataStrip.test.ts` gegen synthetisch gebaute JPEG- und AVIF-Strukturen: GPS verschwindet, ICC und JFIF bleiben, Bilddaten und Dateilänge sind Byte für Byte unverändert, kaputte Container liefern `null`. Gesamte Suite: 871 Tests grün, `tsc` und `eslint` sauber, `next build` läuft durch.

## ⚠️ Beim Ausrollen zu beachten

Diese URLs werden als `immutable` mit einem Jahr Cache ausgeliefert. Bereits ausgelieferte Originale bleiben in Browser-Caches also erhalten, auch nach dem Deploy. **`IMAGE_CACHE_VERSION` muss hochgezählt werden**, weil das die URLs selbst ändert; das eingebaute `STRIP_VERSION` deckt nur Caches ab, die revalidieren.

Ob ein bereits abgeflossenes Original bei Dritten liegt, lässt sich naturgemäß nicht rückgängig machen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BkUJtcTjmKHPoUwxArAdGb
