### PR TITLE
feat(journal): allow markdown links in quote attributions

### DIFF
--- a/app/[...path]/EssayView.tsx
+++ b/app/[...path]/EssayView.tsx
@@ -7,6 +7,7 @@ import { ProofingProvider, useProofing } from '@/components/ProofingContext';
 import { ProofingModal } from '@/components/ProofingModal';
 import { FadeIn } from '@/components/FadeIn';
 import type { ParsedEssay, EssayBlock } from '@/lib/essay';
+import { renderInlineMarkdown } from '@/lib/essay';
 import type { PhotoItem } from './PhotoGrid';
 import './essay.css';
 import { useDictionary } from '@/components/I18nProvider';
@@ -78,7 +79,15 @@ function EssayViewContent({
         return (
           <blockquote key={idx} className="essay-quote">
             <div dangerouslySetInnerHTML={{ __html: block.text }} />
-            {block.author && <span className="essay-quote__author">— {block.author}</span>}
+            {block.author && (
+              <span
+                className="essay-quote__author"
+                // The attribution keeps its Markdown and is rendered here, like
+                // the quote body, so `[link](…)` becomes an anchor (#559).
+                // renderInlineMarkdown escapes everything it does not emit.
+                dangerouslySetInnerHTML={{ __html: `— ${renderInlineMarkdown(block.author)}` }}
+              />
+            )}
           </blockquote>
         );
 

--- a/lib/__tests__/essay.test.ts
+++ b/lib/__tests__/essay.test.ts
@@ -142,4 +142,45 @@ A closing paragraph with **bold** details.`;
     expect(markdown).toContain('![photo-1:fullbleed](Caption)');
     expect(markdown).toContain('![p1, p2](Pair caption)');
   });
+
+  it('keeps a markdown link in the quote attribution for rendering (#559)', () => {
+    const markdown = '> Silence was absolute. -- [BBC Archive](https://example.com/archive)';
+    const parsed = parseEssayMarkdown(markdown);
+    const quote = parsed.blocks[0];
+    expect(quote.type).toBe('quote');
+    if (quote.type !== 'quote') return;
+
+    // The attribution stays Markdown; EssayView renders it with
+    // renderInlineMarkdown, which is what turns the link into an anchor.
+    expect(quote.author).toBe('[BBC Archive](https://example.com/archive)');
+    expect(renderInlineMarkdown(quote.author!)).toContain(
+      '<a href="https://example.com/archive" target="_blank" rel="noopener noreferrer">BBC Archive</a>',
+    );
+  });
+
+  it('survives a serialize/parse round-trip without losing the attribution link', () => {
+    const markdown = '> Silence was absolute. -- [BBC Archive](https://example.com/archive)';
+
+    const once = serializeEssayMarkdown(parseEssayMarkdown(markdown));
+    expect(once).toContain('> Silence was absolute. -- [BBC Archive](https://example.com/archive)');
+
+    const reparsed = parseEssayMarkdown(once);
+    const quote = reparsed.blocks[0];
+    expect(quote.type).toBe('quote');
+    if (quote.type === 'quote') {
+      expect(quote.author).toBe('[BBC Archive](https://example.com/archive)');
+    }
+  });
+
+  it('does not turn an unsafe scheme in the attribution into a link', () => {
+    const markdown = '> Careful. -- [x](javascript:alert(1))';
+    const parsed = parseEssayMarkdown(markdown);
+    const quote = parsed.blocks[0];
+    expect(quote.type).toBe('quote');
+    if (quote.type !== 'quote') return;
+
+    const html = renderInlineMarkdown(quote.author!);
+    expect(html).not.toContain('<a');
+    expect(html).not.toContain('href');
+  });
 });


### PR DESCRIPTION
## Summary

Enables Markdown links in journal/essay **quote attributions**, per #559.

The quote body and photo captions already go through `renderInlineMarkdown`, so `[text](url)` becomes an anchor there — but the attribution was the one inline field rendered as plain text, so a link in `Quote text -- [Source](https://…)` showed as literal markdown.

## What changed

`app/[...path]/EssayView.tsx` — render the attribution the same way as the quote body:

```tsx
<span className="essay-quote__author"
      dangerouslySetInnerHTML={{ __html: `— ${renderInlineMarkdown(block.author)}` }} />
```

The attribution keeps its Markdown in the parsed block and is rendered at display time, which means it works:

- in the published journal page and photo essays (they share `EssayView`),
- in the Journal Studio live preview (which renders the same component),
- from both the raw-Markdown file *and* the block editor — because the field stays Markdown, typing `[link](…)` in the author input round-trips untouched and renders live.

## Security

No new surface: it reuses `renderInlineMarkdown`, which escapes everything first and then emits only bold/italic/anchors, with the URL scheme allowlisted (`http/https/mailto/tel`/relative/anchor). `javascript:`/`data:` URLs render as plain text, exactly as captions behave today.

## Tests

`lib/__tests__/essay.test.ts` — three cases:

- a link in the attribution is preserved for rendering,
- it survives a serialize → parse round-trip,
- an unsafe scheme (`javascript:`) is not turned into an anchor.

## Notes

- **Photo captions already support links** — they've always run through `renderInlineMarkdown` (this also answers the question raised in #559).
- Out of scope, flagged for later: links in paragraphs/captions still get *dropped* on a save through the block editor (the serializer undoes `<strong>`/`<em>` but strips `<a>`). The attribution is unaffected because it stays Markdown. Fixing that would be a small follow-up in `serializeJournalMarkdown`.
