### PR TITLE
fix(proofing): theme the selection UI so it follows light/dark mode

### DIFF
--- a/app/[...path]/EssayView.tsx
+++ b/app/[...path]/EssayView.tsx
@@ -312,9 +312,9 @@ function EssayViewContent({
             gap: '12px',
             padding: '8px 16px',
             borderRadius: '30px',
-            background: 'var(--bg-surface, #1e1e1e)',
-            color: 'var(--text-primary, #ffffff)',
-            border: '1px solid var(--border-color, rgba(255,255,255,0.15))',
+            background: 'var(--bg-card)',
+            color: 'var(--text-primary)',
+            border: '1px solid var(--border-subtle)',
             boxShadow: '0 8px 24px rgba(0,0,0,0.4)',
             backdropFilter: 'blur(8px)',
           }}
@@ -325,8 +325,8 @@ function EssayViewContent({
             style={{
               background: proofing.isFilterActive
                 ? 'var(--accent, #e60012)'
-                : 'rgba(255,255,255,0.15)',
-              color: '#fff',
+                : 'var(--bg-card-hover)',
+              color: proofing.isFilterActive ? '#fff' : 'var(--text-primary)',
               border: 'none',
               padding: '6px 14px',
               borderRadius: '20px',

--- a/app/[...path]/PhotoGrid.tsx
+++ b/app/[...path]/PhotoGrid.tsx
@@ -266,9 +266,9 @@ function PhotoGridInner({
             gap: '12px',
             padding: '8px 16px',
             borderRadius: '30px',
-            background: 'var(--bg-surface, #1e1e1e)',
-            color: 'var(--text-primary, #ffffff)',
-            border: '1px solid var(--border-color, rgba(255,255,255,0.15))',
+            background: 'var(--bg-card)',
+            color: 'var(--text-primary)',
+            border: '1px solid var(--border-subtle)',
             boxShadow: '0 8px 24px rgba(0,0,0,0.4)',
             backdropFilter: 'blur(8px)',
           }}
@@ -279,8 +279,8 @@ function PhotoGridInner({
             style={{
               background: proofing.isFilterActive
                 ? 'var(--accent, #e60012)'
-                : 'rgba(255,255,255,0.15)',
-              color: '#fff',
+                : 'var(--bg-card-hover)',
+              color: proofing.isFilterActive ? '#fff' : 'var(--text-primary)',
               border: 'none',
               padding: '6px 14px',
               borderRadius: '20px',

--- a/components/ProofingModal.tsx
+++ b/components/ProofingModal.tsx
@@ -63,10 +63,10 @@ export function ProofingModal() {
         className="proofing-modal-card"
         onClick={(e) => e.stopPropagation()}
         style={{
-          background: 'var(--bg-surface, #1e1e1e)',
-          color: 'var(--text-primary, #ffffff)',
+          background: 'var(--bg-card)',
+          color: 'var(--text-primary)',
           borderRadius: 'var(--radius-md, 12px)',
-          border: '1px solid var(--border-color, rgba(255,255,255,0.1))',
+          border: '1px solid var(--border-subtle)',
           padding: '1.5rem',
           maxWidth: '480px',
           width: '100%',
@@ -145,9 +145,9 @@ export function ProofingModal() {
               gap: '0.5rem',
               padding: '0.75rem 1rem',
               borderRadius: 'var(--radius-sm, 6px)',
-              background: 'rgba(255,255,255,0.1)',
+              background: 'var(--bg-card-hover)',
               color: 'inherit',
-              border: '1px solid rgba(255,255,255,0.15)',
+              border: '1px solid var(--border-subtle)',
               fontWeight: 500,
               cursor: 'pointer',
             }}
@@ -174,9 +174,9 @@ export function ProofingModal() {
                 gap: '0.5rem',
                 padding: '0.75rem 1rem',
                 borderRadius: 'var(--radius-sm, 6px)',
-                background: 'rgba(255,255,255,0.1)',
+                background: 'var(--bg-card-hover)',
                 color: 'inherit',
-                border: '1px solid rgba(255,255,255,0.15)',
+                border: '1px solid var(--border-subtle)',
                 fontWeight: 500,
                 cursor: 'pointer',
               }}


### PR DESCRIPTION
## Problem

The client-proofing selection UI — the floating "❤️ N Selected" bar and the **Share & Export** modal — ignores the page's colour mode. In light mode the text turns dark but the bar/modal stay dark, so the text is unreadable.

## Root cause

The bar and modal were styled with two CSS custom properties that no theme defines:

- `var(--bg-surface, #1e1e1e)` — `--bg-surface` does not exist in `app/tokens.css`, so it **always** falls back to the hardcoded dark `#1e1e1e`.
- `var(--border-color, rgba(255,255,255,0.15))` — `--border-color` also does not exist, so the border stays a white-alpha value that only reads correctly on dark.
- The secondary buttons used hardcoded `rgba(255,255,255,…)` backgrounds/borders.

`--text-primary` *is* a real, themed token, which is why the text switched to dark while the surfaces stayed dark — the mismatch made it unreadable.

## Fix

Swap the undefined tokens for the ones the rest of the site already uses (all defined for both dark and light in every preset):

| Before | After |
| --- | --- |
| `var(--bg-surface, #1e1e1e)` | `var(--bg-card)` |
| `var(--border-color, …)` | `var(--border-subtle)` |
| `rgba(255,255,255,0.1/0.15)` button surfaces/borders | `var(--bg-card-hover)` / `var(--border-subtle)` |

Also, the "❤️ N Selected" filter chip now uses `var(--text-primary)` when inactive instead of hardcoded white, so it reads on a light surface.

## Scope

- `components/ProofingModal.tsx`
- `app/[...path]/PhotoGrid.tsx`
- `app/[...path]/EssayView.tsx` (essays render a duplicate of the selection bar)

## Verification

- `npx tsc --noEmit` ✅
- `npm run build` ✅
- `npx vitest run` ✅

No config, markup, or API changes — this is purely swapping colour tokens.
